### PR TITLE
gh-48 Implement bulk import of apps

### DIFF
--- a/ui/app/scripts/app/controllers.js
+++ b/ui/app/scripts/app/controllers.js
@@ -35,5 +35,11 @@ define(['angular'], function (angular) {
                 require(['app/controllers/register-apps'], function (registerAppsController) {
                     $injector.invoke(registerAppsController, this, {'$scope': $scope});
                 });
+            }])
+        .controller('BulkImportAppsController',
+            ['$scope', '$injector', function ($scope, $injector) {
+                require(['app/controllers/bulk-import-apps'], function (bulkImportAppsController) {
+                    $injector.invoke(bulkImportAppsController, this, {'$scope': $scope});
+                });
             }]);
 });

--- a/ui/app/scripts/app/controllers/apps.js
+++ b/ui/app/scripts/app/controllers/apps.js
@@ -326,6 +326,13 @@ define(['model/pageable'], function (Pageable) {
                 $state.go('home.apps.registerApps');
             };
 
+            /**
+             * Takes one to bulk import app page
+             */
+            $scope.bulkImportApps = function() {
+                $state.go('home.apps.bulkImportApps');
+            };
+
             $scope.$on('$destroy', function(){
                 if ($scope.getAppDefinitions) {
                     utils.$timeout.cancel($scope.getAppDefinitions);

--- a/ui/app/scripts/app/controllers/bulk-import-apps.js
+++ b/ui/app/scripts/app/controllers/bulk-import-apps.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Definition bulk import apps controller.
+ *
+ * @author Gunnar Hillert
+ */
+define(function () {
+    'use strict';
+    return ['$scope', 'AppService', 'DataflowUtils', '$modal', '$state',
+        function ($scope, appService, utils, $modal, $state) {
+
+            function newBulkAppImport() {
+                return {
+                    uri: '',
+                    appsProperties: null,
+                    force: false
+                };
+            }
+
+            function newStreamAppStarters() {
+                return [
+                    {
+                        name: 'Maven based Stream Applications with RabbitMQ Binder',
+                        uri:  'http://bit.ly/stream-applications-rabbit-maven',
+                        force: false
+                    },
+                    {
+                        name: 'Maven based Stream Applications with Kafka Binder',
+                        uri:  'http://bit.ly/stream-applications-kafka-maven',
+                        force: false
+                    },
+                    {
+                        name: 'Docker based Stream Applications with RabbitMQ Binder',
+                        uri:  'http://bit.ly/stream-applications-rabbit-docker',
+                        force: false
+                    },
+                    {
+                        name: 'Docker based Stream Applications with Kafka Binder',
+                        uri:  'http://bit.ly/stream-applications-kafka-docker',
+                        force: false
+                    }
+                ];
+            }
+
+            function newTaskAppStarters() {
+                return [
+                    {
+                        name: 'Maven based Task Applications',
+                        uri:  'http://bit.ly/task-applications-maven',
+                        force: false
+                    },
+                    {
+                        name: 'Docker based Task Applications',
+                        uri:  'http://bit.ly/task-applications-docker',
+                        force: false
+                    }
+                ];
+            }
+
+            // Basic URI validation RegEx pattern
+            $scope.uriPattern = '^([a-z0-9-]+:\/\/)([\\w\\.:-]+)(\/[\\w\\.:-]+)*$';
+
+            /**
+             * Bulk Import Apps.
+             */
+            $scope.bulkImportApps = function(item) {
+
+                if (item.uri && item.appsProperties) {
+                    utils.growl.error('Please provide only a URI or Properties not both.');
+                    return;
+                }
+
+                if (item.uri) {
+                    console.log('Importing apps from ' + item.uri + ' (force: ' + item.force + ')');
+                }
+                if (item.appsProperties) {
+                    console.log('Importing apps using textarea values:\n' + item.appsProperties + ' (force: ' + item.force + ')');
+                }
+
+                var promise;
+
+                promise = appService.bulkImportApps(item.uri, item.appsProperties, item.force).$promise;
+                utils.addBusyPromise(promise);
+
+                promise.then(function() {
+                    utils.growl.success('Submitted bulk import request');
+                    console.log(newBulkAppImport());
+                    $scope.$watch('apps', function () {
+                        $scope.apps.appsProperties = '';
+                        $scope.apps.uri = '';
+                        $scope.apps.force = false;
+                    });
+                    $scope.streamAppStarters = newStreamAppStarters();
+                    $scope.taskAppStarters   = newTaskAppStarters();
+                });
+                promise.catch(function(error) {
+                    utils.growl.error(error.data[0].message);
+                });
+            };
+
+            /**
+             * Takes one to All Applications page
+             */
+            $scope.close = function() {
+                $state.go('home.apps.tabs.appsList');
+            };
+
+            $scope.displayFileContents = function(contents) {
+                console.log(contents);
+                $scope.$watch('apps', function () {
+                    $scope.apps.appsProperties = contents.split('\n');
+                });
+            };
+
+            $scope.apps = newBulkAppImport();
+            $scope.streamAppStarters = newStreamAppStarters();
+            $scope.taskAppStarters   = newTaskAppStarters();
+
+            $scope.$apply();
+
+        }];
+});

--- a/ui/app/scripts/app/services.js
+++ b/ui/app/scripts/app/services.js
@@ -79,6 +79,18 @@ define(['angular'], function (angular) {
                             method: 'DELETE'
                         }
                     }).unregisterApp();
+                },
+                bulkImportApps: function(uri, appsProperties, force) {
+                    return $resource($rootScope.dataflowServerUrl + '/apps', {}, {
+                        bulkImportApps: {
+                            method: 'POST',
+                            params: {
+                                uri: uri,
+                                apps: appsProperties ? appsProperties.join('\n') : null,
+                                force: force ? true : false
+                            }
+                        }
+                    }).bulkImportApps();
                 }
             };
         });

