### PR TITLE
IE 11, Edge, old browser versions don't support Array#findIndex()

### DIFF
--- a/ui/app/scripts/stream/controllers/create-streams-dialog.js
+++ b/ui/app/scripts/stream/controllers/create-streams-dialog.js
@@ -106,9 +106,11 @@ define(function(require) {
                     });
                 } else {
                     // Find index of the first not yet created stream
-                    var index = $scope.streamdefs.findIndex(function(def) {
-                        return !def.created;
-                    });
+                    // Can't use Array#findIndex(...) because not all browsers support it
+                    var index = 0;
+                    for (; index < $scope.streamdefs.length && $scope.streamdefs[index].created; index++) {
+                        // nothing to do - just loop to the not created stream def
+                    }
                     if (index < 0 || index >= $scope.streamdefs.length) {
                         // Invalid index means all streams have been created, close the dialog.
                         $modalInstance.close(true);


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/75
Should also resolve the same issue for Chrome version <45

There are other UI glitches on IE11 and Edge... Tooltips aren't removed under some conditions... Zooming slider is ugly... This is just for the dialog to close because it's a real blocker