### PR TITLE
Bulk Define Tasks UI and Validation

### DIFF
--- a/ui/app/scripts/routes.js
+++ b/ui/app/scripts/routes.js
@@ -285,6 +285,15 @@ define(['./app'], function (dashboard) {
         feature: 'tasksEnabled'
       }
     })
+    .state('home.tasks.bulkDefineTasks', {
+      url : 'tasks/bulk-define-tasks',
+      templateUrl : taskTemplatesPath + '/bulk-define-tasks.html',
+      controller: 'BulkDefineTasksController',
+      data:{
+        authenticate: true,
+        feature: 'tasksEnabled'
+      }
+    })
         .state('home.tasks.deploymentsLaunch', {
           url: 'tasks/definitions/launch/{taskName}',
           templateUrl: taskTemplatesPath + '/launch.html',

--- a/ui/app/scripts/shared/services.js
+++ b/ui/app/scripts/shared/services.js
@@ -19,8 +19,11 @@
  *
  * @author Ilayaperumal Gopinathan
  */
-define(['angular', 'xregexp'], function (angular) {
+define(function (require) {
   'use strict';
+
+  var angular = require('angular');
+  require('xregexp');
 
   return angular.module('dataflowShared.services', [])
       .factory('DataflowUtils', function ($log, growl, $timeout, $q, $rootScope) {
@@ -57,6 +60,7 @@ define(['angular', 'xregexp'], function (angular) {
           }
         };
       })
+      .factory('ParserService',require('shared/services/parser'))
       .factory('dataflowVersionInfo', function ($resource, $rootScope, DataflowUtils) {
         console.log('dataflowVersionInfo');
         var dataflowVersionInfoPromise =  $resource($rootScope.dataflowServerUrl + '/management/info', {}, {

--- a/ui/app/scripts/shared/services/parser.js
+++ b/ui/app/scripts/shared/services/parser.js
@@ -117,7 +117,7 @@ define(function() {
         				}
         			}
         			if (pos >= max) {
-        				throw {'msg':'StreamDefinitionException: non terminating quoted string','start':start,'end':pos};
+        				throw {'msg':'DefinitionException: non terminating quoted string','start':start,'end':pos};
         			}
         		}
         		pos++;
@@ -201,7 +201,7 @@ define(function() {
         				}
         			}
         			if (pos >= max) {
-        				throw {'msg':'StreamDefinitionException: non terminating double quoted string','start':start,'end':pos};
+        				throw {'msg':'DefinitionException: non terminating double quoted string','start':start,'end':pos};
         			}
         		}
         		pos++;
@@ -300,9 +300,9 @@ define(function() {
 						pos++; // will take us to the end
 						break;
 					case '\\':
-						throw {'msg':'StreamDefinitionException: Unexpected escape char','start':pos};
+						throw {'msg':'DefinitionException: Unexpected escape char','start':pos};
 					default:
-						throw {'msg':'StreamDefinitionException: Unexpected character','start':pos};
+						throw {'msg':'DefinitionException: Unexpected character','start':pos};
         			}
         		}
         	}
@@ -310,7 +310,11 @@ define(function() {
         }
 
         // TODO switch to the var x= (function() {... return yyy; })(); model
-        function parse(definitionsText) {
+		// mode may be 'task' or 'stream' - will default to 'stream'
+        function parse(definitionsText, mode) {
+			if (!mode) { 
+				mode = 'stream';
+			}
 			var lines = [];
 			var line;
 			var text;
@@ -665,12 +669,13 @@ define(function() {
         		return appNodes;
         	}
 
+
         	// (name =)
         	function maybeEatStreamName() {
         		var streamName = null;
         		if (lookAhead(1, tokenKinds.EQUALS)) {
         			if (peekToken(tokenKinds.IDENTIFIER)) {
-        				streamName = eatToken(tokenKinds.IDENTIFIER).data;
+        				streamName = eatToken(tokenKinds.IDENTIFIER);
         				nextToken(); // skip '='
         			}
         			else {
@@ -700,13 +705,44 @@ define(function() {
 	        	}
         		node.errors.push(error);
         	}
+			
+			function eatTaskDefinition(lineNum) {
+				var taskNode = {};
+				var taskName = maybeEatStreamName();
+				if (!taskName) {
+					recordError(taskNode, {
+						'msg': 'Expected format: name = taskapplication [options]',
+						'range':{'start':{'ch':0,'line':lineNum},
+									'end':{'ch':0,'line':lineNum}}
+					});
+				} else {
+					taskNode.name = taskName.data;
+					taskNode.namerange = 
+						{'start':{'ch':taskName.start,'line':lineNum},
+						   'end':{'ch':taskName.end,'line':lineNum}};
+					if (outOfData()) {
+						recordError(taskNode,{
+							'msg':'Expected format: name = taskapplication [options]',
+							'range':{'start':{'ch':0,'line':lineNum},
+									'end':{'ch':0,'line':lineNum}
+						}});
+						return taskNode;
+					}
+				}
+				taskNode.app = eatApp();
+				if (moreTokens()) {
+        			var t = peekAtToken();
+        			throw {'msg':'Unexpected data after task definition: '+toString(t),'start':t.start};
+        		}
+				return taskNode;
+			}
 
         	function eatStream() {
         		var streamNode = {};
 
         		var streamName = maybeEatStreamName();
         		if (streamName) {
-        			streamNode.name = streamName;
+        			streamNode.name = streamName.data;
         		}
 
         		var sourceChannelNode = maybeEatSourceChannel();
@@ -752,6 +788,7 @@ define(function() {
         	}
 
 			var start, end, errorToRecord;
+
         	for (var lineNumber=0;lineNumber<textlines.length;lineNumber++) {
 	        	try {
 		        	line = {};
@@ -764,7 +801,7 @@ define(function() {
 		        	}
 	        		$log.info('JSParse: processing '+text);
 		        	tokenStream = tokenize(text);
-		        	$log.info('JSParse: tokenized to '+JSON.stringify(tokenStream));
+		        	// $log.info('JSParse: tokenized to '+JSON.stringify(tokenStream));
 		        	tokenStreamPointer = 0;
 		        	tokenStreamLength = tokenStream.length;
 		        	// time | log
@@ -772,90 +809,125 @@ define(function() {
                     //  {"token":4,"start":5,"end":6},
                     //  {"token":0,"data":"log","start":7,"end":10}]
 	
-		        	var streamdef = eatStream();
-		        	$log.info('JSParse: parsed to '+JSON.stringify(streamdef));
-		        	// streamDef = {"apps":[{"name":"time","start":0,"end":4},{"name":"log","start":7,"end":10}]}
-		        	
-		        	// {"lines":[{"errors":null,"success":
-		        	// [{"group":"UNKNOWN_1","label":"time","type":"source","name":"time","options":{},"sourceChannelName":null,"sinkChannelName":null},{"group":"UNKNOWN_1","label":"log","type":"sink","name":"log","options":{},"sourceChannelName":null,"sinkChannelName":null}]
-		        	// }],"links":[]}
-		        	
-		        	var streamName = streamdef.name?streamdef.name:'UNKNOWN_'+lineNumber;
-		        	var success = [];
-		        	if (streamdef.apps) {
-						var alreadySeen = {};
-		        		for (var m=0;m<streamdef.apps.length;m++) {
-		        			var expectedType = 'processor';
-		        			if (m === 0 && !streamdef.sourceChannel) {
-		        				expectedType = 'source';
-		        			}
-		        			if (m === (streamdef.apps.length-1) && !streamdef.sourceChannel) {
-		        				expectedType = 'sink';
-		        			}
-				        	var sourceChannelName = null;
-				        	if (m === 0 && streamdef.sourceChannel) {
-				        		sourceChannelName = streamdef.sourceChannel.channel.name;
-				        	}
-				        	var sinkChannelName = null;
-				        	if (m===streamdef.apps.length-1 && streamdef.sinkChannel) {
-				        		sinkChannelName = streamdef.sinkChannel.channel.name;
-				        	}
-		        			var app = streamdef.apps[m];
-		        			var uglyObject = {};
-		        			uglyObject.group=streamName;
-		        			if (app.label) {
-		        				uglyObject.label = app.label;
-		        			}
-		        			uglyObject.type = expectedType;
-	        				uglyObject.name = app.name;
-	        				uglyObject.range = {'start':{'ch':app.start,'line':lineNumber},'end':{'ch':app.end,'line':lineNumber}};
-	        				var options = {};
-	        				var optionsranges = {};
-	        				if (app.options) {
-	        					options = {};
-	        					optionsranges = {};
-	        					for (var o=0;o<app.options.length;o++) {
-	        						var option = app.options[o];
-	        						options[option.name]=option.value;
-	        						optionsranges[option.name]={'start':{'ch':option.start,'line':lineNumber},'end':{'ch':option.end,'line':lineNumber}};
-	        					}
-	        				}
-	    					uglyObject.options=options;
-	    					uglyObject.optionsranges = optionsranges;
-							uglyObject.sourceChannelName = sourceChannelName;
-							uglyObject.sinkChannelName = sinkChannelName;
-				        	success.push(uglyObject);
-
-				        	var nameToCheck = uglyObject.label?uglyObject.label:uglyObject.name;
-							// Check that each app has a unique label (either explicit or implicit)
-							var previous = alreadySeen[nameToCheck];
-							if (typeof previous === 'number') {
-								recordError(streamdef, {
-									'msg': app.label ?
-										'Label \'' + app.label + '\' should be unique but app \'' + app.name + '\' (at position ' + m + ') and app \'' + streamdef.apps[previous].name + '\' (at position ' + previous + ') both use it'
-										: 'App \'' + app.name + '\' should be unique within the stream, use a label to differentiate multiple occurrences',
-									'range': uglyObject.range
-								});
-							} else {
-								alreadySeen[nameToCheck] = m;
+					var errorsToProcess = [];
+					var success = [];
+					var app;
+					var option;
+					var options;
+					var optionsranges;
+					if (mode === 'task') {
+						var taskdef = eatTaskDefinition(lineNumber);
+						$log.info('JSParse: parsed to task definition: '+JSON.stringify(taskdef));
+						app = taskdef.app;
+						if (app) {
+							var taskObject = {};
+							taskObject.group = taskdef.name;
+							taskObject.grouprange = taskdef.namerange;
+							taskObject.type = 'task';
+							taskObject.name = app.name;
+							taskObject.range = {'start':{'ch':app.start,'line':lineNumber},'end':{'ch':app.end,'line':lineNumber}};
+							options = {};
+							optionsranges = {};
+							if (app.options) {
+								for (var o1=0;o1<app.options.length;o1++) {
+									option = app.options[o1];
+									options[option.name]=option.value;
+									optionsranges[option.name]={'start':{'ch':option.start,'line':lineNumber},'end':{'ch':option.end,'line':lineNumber}};
+								}
 							}
-		        		}
-		        	} else {
-		        		// error case: ':stream:foo >'
-		        		// there is no target for the tap yet
-		        		if (streamdef.sourceChannel) {
-		        			// need to build a dummy app to hang the sourcechannel off
-		        			var obj = {};
-		        			obj.sourceChannelName = streamdef.sourceChannel.channel.name;
-		        			success.push(obj);
-		        		}
-		        	}
+							taskObject.options=options;
+							taskObject.optionsranges = optionsranges;
+							success.push(taskObject);
+						}
+						if (taskdef.errors) {
+							errorsToProcess = taskdef.errors;
+						}
+					} else {
+						var streamdef = eatStream();
+						$log.info('JSParse: parsed to stream definition: '+JSON.stringify(streamdef));
+						// streamDef = {"apps":[{"name":"time","start":0,"end":4},{"name":"log","start":7,"end":10}]}
+						
+						// {"lines":[{"errors":null,"success":
+						// [{"group":"UNKNOWN_1","label":"time","type":"source","name":"time","options":{},"sourceChannelName":null,"sinkChannelName":null},{"group":"UNKNOWN_1","label":"log","type":"sink","name":"log","options":{},"sourceChannelName":null,"sinkChannelName":null}]
+						// }],"links":[]}
+						
+						var streamName = streamdef.name?streamdef.name:'UNKNOWN_'+lineNumber;
+						if (streamdef.apps) {
+							var alreadySeen = {};
+							for (var m=0;m<streamdef.apps.length;m++) {
+								var expectedType = 'processor';
+								if (m === 0 && !streamdef.sourceChannel) {
+									expectedType = 'source';
+								}
+								if (m === (streamdef.apps.length-1) && !streamdef.sourceChannel) {
+									expectedType = 'sink';
+								}
+								var sourceChannelName = null;
+								if (m === 0 && streamdef.sourceChannel) {
+									sourceChannelName = streamdef.sourceChannel.channel.name;
+								}
+								var sinkChannelName = null;
+								if (m===streamdef.apps.length-1 && streamdef.sinkChannel) {
+									sinkChannelName = streamdef.sinkChannel.channel.name;
+								}
+								app = streamdef.apps[m];
+								var uglyObject = {};
+								uglyObject.group=streamName;
+								if (app.label) {
+									uglyObject.label = app.label;
+								}
+								uglyObject.type = expectedType;
+								uglyObject.name = app.name;
+								uglyObject.range = {'start':{'ch':app.start,'line':lineNumber},'end':{'ch':app.end,'line':lineNumber}};
+								options = {};
+								optionsranges = {};
+								if (app.options) {
+									for (var o2=0;o2<app.options.length;o2++) {
+										option = app.options[o2];
+										options[option.name]=option.value;
+										optionsranges[option.name]={'start':{'ch':option.start,'line':lineNumber},'end':{'ch':option.end,'line':lineNumber}};
+									}
+								}
+								uglyObject.options=options;
+								uglyObject.optionsranges = optionsranges;
+								uglyObject.sourceChannelName = sourceChannelName;
+								uglyObject.sinkChannelName = sinkChannelName;
+								success.push(uglyObject);
+
+								var nameToCheck = uglyObject.label?uglyObject.label:uglyObject.name;
+								// Check that each app has a unique label (either explicit or implicit)
+								var previous = alreadySeen[nameToCheck];
+								if (typeof previous === 'number') {
+									recordError(streamdef, {
+										'msg': app.label ?
+											'Label \'' + app.label + '\' should be unique but app \'' + app.name + '\' (at position ' + m + ') and app \'' + streamdef.apps[previous].name + '\' (at position ' + previous + ') both use it'
+											: 'App \'' + app.name + '\' should be unique within the stream, use a label to differentiate multiple occurrences',
+										'range': uglyObject.range
+									});
+								} else {
+									alreadySeen[nameToCheck] = m;
+								}
+							}
+						} else {
+							// error case: ':stream:foo >'
+							// there is no target for the tap yet
+							if (streamdef.sourceChannel) {
+								// need to build a dummy app to hang the sourcechannel off
+								var obj = {};
+								obj.sourceChannelName = streamdef.sourceChannel.channel.name;
+								success.push(obj);
+							}
+						}
+						if (streamdef.errors) {
+							errorsToProcess = streamdef.errors;
+						}
+					}
  		        	line.success = success;	  
 		        	
-		        	if (streamdef.errors) {
+		        	if (errorsToProcess && errorsToProcess.length !== 0) {
 		        		line.errors = [];
-		        		for (var e=0;e<streamdef.errors.length;e++) {
-		        			var error = streamdef.errors[e];
+		        		for (var e=0;e<errorsToProcess.length;e++) {
+		        			var error = errorsToProcess[e];
 		        			errorToRecord = {};
 		        			errorToRecord.accurate = true;
 		        			errorToRecord.message = error.msg;
@@ -901,7 +973,7 @@ define(function() {
 	        		}
 	        	}
         	}
-        	$log.info('JSParse: final lines: '+JSON.stringify(lines));
+        	// $log.info('JSParse: final lines: '+JSON.stringify(lines));
         	return {'lines':lines};
         }
 

--- a/ui/app/scripts/shared/services/parser.js
+++ b/ui/app/scripts/shared/services/parser.js
@@ -669,22 +669,6 @@ define(function() {
         		return appNodes;
         	}
 
-
-        	// (name =)
-        	function maybeEatStreamName() {
-        		var streamName = null;
-        		if (lookAhead(1, tokenKinds.EQUALS)) {
-        			if (peekToken(tokenKinds.IDENTIFIER)) {
-        				streamName = eatToken(tokenKinds.IDENTIFIER);
-        				nextToken(); // skip '='
-        			}
-        			else {
-        				throw {'msg':'Illegal Stream Name '+peekAtToken(),'start':peekAtToken().start};
-        			}
-        		}
-        		return streamName;
-        	}
-
         	function toString(token) {
         		if (token.data) {
         			return token.data;
@@ -693,6 +677,21 @@ define(function() {
         			return token.kind.value;
         		}
     			return JSON.stringify(token);
+        	}
+
+        	// (name =)
+        	function maybeEatName() {
+        		var name = null;
+        		if (lookAhead(1, tokenKinds.EQUALS)) {
+        			if (peekToken(tokenKinds.IDENTIFIER)) {
+        				name = eatToken(tokenKinds.IDENTIFIER);
+        				nextToken(); // skip '='
+        			}
+        			else {
+        				throw {'msg':'Illegal Name \''+toString(peekAtToken())+'\'','start':peekAtToken().start};
+        			}
+        		}
+        		return name;
         	}
 
         	function outOfData() {
@@ -708,7 +707,7 @@ define(function() {
 			
 			function eatTaskDefinition(lineNum) {
 				var taskNode = {};
-				var taskName = maybeEatStreamName();
+				var taskName = maybeEatName();
 				if (!taskName) {
 					recordError(taskNode, {
 						'msg': 'Expected format: name = taskapplication [options]',
@@ -740,7 +739,7 @@ define(function() {
         	function eatStream() {
         		var streamNode = {};
 
-        		var streamName = maybeEatStreamName();
+        		var streamName = maybeEatName();
         		if (streamName) {
         			streamNode.name = streamName.data;
         		}
@@ -943,7 +942,7 @@ define(function() {
 		        	}        	
 		        	$log.info('JSParse: translated to '+JSON.stringify(line));
 		        	lines.push(line);
-		    	} catch (err) { 
+		    	} catch (err) {
 	        		if (typeof err === 'object' && err.msg) {
 	        			if (!line.errors) {
 	        				line.errors = [];
@@ -973,7 +972,6 @@ define(function() {
 	        		}
 	        	}
         	}
-        	// $log.info('JSParse: final lines: '+JSON.stringify(lines));
         	return {'lines':lines};
         }
 

--- a/ui/app/scripts/stream/services.js
+++ b/ui/app/scripts/stream/services.js
@@ -100,7 +100,6 @@ define(function(require) {
         };
       }).
       factory('StreamMetamodelService',require('stream/services/metamodel')).
-      factory('StreamParserService',require('stream/services/parser')).
       factory('StreamEditorService', require('stream/services/editor-service')).
       factory('StreamRenderService', require('stream/services/render-service')).
       factory('StreamContentAssistService', require('stream/services/content-assist-service'));

--- a/ui/app/scripts/stream/services/metamodel.js
+++ b/ui/app/scripts/stream/services/metamodel.js
@@ -42,7 +42,7 @@ define(function (require) {
 
     var angular = require('angular');
 
-    return ['$http', 'DataflowUtils', 'AppService', 'StreamParserService', 'MetamodelUtils',
+    return ['$http', 'DataflowUtils', 'AppService', 'ParserService', 'MetamodelUtils',
         function ($http, utils, appService, ParserService, metamodelUtils) {
 
             // Pre ES6 browsers don't have 'startsWith' function, hence add it if necessary

--- a/ui/app/scripts/stream/views/create-stream.html
+++ b/ui/app/scripts/stream/views/create-stream.html
@@ -25,7 +25,7 @@
 			</div>
 		</div>
 		<div class="flow-definition-container">
-			<textarea dsl-editor id="flow-definition" class="flow-definition" content-assist-service-name="StreamContentAssistService"></textarea>
+			<textarea dsl-editor id="flow-definition" class="flow-definition" content-assist-service-name="StreamContentAssistService" placeholder="Enter stream definition here..." overview-ruler="true"></textarea>
 		</div>
 	</flo-editor>
 </div>

--- a/ui/app/scripts/stream/views/properties-dialog.html
+++ b/ui/app/scripts/stream/views/properties-dialog.html
@@ -36,9 +36,10 @@
                         </div>
                     </div>
                     <div class="col-sm-9" ng-if="getInputType(derivedProperties[key]) === 'code'">
-                        <div class="property-code-editor">
+                        <div class="dsl-editor property-code-editor">
                             <textarea code-editor name="{{derivedProperties[key].id}}" class="form-control"
                                       placeholder="{{derivedProperties[key].defaultValue}}"
+                                      overview-ruler="true"
                                       code-language="derivedProperties[getLanguageProperty(derivedProperties[key])].value"
                                       code-text="derivedProperties[key].value"
                                       default-text="{{derivedProperties[key].defaultValue}}"
@@ -79,9 +80,10 @@
                         </div>
                     </div>
                     <div class="col-sm-9" ng-if="getInputType(properties[key]) === 'code'">
-                        <div class="property-code-editor">
+                        <div class="dsl-editor property-code-editor">
                             <textarea code-editor name="{{properties[key].id}}" class="form-control"
                                       placeholder="{{properties[key].defaultValue}}"
+                                      overview-ruler="true"
                                       code-language="properties[getLanguageProperty(properties[key])].value"
                                       code-text="properties[key].value"
                                       default-text="{{properties[key].defaultValue}}"

--- a/ui/app/scripts/task/app.js
+++ b/ui/app/scripts/task/app.js
@@ -34,11 +34,13 @@ define([
   '../directives',
   '../filters',
   '../shared/services',
+  '../app/services',
   'model/pageable',
   '../shared/interceptors'
 ], function (angular) {
   'use strict';
   return angular.module('dataflowTasks', [
+    'dataflowApps.services',
     'dataflowTasks.services',
     'dataflowTasks.controllers',
     'dataflowShared.services',

--- a/ui/app/scripts/task/controllers.js
+++ b/ui/app/scripts/task/controllers.js
@@ -19,6 +19,7 @@
  *
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Alex Boyko
  */
 define(['angular'], function (angular) {
   'use strict';
@@ -29,6 +30,12 @@ define(['angular'], function (angular) {
             require(['task/controllers/definitions'], function (taskDefinitionsController) {
               $injector.invoke(taskDefinitionsController, this, {'$scope': $scope});
             });
+          }])
+      .controller('BulkDefineTasksController',
+          ['$scope', '$injector', function ($scope, $injector) {
+              require(['task/controllers/bulk-define-tasks'], function (bulkDefineTasksController) {
+                  $injector.invoke(bulkDefineTasksController, this, {'$scope': $scope});
+              });
           }])
       .controller('TaskExecutionsController',
           ['$scope', '$injector', function ($scope, $injector) {

--- a/ui/app/scripts/task/controllers/bulk-define-tasks.js
+++ b/ui/app/scripts/task/controllers/bulk-define-tasks.js
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Definition bulk import apps controller.
+ *
+ * @author Alex Boyko
+ * @author Andy Clement
+ */
+define(function (require) {
+    'use strict';
+
+    var PROGRESS_BAR_WAIT_TIME = 500;
+
+    var angular = require('angular');
+
+    return ['$scope', 'DataflowUtils', '$modal', '$state', 'TaskAppService', 'TaskDslValidatorService',
+        function ($scope, utils, $modal, $state, taskAppService, validatorService) {
+
+            var editor;
+
+            var updateRulerErrors;
+
+            var updateRulerWarnings;
+
+            var activeValidator;
+
+            function findNextMarker(markers, cursor) {
+                if (angular.isArray(markers)) {
+                    for (var i = 0; i < markers.length; i++) {
+                        if (markers[i].from.line === cursor.line && markers[i].from.ch > cursor.ch) {
+                            return markers[i];
+                        } else if (markers[i].from.line > cursor.line) {
+                            return markers[i];
+                        }
+                    }
+                    return markers[0];
+                }
+            }
+
+            function navigateToNextMarker(editor, markers) {
+                var nextMarker = findNextMarker(markers, editor.getCursor());
+                if (nextMarker) {
+                    // Select the chunk of DSL that caused an error
+                    editor.setSelection(nextMarker.from, nextMarker.to, {scroll: false});
+                    // Scroll to marker and allow scroller viewport height / 2 space around vertically
+                    editor.scrollIntoView(nextMarker, $(editor.getScrollerElement()).height() / 2);
+                }
+            }
+
+            /**
+             * Bulk Define Tasks.
+             */
+            $scope.bulkDefineTasks = function() {
+                if (!$scope.definitions || !$scope.definitions.length) {
+                    utils.$log.error('No tasks defined by the DSL');
+                    return;
+                }
+                var failedDefs = [];
+                var requests = [];
+                $scope.definitions.forEach(function(def) {
+                    var request = taskAppService.createDefinition(
+                        def.name,
+                        def.definition
+                    ).$promise;
+                    request.catch(function() {
+                        failedDefs.push(def);
+                    });
+                    requests.push(request);
+                });
+                
+                utils.$q.all(requests).then(function() {
+                    utils.growl.success('Task Definitions created successfully');
+                }, function() {
+                    utils.growl.error('Failed creating some Task Definitions');
+                });
+
+                // Pop up progress dialog
+                $modal.open({
+                    animation: true,
+                    templateUrl: 'scripts/task/dialogs/bulk-define-progress.html',
+                    controller: ['$scope', 'DataflowUtils', '$modalInstance', 'requests',
+                        function ($scope, utils, $modalInstance, requests) {
+
+                            var total = requests.length;
+                            var completed = 0;
+                            var errors = 0;
+
+                            $scope.close = function() {
+                                $modalInstance.close();
+                            };
+
+                            $scope.cancel = function() {
+                                $modalInstance.dismiss('cancel');
+                            };
+
+                            $scope.getProgressPercent = function() {
+                                return Math.round(100 * completed / total);
+                            };
+
+                            var deferred = utils.$q.defer();
+
+                            function tryResolve() {
+                                if (completed + errors === requests.length) {
+                                    if (errors) {
+                                        deferred.reject();
+                                    } else {
+                                        deferred.resolve();
+                                    }
+                                }
+                            }
+
+                            requests.forEach(function(promise) {
+                                promise.then(function() {
+                                    completed++;
+                                    tryResolve();
+                                }, function() {
+                                    errors++;
+                                    tryResolve();
+                                });
+                            });
+
+                            deferred.promise.then(function() {
+                                utils.$timeout($scope.close, PROGRESS_BAR_WAIT_TIME);
+                            }, function() {
+                                utils.$timeout($scope.cancel, PROGRESS_BAR_WAIT_TIME);
+                            });
+
+                        }],
+                    resolve: {
+                        requests: function () {
+                            return requests;
+                        }
+                    }
+                }).result.then(function() {
+                    // Dialog closed in the case of success
+                    $state.go('home.tasks.tabs.definitions');
+                }, function() {
+                    utils.growl.info('Failed to be created task(s) definition(s) are shown in the editor!');
+                    // Show only failed defs DSL
+                    if (failedDefs.length !== $scope.definitions.length) {
+                        var text = '';
+                        failedDefs.sort(function(d1, d2) {
+                           return d1.line - d2.line;
+                        }).forEach(function(def) {
+                            text += editor.getLine(def.line) + '\n';
+                        });
+                        $scope.dsl = text;
+                    }
+                });
+
+            };
+
+            /**
+             * Takes one to Tasks Definitions page
+             */
+            $scope.cancel = function() {
+                // Pop up confirmation dialog
+                if ($scope.dsl) {
+                    $modal.open({
+                        animation: true,
+                        templateUrl: 'scripts/task/dialogs/bulk-define-cancel.html',
+                        controller: ['$scope', '$modalInstance',
+                            function ($scope, $modalInstance) {
+
+                                $scope.proceed = function() {
+                                    $modalInstance.close();
+                                };
+
+                                $scope.cancel = function() {
+                                    $modalInstance.dismiss('cancel');
+                                };
+
+                            }]
+                    }).result.then(function() {
+                        // Navigate away on successfully closed dialog
+                        $state.go('home.tasks.tabs.definitions');
+                    });
+                } else {
+                    // Simply navigate away if DSL editor is empty
+                    $state.go('home.tasks.tabs.definitions');
+                }
+            };
+
+            $scope.displayFileContents = function(contents) {
+                $scope.dsl = contents;
+            };
+
+            $scope.hint = {
+                async: 'true',
+                hint: function(cm, callback) { // jshint ignore:line
+                    // TODO: calculate completion proposals and return results as shown below
+
+                    // See https://codemirror.net/doc/manual.html#addons hint/show-hint.js section
+
+                    // return callback({
+                    //   list: listOfStrings
+                    //   from: {line: startLine, ch:startCharIndex},
+                    //   to: {line: endLine, ch:endCharIndex}
+                    // });
+
+                    utils.$log.info('Task DSL Content Assist Invoked!');
+                }
+            };
+
+            $scope.lint = {
+                async: true,
+                getAnnotations: function (dslText, callback, options, doc) { // jshint ignore:line
+                    // markers.push({from: range.start, to: range.end, message: 'Some error message!', severity: 'error'});
+                    // callback(doc, markers);
+
+                    if (!editor) {
+                        editor = doc;
+                        editor.on('change', function() {
+                            $scope.definitions = undefined;
+                        });
+                        updateRulerWarnings = editor.annotateScrollbar('CodeMirror-vertical-ruler-warning');
+                        updateRulerErrors =  editor.annotateScrollbar('CodeMirror-vertical-ruler-error');
+                    }
+
+                    $scope.definitions = undefined;
+
+                    if (activeValidator) {
+                        activeValidator.cancel();
+                    }
+                    activeValidator = validatorService.createValidator(dslText);
+                    activeValidator.validate().then(function(validationResults) {
+                        // Update CodeMirror gutter error/warning markers
+                        callback(doc, validationResults.errors.concat(validationResults.warnings));
+                        // Update overview ruler error/warning markers
+                        updateRulerWarnings.update(validationResults.warnings);
+                        updateRulerErrors.update(validationResults.errors);
+
+                        validationResults.errors.sort(function (a, b) {
+                            return a.from.line - b.from.line;
+                        });
+                        validationResults.warnings.sort(function (a, b) {
+                            return a.from.line - b.from.line;
+                        });
+                        $scope.errors = validationResults.errors;
+                        $scope.warnings = validationResults.warnings;
+                        $scope.definitions = validationResults.definitions;
+                    });
+                }
+            };
+
+            $scope.nextError = function() {
+                navigateToNextMarker(editor, $scope.errors);
+            };
+
+            $scope.nextWarning = function() {
+                navigateToNextMarker(editor, $scope.warnings);
+            };
+
+            $scope.$watch('errors', function(errors) {
+                $scope.bulkDefineTasksForm.$setValidity('validDsl', !errors || errors.length === 0);
+            });
+
+            $scope.$watch('definitions', function(definitions) {
+                $scope.bulkDefineTasksForm.$setValidity('taskDefsPresent', angular.isArray(definitions) && definitions.length > 0);
+                $scope.bulkDefineTasksForm.$setValidity('processedDsl', angular.isArray(definitions));
+            });
+
+            $scope.numberOfTasks = 0;
+            $scope.errors = [];
+            $scope.warnings = [];
+            $scope.definitions = [];
+
+            $scope.$apply();
+
+        }];
+});

--- a/ui/app/scripts/task/controllers/definitions.js
+++ b/ui/app/scripts/task/controllers/definitions.js
@@ -78,6 +78,9 @@ define(['model/pageable'], function (Pageable) {
         utils.$log.info('Launching Task: ' + item.name);
         $state.go('home.tasks.deploymentsLaunch', {taskName: item.name});
       };
+      $scope.bulkDefineTasks = function() {
+        $state.go('home.tasks.bulkDefineTasks');
+      };
 
       loadTaskDefinitions($scope.pageable);
     }];

--- a/ui/app/scripts/task/dialogs/bulk-define-cancel.html
+++ b/ui/app/scripts/task/dialogs/bulk-define-cancel.html
@@ -1,0 +1,11 @@
+<div class="modal-header">
+    <h4 class="modal-title">Confirm Cancellation</h4>
+</div>
+<div class="modal-body">
+    <p>Cancellation will result in losing current editor content.</p>
+    <p>Do you want to continue anyway?</p>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-default" ng-click="cancel()">No</button>
+    <button type="button" class="btn btn-primary" ng-click="proceed()">Yes</button>
+</div>

--- a/ui/app/scripts/task/dialogs/bulk-define-progress.html
+++ b/ui/app/scripts/task/dialogs/bulk-define-progress.html
@@ -1,0 +1,12 @@
+<div class="modal-header">
+    <button type="button" class="close" ng-click="close()">&times;</button>
+    <h4 class="modal-title">Creating Tasks Definitions</h4>
+</div>
+<div class="modal-body">
+    <hr/>
+    <div>Creating Tasks Definitions...</div>
+    <progressbar animate="true" value="getProgressPercent()" type="success"><b>{{getProgressPercent()}}%</b></progressbar>
+</div>
+<div class="modal-footer">
+    <button class="btn btn-primary" ng-click="close()">OK</button>
+</div>

--- a/ui/app/scripts/task/services.js
+++ b/ui/app/scripts/task/services.js
@@ -19,9 +19,12 @@
  *
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Alex Boyko
  */
-define(['angular'], function (angular) {
+define(function(require) {
   'use strict';
+
+  var angular = require('angular');
 
   return angular.module('dataflowTasks.services', [])
       .factory('TaskDefinitions', function ($resource, $rootScope, $log, $http) {
@@ -197,5 +200,6 @@ define(['angular'], function (angular) {
             );
           }
         };
-      });
+      })
+      .factory('TaskDslValidatorService', require('task/services/task-dsl-validator'));
 });

--- a/ui/app/scripts/task/services/task-dsl-validator.js
+++ b/ui/app/scripts/task/services/task-dsl-validator.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Service providing validation for task definitions.
+ *
+ * @author Andy Clement
+ * @author Alex Boyko
+ */
+define(function() {
+    'use strict';
+
+    return ['DataflowUtils', 'ParserService', 'AppService', function (utils, parserService, appService) {
+
+        var DEBUG = false;
+
+        function createValidator(dslText) {
+            var cancelled = false;
+            var appInfos = {}; // Cached results for one run of the validator
+
+            function cancel() {
+                cancelled = true;
+            }
+
+            /**
+             * Retrieve application description (what options does it support, etc). This
+             * function uses a cache with a lifetime of this validation run to avoid
+             * asking for the definition of the same app over and over.
+             */
+            function getAppInfo(name) {
+                if (DEBUG) { utils.$log.info('>getAppInfo '+name); }
+                var deferred = utils.$q.defer();
+                if (appInfos.hasOwnProperty(name)) {
+                    deferred.resolve(appInfos[name]);
+                } else {
+                    // On a successful call, result.data will be a JSON Object
+                    // with name/type/uri/shortDescription/options
+                    appService.getAppInfo('task', name).then(function (result) {
+                        // sleep(2000).then(()=>{
+                        appInfos[name] = result.data;
+                        deferred.resolve(result.data);
+                        if (DEBUG) { utils.$log.info('>getAppInfo fetched data for app '+name+' = '+JSON.stringify(result.data)); }
+                        // });
+                    }, function (error) {
+                        utils.$log.error(error);
+                        deferred.reject(error);
+                    });
+                }
+                return deferred.promise;
+            }
+
+            /**
+             * Check if the parsed definition supports the specified options. If not then
+             * append error messages to the messageAccumulator. Returns a promise that will be resolved
+             * when the checking is complete.
+             */
+            function verifyApp(parsedInfo, messagesAccumulator, definitionsAccumulator) {
+                if (DEBUG) { utils.$log.info('>verifyApp '+JSON.stringify(parsedInfo)); }
+                var appName = parsedInfo.name;
+                var deferred = utils.$q.defer();
+                getAppInfo(appName).then(function (result) {
+                    if (!result || result === '') {
+                        // unknown app
+                        messagesAccumulator.push({
+                            message: '\'' + appName + '\' is not a known task application',
+                            severity: 'error',
+                            from: parsedInfo.range.start,
+                            to: parsedInfo.range.end,
+                        });
+                    } else {
+                        var hasErrors = false;
+                        var validOptions = result.options;
+                        Object.keys(parsedInfo.options).forEach(function (k) {
+                            var valid = false;
+                            for (var o = 0; o < validOptions.length; o++) {
+                                if (k === validOptions[o].name || k === validOptions[o].id) {
+                                    valid = true;
+                                    break;
+                                }
+                            }
+                            if (!valid) {
+                                hasErrors = true;
+                                messagesAccumulator.push({
+                                    from: parsedInfo.optionsranges[k].start,
+                                    to: parsedInfo.optionsranges[k].end,
+                                    message: 'Application \'' + appName + '\' does not support the option \'' + k + '\'',
+                                    severity: 'error'
+                                });
+                            }
+                        });
+                        // TODO create errors for options you *must* specify but haven't
+                        if (!hasErrors && parsedInfo.group) {
+                            // Build a nicely structured command definition
+                            var def = appName;
+                            if (parsedInfo.options) {
+                                Object.keys(parsedInfo.options).forEach(function (name) {
+                                    def += ' --' + name + '=' + parsedInfo.options[name];
+                                });
+                            }
+                            definitionsAccumulator.push({
+                                name: parsedInfo.group,
+                                definition: def,
+                                line: parsedInfo.range.start.line
+                            });
+                        }
+                    }
+                    deferred.resolve(parsedInfo);
+                }, function (error) {
+                    messagesAccumulator.push({
+                        message: '\'' + appName + '\' is not a known task application',
+                        severity: 'error',
+                        from: parsedInfo.range.start,
+                        to: parsedInfo.range.end,
+                    });
+                    utils.$log.error(error);
+                    deferred.resolve(parsedInfo);
+                });
+                return deferred.promise;
+            }
+
+            /**
+             * Validate the data in the text box. First attempt to parse it and if successful
+             * then verify each line refers to a valid application and provides valid options.
+             */
+            function validate() {
+                var deferred = utils.$q.defer();
+                var results = parserService.parse(dslText,'task');
+                var messages = [];
+                var definitions = [];
+                var knownTaskDefinitionNames = [];
+                var verificationPromiseChain = utils.$q.when(function() { });
+                var createVerifyAppInvoker = function (toValidate, messages, definitions) {
+                    return function() {
+                        return verifyApp(toValidate, messages, definitions);
+                    };
+                };
+                if (results.lines) {
+                    for (var i = 0; i<results.lines.length; i++) {
+                        if (cancelled) {
+                            return;
+                        }
+                        var line = results.lines[i];
+                        if (line.errors) {
+                            for (var e = 0; e < line.errors.length; e++) {
+                                var error = line.errors[e];
+                                messages.push({message: error.message, severity: 'error', from: error.range.start, to: error.range.end});
+                            }
+                        }
+                        if (line.success && line.success.length !== 0) {
+                            // Check if already seen an app called this
+                            if (line.success[0].group) {
+                                var taskDefinitionName = line.success[0].group;
+                                var alreadyExists = false;
+                                for (var d = 0; d < knownTaskDefinitionNames.length; d++) {
+                                    if (knownTaskDefinitionNames[d] === taskDefinitionName) {
+                                        alreadyExists = true;
+                                        messages.push({message: 'Duplicate task definition name \''+taskDefinitionName+'\'', severity: 'error', from: line.success[0].grouprange.start, to: line.success[0].grouprange.end});
+                                    }
+                                }
+                                if (!alreadyExists) {
+                                    knownTaskDefinitionNames.push(taskDefinitionName);
+                                }
+                            }
+                            verificationPromiseChain = 
+                                verificationPromiseChain.then(
+                                    createVerifyAppInvoker(line.success[0],messages,definitions));
+                        }
+                    }
+                }
+
+                verificationPromiseChain.then(function () {
+                    if (!cancelled) {
+                        messages.sort(function(a,b) {
+                            return a.from.line - b.from.line;
+                        });
+                        deferred.resolve({
+                            errors: messages,
+                            warnings: [],
+                            definitions: definitions
+                        });
+                    } else {
+                        deferred.reject();
+                    }
+                });
+
+                return deferred.promise;
+            }
+
+            return {
+                cancel: cancel,
+                validate: validate
+            };   
+        }
+
+        return {
+            'createValidator': createValidator
+        };
+
+    }];
+
+});

--- a/ui/app/scripts/task/views/bulk-define-tasks.html
+++ b/ui/app/scripts/task/views/bulk-define-tasks.html
@@ -1,0 +1,53 @@
+<h1>Bulk Define Tasks</h1>
+<p>
+    Define tasks in bulk. Type in tasks definitions in the text box or simply browse to a local task definitions
+    file
+</p>
+<hr/>
+<form class="form-horizontal col-md-12" style="padding: 0px;" name="bulkDefineTasksForm" role="form" ng-submit="bulkDefineTasks()" novalidate>
+    <div class="row help-block">
+        <div class="text-left pull-left">
+            <span ng-hide="bulkDefineTasksForm.$error.processedDsl">{{definitions.length === 0 ? 'No valid task definitions detected' : definitions.length + ' valid task definition'+(definitions.length>1?'s':'')+' detected'}}</span>
+            <span ng-show="bulkDefineTasksForm.$error.processedDsl">
+                <span class="glyphicon glyphicon-refresh icon-rotate-animation"></span>
+                <i>Validating task definitions</i>
+            </span>
+        </div>
+        <div class="text-right pull-right" ng-hide="bulkDefineTasksForm.$error.processedDsl">
+            <span ng-show="errors && errors.length">
+                <span class="CodeMirror-lint-marker-error"></span>
+                <a href="" ng-click="nextError()">{{errors.length}} {{errors.length === 1 ? 'Error':'Errors'}}</a>
+            </span>
+            <span ng-show="warnings && warnings.length">
+                <span class="CodeMirror-lint-marker-warning"></span>
+                <a href="" ng-click="nextWarning()">{{warnings.length}} Warning(s)</a>
+            </span>
+        </div>
+    </div>
+    <fieldset id="bulkDefine">
+        <div class="form-group dsl-editor dsl-editor-page">
+            <textarea id="taskDefinitions" autofocus ng-trim="false"
+                class="form-control" generic-dsl-editor dsl="dsl" debounce="300" line-wrapping="false"
+                line-numbers="true" hint="hint" lint="lint" scrollbar-style="simple"
+                placeholder="Please enter one or more definitions in the format: mytask=taskapp --option1=value1 --option2=value2"></textarea>
+        </div>
+    </fieldset>
+    <div class="col-md-12 text-right">
+        <label type="button" class="btn btn-default" tooltip-placement="top"
+               tooltip="Select a file from local file system to import its contents into the DSL editor">
+            <span class="glyphicon glyphicon-file"></span>
+            <input type="file" on-read-file="displayFileContents(contents)" style="display:none;"/>
+            Import File
+        </label>
+    </div>
+    <div class="col-md-12 text-center" style="padding: 9px 12px;">
+        <span style="padding-right: 15px;">
+            <button id="back-button" type="button" class="btn btn-default" ng-click="cancel()">Cancel</button>
+        </span>
+        <span style="padding-left: 15px;">
+            <button id="submit-button" type="submit" class="btn btn-default" ng-disabled="bulkDefineTasksForm.$invalid">
+                <span class="glyphicon glyphicon-import" aria-hidden="true"></span> Create
+            </button>
+        </span>
+    </div>
+</form>

--- a/ui/app/scripts/task/views/definitions.html
+++ b/ui/app/scripts/task/views/definitions.html
@@ -1,9 +1,20 @@
 <div class="row">
   <div class="col-md-12">
     <div class="col-md-12 table-filter">
-      <div class="col-md-4 col-md-offset-8">
-        <input type="text" class="form-control" ng-model="filterQuery" id="filterTable"
-               placeholder="Quick filter">
+      <div>
+        <table class="col-lg-12 tab-content-header"><tr>
+          <td class="col-xs-8">
+            <button id="bulkDefineTasksButton" type="button" ng-click="bulkDefineTasks()"
+                    class="btn btn-default"
+            ><span class="glyphicon glyphicon-import"></span>
+              Bulk Define
+            </button>
+          </td>
+          <td>
+            <input type="text" class="form-control" ng-model="filterQuery" id="filterTable"
+                   placeholder="Quick filter">
+          </td>
+        </tr></table>
       </div>
     </div>
   </div>

--- a/ui/app/scripts/task/views/definitions.html
+++ b/ui/app/scripts/task/views/definitions.html
@@ -7,7 +7,7 @@
             <button id="bulkDefineTasksButton" type="button" ng-click="bulkDefineTasks()"
                     class="btn btn-default"
             ><span class="glyphicon glyphicon-import"></span>
-              Bulk Define
+              Bulk Define Tasks
             </button>
           </td>
           <td>

--- a/ui/app/styles/flo.less
+++ b/ui/app/styles/flo.less
@@ -219,9 +219,12 @@ input.btn.ng-invalid {
   font-family: inherit;
 }
 
-.property-code-editor {
+.dsl-editor {
   border: 1px solid;
   border-color: lightgrey;
+}
+
+.property-code-editor {
   height: 180px;
 }
 
@@ -311,3 +314,10 @@ input.btn.ng-invalid {
   border-color: @spring-grey;
 }
 
+.CodeMirror pre.CodeMirror-placeholder {
+  color: @spring-grey;
+}
+
+.dsl-editor-page {
+  height: 400px;
+}

--- a/ui/app/styles/main.less
+++ b/ui/app/styles/main.less
@@ -387,6 +387,19 @@ hr {
   border-top-width: 0px;
 }
 
+.icon-rotate-animation {
+  animation-name: rotateIcon;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+@keyframes rotateIcon {
+  from { transform: scale( 1 ) rotate( 0deg );   }
+  to   { transform: scale( 1 ) rotate( 360deg ); }
+}
+
+
 @import (less) "../lib/spring-flo/spring-flo.css";
 
 @import "analytics.less";

--- a/ui/bower.json
+++ b/ui/bower.json
@@ -22,7 +22,7 @@
     "moment": "2.8.4",
     "angular-utils-pagination": "0.11.0",
     "d3": "3.5.5",
-    "spring-flo": "0.5.1"
+    "spring-flo": "git://github.com/spring-projects/spring-flo#master"
   },
   "devDependencies": {
     "angular-mocks": "1.3.5",

--- a/ui/test/spec/services/metamodelSpec.js
+++ b/ui/test/spec/services/metamodelSpec.js
@@ -29,14 +29,14 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
 	//beforeEach(function() {angular.mock.module('dataflowJobs');});
 	//beforeEach(function() {angular.mock.module('dataflowStreams');});
 
-    it('should contain a StreamParserService service', inject(function(StreamParserService, StreamMetamodelService) {
-    	expect(StreamParserService).toBeDefined();
+    it('should contain a ParserService service', inject(function(ParserService, StreamMetamodelService) {
+    	expect(ParserService).toBeDefined();
     	expect(StreamMetamodelService).toBeDefined();
     }));
 
-    it('basic text to graph', inject(function(StreamParserService, StreamMetamodelService) {
+    it('basic text to graph', inject(function(ParserService, StreamMetamodelService) {
     	var text = 'time | log';
-    	var parseResponse = StreamParserService.parse(text);
+    	var parseResponse = ParserService.parse(text);
     	expect(parseResponse.lines).toBeDefined();
     	var line = parseResponse.lines[0];
     	expect(line.errors).toBeNull();
@@ -62,9 +62,9 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
     	expect(logNode.id).toEqual(1);
     }));
 
-    it('destination output', inject(function(StreamParserService, StreamMetamodelService) {
+    it('destination output', inject(function(ParserService, StreamMetamodelService) {
     	var text = 'time > :foo';
-    	var parseResponse = StreamParserService.parse(text);
+    	var parseResponse = ParserService.parse(text);
     	expect(parseResponse.lines).toBeDefined();
     	var line = parseResponse.lines[0];
     	expect(line.errors).toBeNull();
@@ -96,9 +96,9 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
     	expect(link.to).toEqual(1);
     }));
 
-    it('tap text to graph', inject(function(StreamParserService, StreamMetamodelService) {
+    it('tap text to graph', inject(function(ParserService, StreamMetamodelService) {
     	var text = 'FOO = time | log1\n:FOO.time > log2';
-    	var parseResponse = StreamParserService.parse(text);
+    	var parseResponse = ParserService.parse(text);
     	expect(parseResponse.lines).toBeDefined();
     	var line = parseResponse.lines[0];
     	expect(line.errors).toBeNull();
@@ -130,9 +130,9 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
     	// Verify tap stream
     }));
 
-//    it('text to graph and back again - basic', inject(function(StreamParserService, StreamMetamodelService) {
+//    it('text to graph and back again - basic', inject(function(ParserService, StreamMetamodelService) {
 //       	var text = 'time | log';
-//    	var parseResponse = StreamParserService.parse(text);
+//    	var parseResponse = ParserService.parse(text);
 //    	var graph = StreamMetamodelService.convertParseResponseToGraph(text,parseResponse);
 //    	console.log('>>>>'+graph);
 //    	var newtext = StreamMetamodelService.convertGraphToText(graph);
@@ -140,9 +140,9 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
 ////    	expect(newtext).equals(text);
 //    }));
 
-//    it('text to graph and back again - tap', inject(function(StreamParserService, StreamMetamodelService) {
+//    it('text to graph and back again - tap', inject(function(ParserService, StreamMetamodelService) {
 //    	var text = "FOO = time | log1\n:FOO.time > log2";
-//    	var parseResponse = StreamParserService.parse(text);
+//    	var parseResponse = ParserService.parse(text);
 //    	expect(parseResponse.lines).toBeDefined();
 //    	var line = parseResponse.lines[0];
 //    	expect(line.errors).toBeNull();

--- a/ui/test/spec/services/parserSpec.js
+++ b/ui/test/spec/services/parserSpec.js
@@ -27,12 +27,12 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
           angular.mock.module('dataflowMain');
         });
 
-    it('should contain a StreamParserService service', inject(function(StreamParserService) {
-    	expect(StreamParserService).toBeDefined();
+    it('should contain a ParserService service', inject(function(ParserService) {
+    	expect(ParserService).toBeDefined();
     }));
 
-    it('basic stream', inject(function(StreamParserService) {
-    	var output = StreamParserService.parse('time | log');
+    it('basic stream', inject(function(ParserService) {
+    	var output = ParserService.parse('time | log');
     	// {"lines":[
     	//   {"errors":null,
     	//    "success":[
@@ -55,8 +55,8 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
         expect(logNode.range.end.ch).toEqual(10);
     }));
 
-    it('sink destination parsing', inject(function(StreamParserService) {
-    	var output = StreamParserService.parse('time > :destination');
+    it('sink destination parsing', inject(function(ParserService) {
+    	var output = ParserService.parse('time > :destination');
     	// {"lines":[
     	//  {"errors":null,
     	//   "success":[
@@ -75,9 +75,9 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
         expect(timeNode.sinkChannelName).toEqual('destination');
     }));
 
-    it('source destination parsing', inject(function(StreamParserService) {
+    it('source destination parsing', inject(function(ParserService) {
     	// {"lines":[{"errors":null,"success":[{"group":"UNKNOWN_0","type":"processor","name":"log","range":{"start":{"ch":15,"line":0},"end":{"ch":18,"line":0}},"options":{},"optionsranges":{},"sourceChannelName":"destination","sinkChannelName":null}]}]}
-    	var output = StreamParserService.parse(':destination > log');
+    	var output = ParserService.parse(':destination > log');
 		// console.log('parse response'+JSON.stringify(output));
     	expect(output.lines).toBeDefined();
     	expect(output.lines.length).toEqual(1);
@@ -92,8 +92,8 @@ define(['angular', 'angularMocks', 'app'], function(angular) {
         expect(logNode.sourceChannelName).toEqual('destination');
     }));
 
-    it('tap destination parsing', inject(function(StreamParserService) {
-    	var output = StreamParserService.parse(':someStream.foo > log');
+    it('tap destination parsing', inject(function(ParserService) {
+    	var output = ParserService.parse(':someStream.foo > log');
     	// console.log('parse response'+JSON.stringify(output));
     	expect(output.lines).toBeDefined();
     	expect(output.lines.length).toEqual(1);

--- a/ui/test/spec/services/shared-services-spec.js
+++ b/ui/test/spec/services/shared-services-spec.js
@@ -34,19 +34,19 @@ define([
       expect(DataflowUtils.getAppNameFromJobDefinition).toBeDefined();
       expect(DataflowUtils.getAppNameFromJobDefinition('myMod2')).toEqual('myMod2');
     }));
-    it('Getting a app name from an undefined definition should casuse an error.', inject(function(DataflowUtils) {
+    it('Getting a app name from an undefined definition should cause an error.', inject(function(DataflowUtils) {
       expect(DataflowUtils.getAppNameFromJobDefinition).toBeDefined();
       expect(function() {
         DataflowUtils.getAppNameFromJobDefinition();
       }).toThrow(new Error('jobDefinition must be defined.'));
     }));
-    it('Getting a app name from an undefined definition should casuse an error 2.', inject(function(DataflowUtils) {
+    it('Getting a app name from an undefined definition should cause an error 2.', inject(function(DataflowUtils) {
       expect(DataflowUtils.getAppNameFromJobDefinition).toBeDefined();
       expect(function() {
         DataflowUtils.getAppNameFromJobDefinition(undefined);
       }).toThrow(new Error('jobDefinition must be defined.'));
     }));
-    it('Getting a app name from a null definition should casuse an error.', inject(function(DataflowUtils) {
+    it('Getting a app name from a null definition should cause an error.', inject(function(DataflowUtils) {
       expect(DataflowUtils.getAppNameFromJobDefinition).toBeDefined();
       expect(function() {
         DataflowUtils.getAppNameFromJobDefinition(null);

--- a/ui/test/spec/services/taskDefinitionParsingSpec.js
+++ b/ui/test/spec/services/taskDefinitionParsingSpec.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author Andy Clement
+ */
+define(['angular', 'angularMocks', 'app'], function(angular) {
+  'use strict';
+
+    describe('Unit: Testing JS Parsing of task definitions', function() {
+	  
+    beforeEach(function() {
+      angular.mock.module('dataflowMain');
+    });
+
+    it('should contain a ParserService service', inject(function(ParserService) {
+    	expect(ParserService).toBeDefined();
+    }));
+
+    it('basic task', inject(function(ParserService) {
+    	  var output = ParserService.parse('foo=bar','task');
+    	  expect(output.lines).toBeDefined();
+    	  expect(output.lines.length).toEqual(1);
+    	  var line = output.lines[0];
+    	  expect(line.errors).toBeNull();
+       	expect(line.success).toBeDefined();
+        expect(line.success.length).toEqual(1);
+
+        var nameNode = line.success[0].group;
+        var nameRange = line.success[0].grouprange;
+        expect(nameNode).toEqual('foo');
+        expect(nameRange.start.ch).toEqual(0);
+        expect(nameRange.end.ch).toEqual(3);
+
+        var barNode = line.success[0];
+        expect(barNode.name).toEqual('bar');
+        expect(barNode.range.start.ch).toEqual(4);
+        expect(barNode.range.end.ch).toEqual(7);
+    }));
+
+    it('basic task - extra whitespace', inject(function(ParserService) {
+    	  var output = ParserService.parse('   foo =     bar  --aa=ttttt','task');
+    	  expect(output.lines).toBeDefined();
+    	  expect(output.lines.length).toEqual(1);
+
+    	  var line = output.lines[0];
+    	  expect(line.errors).toBeNull();
+       	expect(line.success).toBeDefined();
+        expect(line.success.length).toEqual(1);
+
+        var nameNode = line.success[0].group;
+        var nameRange = line.success[0].grouprange;
+        expect(nameNode).toEqual('foo');
+        expect(nameRange.start.ch).toEqual(3);
+        expect(nameRange.end.ch).toEqual(6);
+
+        var barNode = line.success[0];
+        expect(barNode.name).toEqual('bar');
+        expect(barNode.range.start.ch).toEqual(13);
+        expect(barNode.range.end.ch).toEqual(16);
+
+        var barOptions = line.success[0].options;
+        var barOptionsranges = line.success[0].optionsranges;
+        expect(barOptions.aa).toEqual('ttttt');
+        expect(barOptionsranges.aa.start.ch).toEqual(18);
+        expect(barOptionsranges.aa.end.ch).toEqual(28);
+    }));
+
+    it('missing name', inject(function(ParserService) {
+        var output = ParserService.parse('timestamp','task');
+        expect(output.lines).toBeDefined();
+    	  expect(output.lines.length).toEqual(1);
+        var line = output.lines[0];
+   	    expect(line.errors).toBeDefined();
+        expect(line.errors.length).toEqual(1);
+        expect(line.errors[0].message).toEqual('Expected format: name = taskapplication [options]');
+    }));
+
+  });
+});
+

--- a/ui/test/spec/services/taskValidationServiceSpec.js
+++ b/ui/test/spec/services/taskValidationServiceSpec.js
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author Alex Boyko
+ * @author Andy Clement
+ */
+define(['angular', 'angularMocks', 'app'], function (angular) {
+    'use strict';
+
+    // Output from: curl localhost:9393/apps/task/timestamp - then just removed the escaped quotes.
+    var TASK_APPS = {
+        'test':'{"name":"test","options":[{"name":"testone"},{"name":"testtwo"}]}',
+        'timestamp': '{"name":"timestamp","type":"task","uri":"maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT","shortDescription":null,"options":[{"id":"timestamp.format","name":"format","type":"java.lang.String","description":"The timestamp format, yyyy-MM-dd HH:mm:ss.SSS by default.","shortDescription":"The timestamp format, yyyy-MM-dd HH:mm:ss.SSS by default.","defaultValue":"yyyy-MM-dd HH:mm:ss.SSS","valueHints":[],"valueProviders":[],"deprecation":null,"sourceType":"org.springframework.cloud.task.app.timestamp.TimestampTaskProperties","sourceMethod":null,"deprecated":false}]}'
+    };
+
+    describe('Unit: Testing JS validation of task definitions', function () {
+
+        // beforeEach(function () {
+        //     angular.mock.module('dataflowMain');
+        // });
+
+        beforeEach(module('dataflowMain'));
+
+        beforeEach(inject(function(AppService, $q){
+            spyOn(AppService, 'getAppInfo').and.callFake(function(type, name) {
+                var deferred = $q.defer();
+                if (angular.isDefined(TASK_APPS[name])) {
+                    deferred.resolve({
+                        data: JSON.parse(TASK_APPS[name])
+                    });
+                } else {
+                    deferred.reject();
+                }
+                return deferred.promise;
+            });
+        }));
+
+        it('should have a TaskDslValidatorService', inject(function (TaskDslValidatorService) {
+            expect(TaskDslValidatorService).toBeDefined();
+        }));
+
+        it('Basic valid of task definition', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=timestamp');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Basic invalid task definition', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=bar');
+                validator.validate().then(function(results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
+                    var error = results.errors[0];
+                    expect(error.message).toEqual('\'bar\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Valid app options', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo = timestamp  --format=hms');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('timestamp --format=hms');
+                    expect(def.line).toEqual(0);
+                    // expect(def.text).toEqual('foo = timestamp  --format=hms');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Invalid app options', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=timestamp --wibble=wobble');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
+
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(14);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(29);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('Application \'timestamp\' does not support the option \'wibble\'');
+                    expect(error.severity).toEqual('error');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Multiple options - all valid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=test --testone=abc --testtwo=def');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('test --testone=abc --testtwo=def');
+                    expect(def.line).toEqual(0);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Multiple options - one invalid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=test --testone=abc --testtwo=def --phoney=baloney');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
+
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(37);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(53);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('Application \'test\' does not support the option \'phoney\'');
+                    expect(error.severity).toEqual('error');
+
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Multi line - 2 invalid, 1 valid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('aaa=bbb\nfoo=timestamp --format=hh\nccc=ddd');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(2);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                   
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('timestamp --format=hh');
+                    expect(def.line).toEqual(1);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
+
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(4);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(7);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('\'bbb\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+                                      
+                    error = results.errors[1];
+                    expect(error.from.ch).toEqual(4);
+                    expect(error.from.line).toEqual(2);
+                    expect(error.to.ch).toEqual(7);
+                    expect(error.to.line).toEqual(2);
+                    expect(error.message).toEqual('\'ddd\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+
+        it('Multi line - 2 valid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('aaa=test\nfoo=timestamp --format=hh');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(2);
+                   
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('aaa');
+                    expect(def.definition).toEqual('test');
+                    expect(def.line).toEqual(0);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
+
+                    def = results.definitions[1];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('timestamp --format=hh');
+                    expect(def.line).toEqual(1);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
+
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Multi line - 2 valid but clashing names, 1 invalid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('aaa=bar\nb=test\nb=timestamp --format=hh');
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(2);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(2);
+                   
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('b');
+                    expect(def.definition).toEqual('test');
+                    expect(def.line).toEqual(1);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
+                       
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(4);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(7);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('\'bar\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+
+                    error = results.errors[1];
+                    expect(error.from.ch).toEqual(0);
+                    expect(error.from.line).toEqual(2);
+                    expect(error.to.ch).toEqual(1);
+                    expect(error.to.line).toEqual(2);
+                    expect(error.message).toEqual('Duplicate task definition name \'b\'');
+                    expect(error.severity).toEqual('error');
+
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+    });
+});
+


### PR DESCRIPTION
Just a quick description of the changes:
- There is a new bulk define tasks action on the tasks>definitions page which opens a new dialog for entering task definitions
- The parser service, previously only used for streams has been moved to the 'shared' area because it is now also used for task parsing too
- there is a new controller for the bulk define tasks page. The page is basically one big text box.
- when data is entered the new validation service is called to check the syntax of the text *and* whether the tasks named in the textbox actually exist on the server.
- The validation service feeds back errors to the dialog page (asynchronously) which indicates how many problems there are and by clicking the errors count or scrolling the textbox you can quickly find them (they are highlighted in the textbox).
- There are a bunch of tests for the new uses of the parser (for parsing tasks) and the validation service.