--- a/ui/app/scripts/app/views/apps-list.html
+++ b/ui/app/scripts/app/views/apps-list.html
@@ -14,6 +14,11 @@
                         ><span class="glyphicon glyphicon-trash"></span>
                             Unregister Application(s)
                         </button>
+                        <button id="bulkImportAppsButton" type="button" ng-click="bulkImportApps()"
+                                class="btn btn-default"
+                        ><span class="glyphicon glyphicon-import"></span>
+                            Bulk Import Applications
+                        </button>
                     </td>
                     <td>
                         <input type="text" class="form-control" ng-model="filterQuery" id="filterTable"

--- a/ui/app/scripts/app/views/bulk-import-apps.html
+++ b/ui/app/scripts/app/views/bulk-import-apps.html
@@ -1,0 +1,138 @@
+<h1>Bulk Import Applications</h1>
+<p>
+    Import and register applications in bulk. Simply provide a URI that points to
+    the location of the <strong>properties file</strong> where the keys are formatted as
+    <strong>type.name</strong> and the values are the URIs of the apps.
+    For convenience, a list of out-of-the-box Stream and Task app starters is provided below, as well.
+</p>
+<hr/>
+
+<form class="form-horizontal" name="bulkImportAppsForm" role="form" ng-submit="bulkImportApps(apps)" novalidate>
+    <fieldset id="importAppsViaUri">
+        <div class="form-group" ng-class="bulkImportAppsForm.uri.$invalid ? 'has-warning has-feedback' : ''">
+            <label for="uri" class="col-sm-3 control-label">Uri</label>
+            <div class="col-sm-7">
+                <input type="text" id="uri" name="uri" autofocus
+                       class="form-control" placeholder="<http://url.to.properties>" ng-model="apps.uri" ng-pattern="uriPattern">
+                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="bulkImportAppsForm.uri.$invalid"></span>
+                <p class="help-block">Please provide a valid URI pointing to the respective properties file.</p>
+            </div>
+        </div>
+    </fieldset>
+    <h2 class="text-center">OR</h2>
+    <div class="row" style="margin-bottom: 1em;">
+        <div class="col-md-6 col-md-offset-3">
+            <p>
+               Enter the list of properties into the text area field below. Alternatively, you can also select a
+               file in your local file system, which is used to populate the text area field.
+            </p>
+        </div>
+    </div>
+
+    <fieldset id="importAppsViaUpload">
+        <div class="form-group" ng-class="bulkImportAppsForm.appsProperties.$invalid ? 'has-warning has-feedback' : ''">
+            <label for="appsProperties" class="col-sm-3 control-label">Apps as Properties</label>
+            <div class="col-sm-7">
+            <textarea id="appsProperties" autofocus ng-model="apps.appsProperties" rows="5" ng-list="&#10;" ng-trim="false"
+                class="form-control" placeholder="Example:
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT
+task.spark-client=maven://org.springframework.cloud.task.app:spark-client-task:1.0.0.BUILD-SNAPSHOT"
+            ></textarea>
+                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="bulkImportAppsForm.appsProperties.$invalid"></span>
+                <p class="help-block">Please provide a valid properties where the keys are formatted as
+                    <strong>type.name</strong> and the values are the URIs of the apps.</p>
+            </div>
+        </div>
+        <div class="form-group" ng-class="bulkImportAppsForm.uri.$invalid ? 'has-warning has-feedback' : ''">
+            <label for="uri" class="col-sm-3 control-label">Select Properties File</label>
+            <div class="col-sm-7">
+                <input type="file" on-read-file="displayFileContents(contents)" />
+                <span class="glyphicon glyphicon-warning-sign form-control-feedback" ng-show="createDefinitionForm.definitionName.$invalid"></span>
+                <p class="help-block">Please provide a text file containing properties. This will be used
+                to populate the text area above.</p>
+            </div>
+        </div>
+    </fieldset>
+
+    <div class="form-group">
+        <div class="col-sm-7 col-sm-offset-3">
+        <input type="checkbox" ng-model="apps.force" ng-model-options="{ getterSetter: true }" ui-indeterminate="someForceButNotAll()"/>
+        Force
+        <a dataflow-popover=".force-help-content" title="Force"><span class="glyphicon glyphicon-question-sign"></span></a>
+        </div>
+    </div>
+
+    <div class="row" style="margin-bottom: 2em;">
+        <div class="col-md-6 text-right"><button id="back-button"   type="button" class="btn btn-default" ng-click="close()">Cancel</button></div>
+        <div class="col-md-6 text-left"><button  id="submit-button" type="submit" class="btn btn-default" ng-disabled="bulkImportAppsForm.$invalid"><span class="glyphicon glyphicon-import" aria-hidden="true"></span> Import</button></div>
+    </div>
+</form>
+
+<h2>Out-of-the-box Stream app-starters</h2>
+
+<table class="table form-table">
+    <col width="80%">
+    <col width="10%">
+    <col width="10%">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th class="text-center">Force <a dataflow-popover=".force-help-content" title="Force"><span class="glyphicon glyphicon-question-sign"></span></a></th>
+        <th class="text-center">Action</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="item in streamAppStarters">
+        <td>
+            {{item.name}}
+        </td>
+        <td class="text-center">
+            <input type="checkbox" name="{{$index + '_force'}}" ng-model="item.force">
+        </td>
+        <td class="action-column text-center">
+            <button type="button" ng-click="bulkImportApps(item)"
+                    class="btn btn-sm btn-default"
+                    title="Bulk Import Apps"
+            ><span class="glyphicon glyphicon-import"></span>
+            </button>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<h2>Out-of-the-box Task app-starters</h2>
+
+<table class="table form-table">
+    <col width="80%">
+    <col width="10%">
+    <col width="10%">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th class="text-center">Force <a dataflow-popover=".force-help-content" title="Force"><span class="glyphicon glyphicon-question-sign"></span></a></th>
+            <th class="text-center">Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr ng-repeat="item in taskAppStarters">
+            <td>
+                {{item.name}}
+            </td>
+            <td class="text-center">
+                <input type="checkbox" name="{{$index + '_force'}}" ng-model="item.force">
+            </td>
+            <td class="action-column text-center">
+                <button type="button" ng-click="bulkImportApps(item)"
+                        class="btn btn-sm btn-default"
+                        title="Bulk Import Apps"
+                ><span class="glyphicon glyphicon-import"></span>
+                </button>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<div class="force-help-content hide">
+    <span class="force-help-content">By checking <strong>force</strong>, the applications will be imported and installed
+        even if it already exists but only if not being used already.</span>
+</div>

