### PR TITLE
Track apps registration changes in other components

### DIFF
--- a/ui/app/scripts/app/controllers/apps.js
+++ b/ui/app/scripts/app/controllers/apps.js
@@ -45,6 +45,8 @@ define(['model/pageable'], function (Pageable) {
                     function (result) {
                         if (!!result._embedded) {
                             $scope.pageable.items = result._embedded.appRegistrationResourceList;
+                        } else {
+                            $scope.pageable.items = [];
                         }
                         // Process received array of apps
                         if (Array.isArray($scope.pageable.items)) {

--- a/ui/app/scripts/stream/services/metamodel.js
+++ b/ui/app/scripts/stream/services/metamodel.js
@@ -758,6 +758,11 @@ define(function (require) {
                 });
             }
 
+            // Add listener to App service to keep track if list of registered apps changing
+            appService.addListener({
+                changed: refresh
+            });
+
             /**
              * Service object. See the comments for individual functions above.
              */


### PR DESCRIPTION
Very simple listener mechanism to update Flo editor palette and possibly tasks after register/unregister single or multiple apps, bulk registering apps etc.
To reproduce:
- Open dashboard page and navigate to `Streams -> Create` tab. Note that there are no sources, processors and sink apps
- Navigate to `Apps -> All Applications` and click on `Bulk Import Applications`
- Import applications appropriate for the SCDF binder
- Navigate again to `Apps -> All Applications` to verify that apps are registered
- Navigate to `Streams -> Create` tab. 
Expected: Flo editor palette should have registered apps listed.
Actual: Flo editor palette looks exactly like in the first step, i.e. not showing the registered apps. Need to refresh the page in the browser to see the registered apps.