### PR TITLE
Syntax validation only for tasks without app name/properties verification

### DIFF
--- a/ui/app/scripts/task/app.js
+++ b/ui/app/scripts/task/app.js
@@ -29,6 +29,7 @@ define([
   'ngAnimate',
   'pagination',
   'angularHighlightjs',
+  'ngCookies',
   './controllers',
   './services',
   '../directives',
@@ -53,6 +54,7 @@ define([
     'angularUtils.directives.dirPagination',
     'cgBusy',
     'hljs',
-    'angular-growl'
+    'angular-growl',
+    'ngCookies'
   ]);
 });

--- a/ui/app/scripts/task/controllers/bulk-define-tasks.js
+++ b/ui/app/scripts/task/controllers/bulk-define-tasks.js
@@ -25,10 +25,12 @@ define(function (require) {
 
     var PROGRESS_BAR_WAIT_TIME = 500;
 
+    var VERIFY_APPS_OFF_COOKIE_KEY = 'taskDefs.bulkDefine.verifyAppsOff';
+
     var angular = require('angular');
 
-    return ['$scope', 'DataflowUtils', '$modal', '$state', 'TaskAppService', 'TaskDslValidatorService',
-        function ($scope, utils, $modal, $state, taskAppService, validatorService) {
+    return ['$scope', 'DataflowUtils', '$modal', '$state', 'TaskAppService', 'TaskDslValidatorService', '$cookieStore',
+        function ($scope, utils, $modal, $state, taskAppService, validatorService, $cookieStore) {
 
             var editor;
 
@@ -61,6 +63,49 @@ define(function (require) {
                 }
             }
 
+            function createLinterOption() {
+                return {
+                    async: true,
+                    getAnnotations: function (dslText, callback, options, doc) { // jshint ignore:line
+                        // markers.push({from: range.start, to: range.end, message: 'Some error message!', severity: 'error'});
+                        // callback(doc, markers);
+
+                        // Init editor
+                        if (!editor) {
+                            editor = doc;
+                            editor.on('change', function() {
+                                $scope.definitions = undefined;
+                                $scope.bulkDefineTasksForm.$setValidity('notEmpty', dslText && dslText.length);
+                            });
+                            updateRulerWarnings = editor.annotateScrollbar('CodeMirror-vertical-ruler-warning');
+                            updateRulerErrors =  editor.annotateScrollbar('CodeMirror-vertical-ruler-error');
+                        }
+
+                        // Switch validator
+                        if (activeValidator) {
+                            activeValidator.cancel();
+                        }
+                        activeValidator = validatorService.createValidator(dslText, {semantics: $scope.verifyApps});
+
+                        // Perform validation
+                        activeValidator.validate().then(function (validationResults) {
+                            // Update CodeMirror gutter error/warning markers
+                            callback(doc, validationResults.errors.concat(validationResults.warnings));
+
+                            validationResults.errors.sort(function (a, b) {
+                                return a.from.line - b.from.line;
+                            });
+                            validationResults.warnings.sort(function (a, b) {
+                                return a.from.line - b.from.line;
+                            });
+                            $scope.errors = validationResults.errors;
+                            $scope.warnings = validationResults.warnings;
+                            $scope.definitions = validationResults.definitions;
+                        });
+                    }
+                };
+            }
+
             /**
              * Bulk Define Tasks.
              */
@@ -81,7 +126,7 @@ define(function (require) {
                     });
                     requests.push(request);
                 });
-
+                
                 utils.$q.all(requests).then(function() {
                     utils.growl.success('Task Definitions created successfully');
                 }, function() {
@@ -152,13 +197,11 @@ define(function (require) {
                     utils.growl.info('Failed to be created task(s) definition(s) are shown in the editor!');
                     // Show only failed defs DSL
                     if (failedDefs.length !== $scope.definitions.length) {
-                        var text = '';
-                        failedDefs.sort(function(d1, d2) {
+                        $scope.dsl = failedDefs.sort(function(d1, d2) {
                            return d1.line - d2.line;
-                        }).forEach(function(def) {
-                            text += editor.getLine(def.line) + '\n';
-                        });
-                        $scope.dsl = text;
+                        }).map(function(def) {
+                            return editor.getLine(def.line);
+                        }).join('\n');
                     }
                 });
 
@@ -216,47 +259,6 @@ define(function (require) {
                 }
             };
 
-            $scope.lint = {
-                async: true,
-                getAnnotations: function (dslText, callback, options, doc) { // jshint ignore:line
-                    // markers.push({from: range.start, to: range.end, message: 'Some error message!', severity: 'error'});
-                    // callback(doc, markers);
-
-                    if (!editor) {
-                        editor = doc;
-                        editor.on('change', function() {
-                            $scope.definitions = undefined;
-                        });
-                        updateRulerWarnings = editor.annotateScrollbar('CodeMirror-vertical-ruler-warning');
-                        updateRulerErrors =  editor.annotateScrollbar('CodeMirror-vertical-ruler-error');
-                    }
-
-                    $scope.definitions = undefined;
-
-                    if (activeValidator) {
-                        activeValidator.cancel();
-                    }
-                    activeValidator = validatorService.createValidator(dslText);
-                    activeValidator.validate().then(function(validationResults) {
-                        // Update CodeMirror gutter error/warning markers
-                        callback(doc, validationResults.errors.concat(validationResults.warnings));
-                        // Update overview ruler error/warning markers
-                        updateRulerWarnings.update(validationResults.warnings);
-                        updateRulerErrors.update(validationResults.errors);
-
-                        validationResults.errors.sort(function (a, b) {
-                            return a.from.line - b.from.line;
-                        });
-                        validationResults.warnings.sort(function (a, b) {
-                            return a.from.line - b.from.line;
-                        });
-                        $scope.errors = validationResults.errors;
-                        $scope.warnings = validationResults.warnings;
-                        $scope.definitions = validationResults.definitions;
-                    });
-                }
-            };
-
             $scope.nextError = function() {
                 navigateToNextMarker(editor, $scope.errors);
             };
@@ -266,7 +268,18 @@ define(function (require) {
             };
 
             $scope.$watch('errors', function(errors) {
+                if (updateRulerErrors) {
+                    // Update overview ruler error/warning markers
+                    updateRulerErrors.update(errors);
+                }
                 $scope.bulkDefineTasksForm.$setValidity('validDsl', !errors || errors.length === 0);
+            });
+
+            $scope.$watch('warnings', function(warnings) {
+                if (updateRulerWarnings) {
+                    // Update overview ruler error/warning markers
+                    updateRulerWarnings.update(warnings);
+                }
             });
 
             $scope.$watch('definitions', function(definitions) {
@@ -274,6 +287,25 @@ define(function (require) {
                 $scope.bulkDefineTasksForm.$setValidity('processedDsl', angular.isArray(definitions));
             });
 
+            $scope.$watch('verifyApps', function() {
+                if (activeValidator) {
+                    activeValidator.cancel();
+                }
+                $scope.lint = createLinterOption();
+            });
+
+            $scope.$on('$destroy', function() {
+                if (activeValidator) {
+                    activeValidator.cancel();
+                }
+                if ($scope.verifyApps) {
+                    $cookieStore.remove(VERIFY_APPS_OFF_COOKIE_KEY);
+                } else {
+                    $cookieStore.put(VERIFY_APPS_OFF_COOKIE_KEY, true);
+                }
+            });
+
+            $scope.verifyApps = !$cookieStore.get(VERIFY_APPS_OFF_COOKIE_KEY);
             $scope.numberOfTasks = 0;
             $scope.errors = [];
             $scope.warnings = [];

--- a/ui/app/scripts/task/controllers/bulk-define-tasks.js
+++ b/ui/app/scripts/task/controllers/bulk-define-tasks.js
@@ -267,6 +267,15 @@ define(function (require) {
                 navigateToNextMarker(editor, $scope.warnings);
             };
 
+            $scope.getValidationStatus = function() {
+                var validStr = $scope.verifyApps ?  'valid' : 'syntactically correct';
+                if ($scope.definitions && $scope.definitions.length) {
+                    return $scope.definitions.length + ' ' + validStr + ' task definition' + ($scope.definitions.length > 1 ? 's' : '') + ' detected';
+                } else {
+                    return 'No ' + validStr + ' task definitions detected';
+                }
+            };
+
             $scope.$watch('errors', function(errors) {
                 if (updateRulerErrors) {
                     // Update overview ruler error/warning markers
@@ -291,6 +300,10 @@ define(function (require) {
                 if (activeValidator) {
                     activeValidator.cancel();
                 }
+                $scope.numberOfTasks = 0;
+                $scope.errors = [];
+                $scope.warnings = [];
+                $scope.definitions = undefined;
                 $scope.lint = createLinterOption();
             });
 

--- a/ui/app/scripts/task/views/bulk-define-tasks.html
+++ b/ui/app/scripts/task/views/bulk-define-tasks.html
@@ -7,7 +7,7 @@
 <form class="form-horizontal col-md-12" style="padding: 0px;" name="bulkDefineTasksForm" role="form" ng-submit="bulkDefineTasks()" novalidate>
     <div class="row help-block">
         <div class="text-left pull-left">
-            <span ng-hide="bulkDefineTasksForm.$error.processedDsl">{{definitions.length === 0 ? 'No valid task definitions detected' : definitions.length + ' valid task definition'+(definitions.length>1?'s':'')+' detected'}}</span>
+            <span ng-hide="bulkDefineTasksForm.$error.processedDsl">{{getValidationStatus()}}</span>
             <span ng-show="bulkDefineTasksForm.$error.processedDsl">
                 <span class="glyphicon glyphicon-refresh icon-rotate-animation"></span>
                 <i>Validating task definitions</i>

--- a/ui/app/scripts/task/views/bulk-define-tasks.html
+++ b/ui/app/scripts/task/views/bulk-define-tasks.html
@@ -39,6 +39,11 @@
             <input type="file" on-read-file="displayFileContents(contents)" style="display:none;"/>
             Import File
         </label>
+		<label class="btn btn-default" tooltip-placement="top"
+               tooltip="Switch On/Off DSL editor live verification of app names and options">
+            <input type="checkbox" ng-model="verifyApps"/>
+            Verify Apps
+    	</label>
     </div>
     <div class="col-md-12 text-center" style="padding: 9px 12px;">
         <span style="padding-right: 15px;">

--- a/ui/test/spec/services/taskValidationServiceSpec.js
+++ b/ui/test/spec/services/taskValidationServiceSpec.js
@@ -19,279 +19,350 @@
  * @author Andy Clement
  */
 define(['angular', 'angularMocks', 'app'], function (angular) {
-		'use strict';
+    'use strict';
 
-	// Output from: curl localhost:9393/apps/task/timestamp - then just removed the escaped quotes.
-	var TASK_APPS = {
-		'test':'{"name":"test","options":[{"name":"testone"},{"name":"testtwo"}]}',
-		'timestamp': '{"name":"timestamp","type":"task","uri":"maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT","shortDescription":null,"options":[{"id":"timestamp.format","name":"format","type":"java.lang.String","description":"The timestamp format, yyyy-MM-dd HH:mm:ss.SSS by default.","shortDescription":"The timestamp format, yyyy-MM-dd HH:mm:ss.SSS by default.","defaultValue":"yyyy-MM-dd HH:mm:ss.SSS","valueHints":[],"valueProviders":[],"deprecation":null,"sourceType":"org.springframework.cloud.task.app.timestamp.TimestampTaskProperties","sourceMethod":null,"deprecated":false}]}'
-	};
+    // Output from: curl localhost:9393/apps/task/timestamp - then just removed the escaped quotes.
+    var TASK_APPS = {
+        'test':'{"name":"test","options":[{"name":"testone"},{"name":"testtwo"}]}',
+        'timestamp': '{"name":"timestamp","type":"task","uri":"maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT","shortDescription":null,"options":[{"id":"timestamp.format","name":"format","type":"java.lang.String","description":"The timestamp format, yyyy-MM-dd HH:mm:ss.SSS by default.","shortDescription":"The timestamp format, yyyy-MM-dd HH:mm:ss.SSS by default.","defaultValue":"yyyy-MM-dd HH:mm:ss.SSS","valueHints":[],"valueProviders":[],"deprecation":null,"sourceType":"org.springframework.cloud.task.app.timestamp.TimestampTaskProperties","sourceMethod":null,"deprecated":false}]}'
+    };
 
-	describe('Unit: Testing JS validation of task definitions', function () {
+    describe('Unit: Testing JS validation of task definitions', function () {
 
-		// beforeEach(function () {
-		//     angular.mock.module('dataflowMain');
-		// });
+        // beforeEach(function () {
+        //     angular.mock.module('dataflowMain');
+        // });
 
-		beforeEach(module('dataflowMain'));
+        beforeEach(module('dataflowMain'));
 
-		beforeEach(inject(function(AppService, $q){
-			spyOn(AppService, 'getAppInfo').and.callFake(function(type, name) {
-				var deferred = $q.defer();
-				if (angular.isDefined(TASK_APPS[name])) {
-					deferred.resolve({
-						data: JSON.parse(TASK_APPS[name])
-					});
-				} else {
-					deferred.reject();
-				}
-				return deferred.promise;
-			});
-		}));
+        beforeEach(inject(function(AppService, $q){
+            spyOn(AppService, 'getAppInfo').and.callFake(function(type, name) {
+                var deferred = $q.defer();
+                if (angular.isDefined(TASK_APPS[name])) {
+                    deferred.resolve({
+                        data: JSON.parse(TASK_APPS[name])
+                    });
+                } else {
+                    deferred.reject();
+                }
+                return deferred.promise;
+            });
+        }));
 
-		it('should have a TaskDslValidatorService', inject(function (TaskDslValidatorService) {
-			expect(TaskDslValidatorService).toBeDefined();
-		}));
+        it('should have a TaskDslValidatorService', inject(function (TaskDslValidatorService) {
+            expect(TaskDslValidatorService).toBeDefined();
+        }));
 
-		it('Basic valid of task definition', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('foo=timestamp');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(0);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(1);
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+        it('Valid task definition syntax', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=bar', {semantics: false});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-		it('Basic invalid task definition', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('foo=bar');
-				validator.validate().then(function(results) {
-					expect(results.errors.length).toEqual(1);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(0);
-					var error = results.errors[0];
-					expect(error.message).toEqual('\'bar\' is not a known task application');
-					expect(error.severity).toEqual('error');
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+        it('Invalid task definition syntax', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo bar', {semantics: false});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-		it('Valid app options', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('foo = timestamp  --format=hms');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(0);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(1);
-					var def = results.definitions[0];
-					expect(def.name).toEqual('foo');
-					expect(def.definition).toEqual('timestamp --format=hms');
-					expect(def.line).toEqual(0);
-					// expect(def.text).toEqual('foo = timestamp  --format=hms');
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+        it('Valid task definition syntax with properties', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=bar --key=value', {semantics: false});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-		it('Invalid app options', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('foo=timestamp --wibble=wobble');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(1);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(0);
+        it('Invalid task definition syntax with properties', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=bar key=value', {semantics: false});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-					var error = results.errors[0];
-					expect(error.from.ch).toEqual(14);
-					expect(error.from.line).toEqual(0);
-					expect(error.to.ch).toEqual(29);
-					expect(error.to.line).toEqual(0);
-					expect(error.message).toEqual('Application \'timestamp\' does not support the option \'wibble\'');
-					expect(error.severity).toEqual('error');
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+        it('Basic valid of task definition', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=timestamp', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-		it('Multiple options - all valid', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('foo=test --testone=abc --testtwo=def');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(0);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(1);
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-					var def = results.definitions[0];
-					expect(def.name).toEqual('foo');
-					expect(def.definition).toEqual('test --testone=abc --testtwo=def');
-					expect(def.line).toEqual(0);
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+        it('Basic invalid task definition', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=bar', {semantics: true});
+                validator.validate().then(function(results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
+                    var error = results.errors[0];
+                    expect(error.message).toEqual('\'bar\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-		it('Multiple options - one invalid', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('foo=test --testone=abc --testtwo=def --phoney=baloney');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(1);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(0);
+        it('Valid app options', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo = timestamp  --format=hms', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('timestamp --format=hms');
+                    expect(def.line).toEqual(0);
+                    // expect(def.text).toEqual('foo = timestamp  --format=hms');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-					var error = results.errors[0];
-					expect(error.from.ch).toEqual(37);
-					expect(error.from.line).toEqual(0);
-					expect(error.to.ch).toEqual(53);
-					expect(error.to.line).toEqual(0);
-					expect(error.message).toEqual('Application \'test\' does not support the option \'phoney\'');
-					expect(error.severity).toEqual('error');
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+        it('Invalid app options', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=timestamp --wibble=wobble', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(14);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(29);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('Application \'timestamp\' does not support the option \'wibble\'');
+                    expect(error.severity).toEqual('error');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-		it('Multi line - 2 invalid, 1 valid', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('aaa=bbb\nfoo=timestamp --format=hh\nccc=ddd');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(2);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(1);
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-					var def = results.definitions[0];
-					expect(def.name).toEqual('foo');
-					expect(def.definition).toEqual('timestamp --format=hh');
-					expect(def.line).toEqual(1);
-					// expect(def.text).toEqual('foo=timestamp --format=hh');
+        it('Multiple options - all valid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=test --testone=abc --testtwo=def', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
 
-					var error = results.errors[0];
-					expect(error.from.ch).toEqual(4);
-					expect(error.from.line).toEqual(0);
-					expect(error.to.ch).toEqual(7);
-					expect(error.to.line).toEqual(0);
-					expect(error.message).toEqual('\'bbb\' is not a known task application');
-					expect(error.severity).toEqual('error');
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('test --testone=abc --testtwo=def');
+                    expect(def.line).toEqual(0);
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-					error = results.errors[1];
-					expect(error.from.ch).toEqual(4);
-					expect(error.from.line).toEqual(2);
-					expect(error.to.ch).toEqual(7);
-					expect(error.to.line).toEqual(2);
-					expect(error.message).toEqual('\'ddd\' is not a known task application');
-					expect(error.severity).toEqual('error');
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+        it('Multiple options - one invalid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('foo=test --testone=abc --testtwo=def --phoney=baloney', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(1);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(0);
 
-		it('Multi line - 2 valid', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('aaa=test\nfoo=timestamp --format=hh');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(0);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(2);
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(37);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(53);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('Application \'test\' does not support the option \'phoney\'');
+                    expect(error.severity).toEqual('error');
 
-					var def = results.definitions[0];
-					expect(def.name).toEqual('aaa');
-					expect(def.definition).toEqual('test');
-					expect(def.line).toEqual(0);
-					// expect(def.text).toEqual('foo=timestamp --format=hh');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-					def = results.definitions[1];
-					expect(def.name).toEqual('foo');
-					expect(def.definition).toEqual('timestamp --format=hh');
-					expect(def.line).toEqual(1);
-					// expect(def.text).toEqual('foo=timestamp --format=hh');
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+        it('Multi line - 2 invalid, 1 valid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('aaa=bbb\nfoo=timestamp --format=hh\nccc=ddd', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(2);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(1);
+                   
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('timestamp --format=hh');
+                    expect(def.line).toEqual(1);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(4);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(7);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('\'bbb\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+                                      
+                    error = results.errors[1];
+                    expect(error.from.ch).toEqual(4);
+                    expect(error.from.line).toEqual(2);
+                    expect(error.to.ch).toEqual(7);
+                    expect(error.to.line).toEqual(2);
+                    expect(error.message).toEqual('\'ddd\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-		it('Multi line - 2 valid but clashing names, 1 invalid', function(done) {
-			inject(function(TaskDslValidatorService, $rootScope) {
-				var validator = TaskDslValidatorService.createValidator('aaa=bar\nb=test\nb=timestamp --format=hh');
-				validator.validate().then(function (results) {
-					expect(results.errors.length).toEqual(2);
-					expect(results.warnings.length).toEqual(0);
-					expect(results.definitions.length).toEqual(2);
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
 
-					var def = results.definitions[0];
-					expect(def.name).toEqual('b');
-					expect(def.definition).toEqual('test');
-					expect(def.line).toEqual(1);
-					// expect(def.text).toEqual('foo=timestamp --format=hh');
 
-					var error = results.errors[0];
-					expect(error.from.ch).toEqual(4);
-					expect(error.from.line).toEqual(0);
-					expect(error.to.ch).toEqual(7);
-					expect(error.to.line).toEqual(0);
-					expect(error.message).toEqual('\'bar\' is not a known task application');
-					expect(error.severity).toEqual('error');
+        it('Multi line - 2 valid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('aaa=test\nfoo=timestamp --format=hh', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(0);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(2);
+                   
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('aaa');
+                    expect(def.definition).toEqual('test');
+                    expect(def.line).toEqual(0);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
 
-					error = results.errors[1];
-					expect(error.from.ch).toEqual(0);
-					expect(error.from.line).toEqual(2);
-					expect(error.to.ch).toEqual(1);
-					expect(error.to.line).toEqual(2);
-					expect(error.message).toEqual('Duplicate task definition name \'b\'');
-					expect(error.severity).toEqual('error');
+                    def = results.definitions[1];
+                    expect(def.name).toEqual('foo');
+                    expect(def.definition).toEqual('timestamp --format=hh');
+                    expect(def.line).toEqual(1);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
 
-					done();
-				}, function() {
-					fail('Validation unexpectedly cancelled'); // jshint ignore:line
-				});
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
 
-				// Mocked promises require digest cycle kick off for `then` to be called
-				$rootScope.$apply();
-			});
-		});
-	});
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+        it('Multi line - 2 valid but clashing names, 1 invalid', function(done) {
+            inject(function(TaskDslValidatorService, $rootScope) {
+                var validator = TaskDslValidatorService.createValidator('aaa=bar\nb=test\nb=timestamp --format=hh', {semantics: true});
+                validator.validate().then(function (results) {
+                    expect(results.errors.length).toEqual(2);
+                    expect(results.warnings.length).toEqual(0);
+                    expect(results.definitions.length).toEqual(2);
+                   
+                    var def = results.definitions[0];
+                    expect(def.name).toEqual('b');
+                    expect(def.definition).toEqual('test');
+                    expect(def.line).toEqual(1);
+                    // expect(def.text).toEqual('foo=timestamp --format=hh');
+                       
+                    var error = results.errors[0];
+                    expect(error.from.ch).toEqual(4);
+                    expect(error.from.line).toEqual(0);
+                    expect(error.to.ch).toEqual(7);
+                    expect(error.to.line).toEqual(0);
+                    expect(error.message).toEqual('\'bar\' is not a known task application');
+                    expect(error.severity).toEqual('error');
+
+                    error = results.errors[1];
+                    expect(error.from.ch).toEqual(0);
+                    expect(error.from.line).toEqual(2);
+                    expect(error.to.ch).toEqual(1);
+                    expect(error.to.line).toEqual(2);
+                    expect(error.message).toEqual('Duplicate task definition name \'b\'');
+                    expect(error.severity).toEqual('error');
+
+                    done();
+                }, function() {
+                    fail('Validation unexpectedly cancelled'); // jshint ignore:line
+                });
+
+                // Mocked promises require digest cycle kick off for `then` to be called
+                $rootScope.$apply();
+            });
+        });
+
+    });
 });
+


### PR DESCRIPTION
- Support for turning on/off semantic validation of app and their options
- UI should have button "Verify Apps" added on the bulk define tasks page
- Unit tests for the option for the validator