### PR TITLE
gh-158 Fix: Dashboard refresh causes user session logout

### DIFF
--- a/ui/app/scripts/auth/controllers/logout.js
+++ b/ui/app/scripts/auth/controllers/logout.js
@@ -21,29 +21,24 @@
  */
 define([], function () {
   'use strict';
-  return ['$window', 'DataflowUtils', '$state', '$log', '$rootScope', '$http', 'userService', function ($window, DataflowUtils, $state, $log, $rootScope, $http, user) {
-    $log.info('Logging out...');
+  return ['$window', 'DataflowUtils', '$state', '$log', '$rootScope', '$http', 'userService', function ($window, DataflowUtils, $state, $log, $rootScope, $http, userService) {
 
-    if ($rootScope.user.isFormLogin) {
+    $log.info('Logging out ...');
+
+    if (userService.isFormLogin) {
+      console.log('Logging out user ' + userService.username + ' (FormLogin)');
       $http.get($rootScope.dataflowServerUrl + '/dashboard/logout').then(function() {
-
-        $rootScope.user.username = '';
-        $rootScope.user.isAuthenticated = false;
-        $rootScope.user.isFormLogin = false;
-
-        user = {
-          authenticationEnabled: true,
-          isFormLogin: false,
-          isAuthenticated: false,
-          username: ''
-        };
-
+        userService.resetUser();
         delete $http.defaults.headers.common[$rootScope.xAuthTokenHeaderName];
+        $window.sessionStorage.removeItem('xAuthToken-token');
         DataflowUtils.growl.success('Logged out.');
         $state.go('login');
       });
     }
-    else{
+    else {
+      console.log('Logging out user ' + userService.username + ' (OAuth)');
+      delete $http.defaults.headers.common[$rootScope.xAuthTokenHeaderName];
+      $window.sessionStorage.removeItem('xAuthToken-token');
       var logoutUrl = '//' + $window.location.host + '/logout';
       console.log('Redirecting to ' + logoutUrl);
       $window.open(logoutUrl, '_self');

--- a/ui/app/scripts/auth/views/login.html
+++ b/ui/app/scripts/auth/views/login.html
@@ -12,14 +12,19 @@
           <div class="platform--title" ng-if="user.isAuthenticated">Please sign out first</div>
           <div class="platform--text">
             <div class="container-fluid">
+              <div class="row" ng-hide="errorMessage === null">
+                <div class="col-md-4 col-md-offset-4">
+                  {{errorMessage}}
+                </div>
+              </div>
               <div class="row">
                 <div class="col-md-4 col-md-offset-4">
-                <form class="form-signin" role="form" ng-submit="login()" novalidate ng-if="!user.isAuthenticated">
-                  <input ng-model="loginForm.username" type="text" class="form-control" placeholder="Username" required autofocus>
+                <form name="loginForm" class="form-signin" role="form" ng-submit="login()" novalidate ng-if="!user.isAuthenticated">
+                  <input name="username" ng-model="loginModel.username" type="text" class="form-control" placeholder="Username" required autofocus>
                   <div class="help-block"></div>
-                  <input ng-model="loginForm.password" type="password" class="form-control" placeholder="Password" required>
+                  <input name="password" ng-model="loginModel.password" type="password" class="form-control" placeholder="Password" required>
                   <div class="help-block"></div>
-                  <button class="btn btn-lg btn-default btn-block" type="submit">Sign in</button>
+                  <button class="btn btn-lg btn-default btn-block" type="submit" ng-disabled="loginForm.$invalid">Sign in</button>
                 </form>
                 <form class="form-signin" role="form" ng-submit="logout()" novalidate ng-if="user.isAuthenticated">
                   <button class="btn btn-lg btn-default btn-block" type="submit">Sign out</button>

--- a/ui/app/scripts/main.js
+++ b/ui/app/scripts/main.js
@@ -135,13 +135,26 @@ define([
 
   var initInjector = angular.injector(['ng']);
   var $http = initInjector.get('$http');
+  var $window = initInjector.get('$window');
+
+  console.log('Checking whether current session is active ...');
+  var xAuthToken = $window.sessionStorage.getItem('xAuthToken');
+
+  if (xAuthToken !== null) {
+    console.log('Current session found.');
+    $http.defaults.headers.common['x-auth-token'] = xAuthToken;
+  }
+  else {
+    console.log('Initiating new session.');
+  }
+
   var securityInfoUrl = '/security/info';
   var timeout = 20000;
   var promiseHttp = $http.get(securityInfoUrl, {timeout: timeout});
   var promiseFeature = $http.get('/features', {timeout: timeout});
 
   promiseHttp.then(function(response) {
-    console.log('Security info retrieved ...', response.data);
+    console.log('Security info retrieved, user authenticated: ' + response.data.authenticated, response.data);
     app.constant('securityInfo', response.data);
 
     promiseFeature.then(function(featuresResponse) {
@@ -155,6 +168,7 @@ define([
     console.log(errorMessage, errorResponse);
     $('.splash .container').html(errorMessage);
   });
+
   function updateGrowl() {
     var bodyScrollTop = $(document).scrollTop();
     var navHeight = $('nav').outerHeight();

--- a/ui/app/scripts/routes.js
+++ b/ui/app/scripts/routes.js
@@ -436,7 +436,7 @@ define(['./app'], function (dashboard) {
           }
         });
   });
-  dashboard.run(function ($rootScope, $state, $stateParams, userService, featuresService, $log) {
+  dashboard.run(function ($rootScope, $state, $stateParams, userService, featuresService, $log, $window, $http) {
 
     $rootScope.$state = $state;
     $rootScope.$stateParams = $stateParams;
@@ -447,6 +447,11 @@ define(['./app'], function (dashboard) {
     $rootScope.pageRefreshTime = 5000;
     $rootScope.enableMessageRates = true;
 
+    var xAuthToken = $window.sessionStorage.getItem('xAuthToken');
+    if (xAuthToken !== null && userService.isAuthenticated) {
+      console.log('User ' + userService.username + ' is already authenticated, populating http header ' + $rootScope.xAuthTokenHeaderName);
+      $http.defaults.headers.common[$rootScope.xAuthTokenHeaderName] = xAuthToken;
+    }
     $rootScope.$on('$stateChangeStart', function(event, toState) {
         if (toState.data.feature && !$rootScope.features[toState.data.feature]) {
           $log.error('Feature disabled: ' + toState.data.feature);


### PR DESCRIPTION
* Store oauth-token in session-store
* Restore Dashboard UI in-case a pre-existing oauth-token can be retrieved AND if the SecurityInfo REST endpoint indicates that the user is still logged in
* Polish login page
  - Improve error handling
  - Disable login button as long as both form-fields (username / password) are not filled
* Logout will clear the session-store

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/158