### PR TITLE
Fix reference from StreamParserService to shared ParserService

### DIFF
--- a/ui/app/scripts/stream/controllers/create-streams-dialog.js
+++ b/ui/app/scripts/stream/controllers/create-streams-dialog.js
@@ -26,7 +26,7 @@ define(function(require) {
 
     var PROGRESS_BAR_WAIT_TIME = 600; // to account for animation delay
 
-    return ['DataflowUtils', '$scope', 'StreamService', '$modalInstance', 'definitionData', 'StreamMetamodelService', 'StreamParserService',
+    return ['DataflowUtils', '$scope', 'StreamService', '$modalInstance', 'definitionData', 'StreamMetamodelService', 'ParserService',
         function (utils, $scope, streamService, $modalInstance, definitionData, metaModelService, ParserService) {
 
             function waitForStreamDef(streamDefNameToWaitFor, attemptCount) {


### PR DESCRIPTION
Without this I think the create button on the Create Streams page is broken (please verify that before you apply). It will open the dialog but then fail because it is looking for the streams parser (when it is now a shared parser). With this change in place it will find the right thing and succeed.

We don't have enough automated tests around that UI.