### PR TITLE
Support either long-names or short-names for properties

### DIFF
--- a/ui/app/scripts/stream/controllers/properties-dialog.js
+++ b/ui/app/scripts/stream/controllers/properties-dialog.js
@@ -75,9 +75,25 @@ define([], function () {
                 Object.keys(schemaProperties).forEach(function (key) {
                     schema = schemaProperties[key];
 
+                    // Captures what the user has specified in the DSL if anything. Search
+                    // for a value under the long-name and the short-name
+                    var specifiedValue;
+                    // If the user specifies a name in the DSL then that 'alias' should be
+                    // used when converting the properties back to text. By default the
+                    // short-name will be used if the user hasn't specified anything.
+                    var nameInUse = schema.name;
+                    var props = cell.attr('props');
+                    if (props.hasOwnProperty(key)) { // long-name, eg. 'trigger.cron'
+                        specifiedValue = props[key];
+                        nameInUse = key;
+                    } else if (props.hasOwnProperty(schema.name)) { // short-name, eg. 'cron'
+                        specifiedValue = props[schema.name];
+                    }
+                    
                     properties[key] = {
                         id: schema.id,
                         name: schema.name,
+                        nameInUse: nameInUse,
                         description: schema.description,
                         defaultValue: schema.defaultValue,
                         type: schema.type,
@@ -85,7 +101,7 @@ define([], function () {
                         contentType: schema.contentType,
                         contentTypeProperty: schema.contentTypeProperty,
                         options: schema.options,
-                        value: cell.attr('props/' + key),
+                        value: specifiedValue,
                         pattern: schema.pattern,
                         valueFunc: function(newValue) {
                             if (arguments.length) {
@@ -99,7 +115,7 @@ define([], function () {
                             }
                         }
                     };
-
+                    
                     // Number and Boolean values may be of String type, hence convert them appropriately
                     var inputType = $scope.getInputType(properties[key]);
                     if (inputType === 'number' && properties[key].value !== undefined && properties[key].value !== null && typeof properties[key].value !== 'number') {

--- a/ui/app/scripts/stream/services/editor-service.js
+++ b/ui/app/scripts/stream/services/editor-service.js
@@ -88,13 +88,13 @@ define(function(require) {
                             property = properties[key];
                             if ((typeof property.value === 'boolean' && !property.defaultValue && !property.value) ||
                                 (property.value === property.defaultValue || property.value === '' || property.value === undefined || property.value === null)) {
-                                if (angular.isDefined(element.attr('props/' + property.id))) {
+                                if (angular.isDefined(element.attr('props/' + property.nameInUse))) {
                                     // Remove attr doesn't fire appropriate event. Set default value first as a workaround to schedule DSL resync
-                                    element.attr('props/' + property.id, property.defaultValue === undefined ? null : property.defaultValue);
-                                    element.removeAttr('props/' + property.id);
+                                    element.attr('props/' + property.nameInUse, property.defaultValue === undefined ? null : property.defaultValue);
+                                    element.removeAttr('props/' + property.nameInUse);
                                 }
                             } else {
-                                element.attr('props/' + property.id, property.value);
+                                element.attr('props/' + property.nameInUse, property.value);
                             }
                         });
 

--- a/ui/app/scripts/stream/services/metamodel.js
+++ b/ui/app/scripts/stream/services/metamodel.js
@@ -165,7 +165,8 @@ define(function (require) {
                                 var whitelisted = isWhitelisted(result.data.options);
                                 result.data.options.forEach(function (p) {
                                     if (whitelisted) {
-                                        p.id = p.name;
+                                        // id is the long-name, eg. 'trigger.initial-delay'
+                                        // name is the short-name, eg. 'initial-delay'
                                         properties[p.id] = p;
                                     } else {
                                         // An interesting property is not dotted and is not 'debug' or 'info'
@@ -176,14 +177,14 @@ define(function (require) {
                                         }
                                     }
                                     if (p.sourceType === 'org.springframework.cloud.stream.app.transform.ProgrammableRxJavaProcessorProperties') {
-                                        if (p.id === 'code') {
+                                        if (p.name === 'code') {
                                             p.contentType = 'java';
                                         }
                                     } else if (p.sourceType === 'org.springframework.cloud.stream.app.scriptable.transform.processor.ScriptableTransformProcessorProperties') {
-                                        if (p.id === 'script') {
+                                        if (p.name === 'script') {
                                             p.contentType = 'Plain Text';
                                             p.contentTypeProperty = 'language';
-                                        } else if (p.id === 'language') {
+                                        } else if (p.name === 'language') {
                                             p.options = ['groovy', 'javascript', 'ruby', 'python'];
                                         }
                                     }


### PR DESCRIPTION
Prior to this change Flo only recognized use of the short names
and any use of long names would not get reflected in the
properties view.

With this change the DSL text can include either short or
long names and the properties view will correctly pickup any
specified values. When the properties view is closed the
DSL text will be updated to reflect new values and should use
the same form of name (long or short) that was originally
used. If the properties view is used to set a property
that previously had no value the DSL text will use the
short name.