### PR TITLE
Clear input file value after file is uploaded

### DIFF
--- a/ui/app/scripts/directives.js
+++ b/ui/app/scripts/directives.js
@@ -382,5 +382,16 @@ define(['angular', 'xregexp', 'moment'], function(angular) {
           });
         }
       };
+    })
+    .directive('clearSelectedFile', function () {
+      return {
+        restrict: 'A',
+        scope: false,
+        link: function(scope, element) {
+          element.bind('change', function() {
+            element.val(null);
+          });
+        }
+      };
     });
 });

--- a/ui/app/scripts/task/views/bulk-define-tasks.html
+++ b/ui/app/scripts/task/views/bulk-define-tasks.html
@@ -36,7 +36,7 @@
         <label type="button" class="btn btn-default" tooltip-placement="top"
                tooltip="Select a file from local file system to import its contents into the DSL editor">
             <span class="glyphicon glyphicon-file"></span>
-            <input type="file" on-read-file="displayFileContents(contents)" style="display:none;"/>
+            <input type="file" on-read-file="displayFileContents(contents)" clear-selected-file style="display:none;"/>
             Import File
         </label>
     </div>


### PR DESCRIPTION
Reproduce:
1. Open "Bulk Define Tasks" page
2. Import file XYZ.txt
3. Select all contents of the editor and remove them, i.e. editor content is empty.
4. Import file XYZ.txt again

Note that content of the editor is still empty. Happened because file path value is still the same and there is nothing to upload.

Solution: added directive clearing file path value from the DOM input element

See: https://www.pivotaltracker.com/story/show/131820453