### PR TITLE
Temporarily deactivate eager stream name validation in create tab

### DIFF
--- a/ui/app/scripts/stream/directives.js
+++ b/ui/app/scripts/stream/directives.js
@@ -36,20 +36,26 @@ define(function(require) {
                             return utils.$q.when();
                         }
 
-                        var def = utils.$q.defer();
-
-                        streamService.getSingleStreamDefinition(modelValue).then(function() {
-                            // Success! Found stream with such name
-                            def.reject('Stream with such name exists');
-                        }, function(error) {
-                            if (error.status === 404) {
-                                def.resolve();
-                            } else {
-                                def.reject(error.statusText);
-                            }
-                        });
-
-                        return def.promise;
+                        // For now consider everything valid (it will fail when the create operation
+                        // is actually driven if there is a real problem). Once there is a quiet
+                        // backend operation to check for stream existence, reactivate the code
+                        // below.
+                        return utils.$q.when();
+                        
+                        // This variant calls the API that currently logs an exception on the server.
+//                        var def = utils.$q.defer();
+//                        streamService.getSingleStreamDefinition(modelValue).then(function() {
+//                            // Success! Found stream with such name
+//                            def.reject('Stream with such name exists');
+//                        }, function(error) {
+//                            if (error.status === 404) {
+//                                def.resolve();
+//                            } else {
+//                                def.reject(error.statusText);
+//                            }
+//                        });
+//
+//                        return def.promise;
                     };
                 }
             };


### PR DESCRIPTION
When building streams it is nice to eagerly validate stream
names and let the user know if they are specifying something
invalid as early as possible.  Unfortunately the current
endpoint logs an exception on the server when a check is made
for a name that does not currently exist. Until we can change
that to avoid the exception for our scenario, this commit
turns off validation.

I did not delete the code because we want to turn it back on as soon
as we can tweak the endpoint on the server. But if you really
want me to, I can do that. For similar reasons I did not 'undo' all the
validation infrastructure that has been built around this feature, I wanted
to keep this change minimal. Comments welcome.