--- a/ui/app/scripts/directives.js
+++ b/ui/app/scripts/directives.js
@@ -359,5 +359,28 @@ define(['angular', 'xregexp', 'moment'], function(angular) {
           };
         }
       };
+    })
+    .directive('onReadFile', function ($parse) {
+      return {
+        restrict: 'A',
+        scope: false,
+        link: function(scope, element, attrs) {
+          element.bind('change', function() {
+
+            var onFileReadFn = $parse(attrs.onReadFile);
+            var reader = new FileReader();
+
+            reader.onload = function() {
+              var fileContents = reader.result;
+              scope.$apply(function() {
+                onFileReadFn(scope, {
+                  'contents' : fileContents
+                });
+              });
+            };
+            reader.readAsText(element[0].files[0]);
+          });
+        }
+      };
     });
 });

--- a/ui/app/scripts/routes.js
+++ b/ui/app/scripts/routes.js
@@ -369,6 +369,15 @@ define(['./app'], function (dashboard) {
             authenticate: true
           }
         })
+        .state('home.apps.bulkImportApps', {
+          url: 'apps/bulk-import-apps',
+          templateUrl: appTemplatesPath + '/bulk-import-apps.html',
+          controller: 'BulkImportAppsController',
+          data: {
+            title: 'Bulk Import Apps',
+            authenticate: true
+          }
+        })
         .state('home.runtime.tabs', {
           url: 'runtime',
           abstract: true,


### PR DESCRIPTION
* Add support to point to http resources
* Add support to paste apps (properties) into a text-area field
* Using a fileupload button, add the ability to load apps properties via a text-file
* Add one-click ability to register out-of-the-box app starters (Stream + Task)

Resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/48