### PR TITLE
Quick fix for download links

### DIFF
--- a/ui/app/scripts/app/controllers/bulk-import-apps.js
+++ b/ui/app/scripts/app/controllers/bulk-import-apps.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
 define(function () {
     'use strict';
 
-    var STREAM_APP_STARTERS_VERSION_SUFFIX = '1-0-2-GA-';
-    var TASK_APP_STARTERS_VERSION_SUFFIX = '1-0-1-GA-';
+    var STREAM_APP_STARTERS_VERSION_SUFFIX = 'Avogadro-SR1-';
+    var TASK_APP_STARTERS_VERSION_SUFFIX = 'Addison-GA-';
 
     return ['$scope', 'AppService', 'DataflowUtils', '$modal', '$state',
         function ($scope, appService, utils, $modal, $state) {
@@ -45,7 +45,7 @@ define(function () {
                     },
                     {
                         name: 'Maven based Stream Applications with Kafka Binder',
-                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-kafka-maven',
+                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-kafka-10-maven',
                         force: false
                     },
                     {
@@ -55,7 +55,7 @@ define(function () {
                     },
                     {
                         name: 'Docker based Stream Applications with Kafka Binder',
-                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-kafka-docker',
+                        uri:  'http://bit.ly/' + STREAM_APP_STARTERS_VERSION_SUFFIX + 'stream-applications-kafka-10-docker',
                         force: false
                     }
                 ];

--- a/ui/app/scripts/shared/views/about.html
+++ b/ui/app/scripts/shared/views/about.html
@@ -25,7 +25,7 @@
 <h2>Get the Spring Cloud Data Flow Shell</h2>
 
 <p class="index-page--subtitle">As an alternative to the Dashboard UI, you can also
-   <a href="https://repo.spring.io/release/org/springframework/cloud/spring-cloud-dataflow-shell/{{dataflowVersionInfo.app.version}}/spring-cloud-dataflow-shell-{{dataflowVersionInfo.app.version}}.jar"
+   <a href="https://repo.spring.io/libs-snapshot/org/springframework/cloud/spring-cloud-dataflow-shell/{{dataflowVersionInfo.app.version}}/spring-cloud-dataflow-shell-{{dataflowVersionInfo.app.version}}.jar"
       target="_blank">download the compatible version of the Shell</a> ({{dataflowVersionInfo.app.version}}).</p>
 
 <h2>Need Help or Found an Issue?</h2>


### PR DESCRIPTION
- pointing shell download to 'libs-snapshot' repo to resolve release, milestone amd snapshot artifacts

- updating app resources to use Avogadto.SR1 and Addison.GA