### PR TITLE
fix variations of create stream with destinations

### DIFF
--- a/ui/app/scripts/stream/services/metamodel.js
+++ b/ui/app/scripts/stream/services/metamodel.js
@@ -383,6 +383,8 @@ define(function (require) {
                                 }
                                 if (channelText.startsWith('tap:')) {
                                     channelText = channelText.substring(3); //TODO tidy up - do it here or sooner?
+                                } else {
+                                    channelText = ':' + channelText;
                                 }
                                 streamdef = channelText + ' > ';
                             }
@@ -451,11 +453,11 @@ define(function (require) {
                                 linkFrom = graphNode.id;
 //    						}
                                 nodes.push(graphNode);
-                                if (!parsedNode.sourceChannelName) {
+                                if (!parsedNode.sourceChannelName || parsedNode.name !== 'bridge') {
                                     // if it is a bridge then the source channel already added a '>'
                                     streamdef = streamdef + ' > ';
                                 }
-                                streamdef = streamdef + channelText;
+                                streamdef = streamdef + ':' + channelText;
                             }
 
                         }


### PR DESCRIPTION
Resolves spring-cloud/spring-cloud-dataflow-ui#53

The fixes are:
- when processing a source channel, if it isn't a tap it will need a leading colon:  :foo > log
- when processing a sink channel, ensure a leading colon is added:  http > :bar
- if using a single module in a bridge like way (but not bridge): `:foo > transform > :bar` ensure enough '>' are added.

Can confirm the fix by attempting to define streams listed in the github issue.