### PR TITLE
gh-97 Deploy Stream Definition - Change Doc Link

### DIFF
--- a/ui/app/scripts/stream/views/definition-deploy.html
+++ b/ui/app/scripts/stream/views/definition-deploy.html
@@ -1,7 +1,7 @@
 <h1 ng-show="definitionName">Deploy Stream Definition {{definitionName}}</h1>
 
 	<p class="index-page--subtitle"> Please specify any <strong>optional</strong> deployment properties. For more information please see the
-		<a href="http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/htmlsingle/#_creating_a_simple_stream"
+		<a href="http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/htmlsingle/#_passing_application_properties_when_deploying_stream"
 		target="_blank">Technical Documentation</a>.
 	</p>
 	<form name="deployDefinitionForm" class="form-horizontal" role="form" ng-submit="deployDefinition(definitionDeployRequest)">


### PR DESCRIPTION
* Link points now to: http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/htmlsingle/#_passing_application_properties_when_deploying_stream

Resolves spring-cloud/spring-cloud-dataflow-ui#97