### PR TITLE
gh-146 Fix Bulk register widget shouldn't include hardcoded bit.ly links

### DIFF
--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -105,7 +105,7 @@ module.exports = function (grunt) {
           context: [
             '/authenticate', '/batch', '/tasks', '/jobs', '/logout', '/meta', '/apps', '/streams',
             '/runtime', '/validation', '/management', '/dashboard', '/security', '/completions',
-            '/metrics', '/features', '/login'],
+            '/metrics', '/features', '/login', '/app-starters'],
           host: 'localhost',
           port: 9393,
           changeOrigin: true

--- a/ui/app/scripts/app/controllers/bulk-import-apps.js
+++ b/ui/app/scripts/app/controllers/bulk-import-apps.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,6 @@
 define(function () {
     'use strict';
 
-    var STREAM_APP_STARTERS_VERSION_SUFFIX = '1-0-2-GA-';
-    var TASK_APP_STARTERS_VERSION_SUFFIX = '1-0-1-GA-';
-
     return ['$scope', 'AppService', 'DataflowUtils', '$modal', '$state',
         function ($scope, appService, utils, $modal, $state) {
 
@@ -36,44 +33,17 @@ define(function () {
                 };
             }
 
-            function newStreamAppStarters() {
-                return [
-                    {
-                        name: 'Maven based Stream Applications with RabbitMQ Binder',
-                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-rabbit-maven',
-                        force: false
-                    },
-                    {
-                        name: 'Maven based Stream Applications with Kafka Binder',
-                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-kafka-maven',
-                        force: false
-                    },
-                    {
-                        name: 'Docker based Stream Applications with RabbitMQ Binder',
-                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-rabbit-docker',
-                        force: false
-                    },
-                    {
-                        name: 'Docker based Stream Applications with Kafka Binder',
-                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-kafka-docker',
-                        force: false
+            function getAppStarters() {
+                var appStartersPromise = appService.getAppStarters().$promise;
+                utils.addBusyPromise(appStartersPromise);
+                appStartersPromise.then(
+                    function (result) {
+                        utils.$log.info(result);
+                        $scope.appStarters = result;
+                    }, function (result) {
+                        utils.growl.error(result.data[0].message);
                     }
-                ];
-            }
-
-            function newTaskAppStarters() {
-                return [
-                    {
-                        name: 'Maven based Task Applications',
-                        uri:  'http://bit.ly/' + TASK_APP_STARTERS_VERSION_SUFFIX + 'task-applications-maven',
-                        force: false
-                    },
-                    {
-                        name: 'Docker based Task Applications',
-                        uri:  'http://bit.ly/' + TASK_APP_STARTERS_VERSION_SUFFIX + 'task-applications-docker',
-                        force: false
-                    }
-                ];
+                );
             }
 
             // Basic URI validation RegEx pattern
@@ -103,14 +73,12 @@ define(function () {
 
                 promise.then(function() {
                     utils.growl.success('Submitted bulk import request');
-                    console.log(newBulkAppImport());
                     $scope.$watch('apps', function () {
                         $scope.apps.appsProperties = '';
                         $scope.apps.uri = '';
                         $scope.apps.force = false;
                     });
-                    $scope.streamAppStarters = newStreamAppStarters();
-                    $scope.taskAppStarters   = newTaskAppStarters();
+                    getAppStarters();
                 });
                 promise.catch(function(error) {
                     utils.growl.error(error.data[0].message);
@@ -132,8 +100,7 @@ define(function () {
             };
 
             $scope.apps = newBulkAppImport();
-            $scope.streamAppStarters = newStreamAppStarters();
-            $scope.taskAppStarters   = newTaskAppStarters();
+            getAppStarters();
 
             $scope.$apply();
 

--- a/ui/app/scripts/app/services.js
+++ b/ui/app/scripts/app/services.js
@@ -57,6 +57,13 @@ define(['angular', 'lodash'], function (angular, _) {
                         }
                     }).get();
                 },
+                getAppStarters: function () {
+                    return $resource($rootScope.dataflowServerUrl + '/app-starters', {}, {
+                        query: {
+                            method: 'GET'
+                        }
+                    }).get();
+                },
                 createCompositeApp: function(appName,definition) {
                     $log.info('Creating composite app name=' + appName + ' def=' + definition);
                     var request = $http({

--- a/ui/app/scripts/app/views/bulk-import-apps.html
+++ b/ui/app/scripts/app/views/bulk-import-apps.html
@@ -68,9 +68,9 @@ task.spark-client=maven://org.springframework.cloud.task.app:spark-client-task:1
     </div>
 </form>
 
-<h2>Out-of-the-box Stream app-starters</h2>
+<h2 ng-hide="!appStarters.streamAppStarters.length">Out-of-the-box Stream app-starters</h2>
 
-<table class="table form-table">
+<table class="table form-table" ng-hide="!appStarters.streamAppStarters.length">
     <col width="80%">
     <col width="10%">
     <col width="10%">
@@ -82,7 +82,7 @@ task.spark-client=maven://org.springframework.cloud.task.app:spark-client-task:1
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="item in streamAppStarters">
+    <tr ng-repeat="item in appStarters.streamAppStarters">
         <td>
             {{item.name}}
         </td>
@@ -100,9 +100,9 @@ task.spark-client=maven://org.springframework.cloud.task.app:spark-client-task:1
     </tbody>
 </table>
 
-<h2>Out-of-the-box Task app-starters</h2>
+<h2 ng-hide="!appStarters.taskAppStarters.length">Out-of-the-box Task app-starters</h2>
 
-<table class="table form-table">
+<table class="table form-table" ng-hide="!appStarters.taskAppStarters.length">
     <col width="80%">
     <col width="10%">
     <col width="10%">
@@ -114,7 +114,7 @@ task.spark-client=maven://org.springframework.cloud.task.app:spark-client-task:1
         </tr>
     </thead>
     <tbody>
-        <tr ng-repeat="item in taskAppStarters">
+        <tr ng-repeat="item in appStarters.taskAppStarters">
             <td>
                 {{item.name}}
             </td>


### PR DESCRIPTION
* Use new `/app-starters` Rest endpoint to get the links

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/146

depends on PR https://github.com/spring-cloud/spring-cloud-dataflow/pull/1140 