### PR TITLE
Remove composed job/task flag from execution detail page

### DIFF
--- a/ui/app/scripts/job/views/execution-details.html
+++ b/ui/app/scripts/job/views/execution-details.html
@@ -43,13 +43,6 @@
       <td><button type="button" class="btn btn-default" ng-click="viewTaskExecutionDetails(jobExecutionDetails.taskExecutionId)" title="Details">{{jobExecutionDetails.taskExecutionId}}</button></td>
     <tr>
     <tr>
-      <td>Composed Job</td>
-      <td>
-        <span ng-show="jobExecutionDetails.composedJob" class="glyphicon glyphicon-ok text-info" aria-hidden="true"></span>
-        <span ng-hide="jobExecutionDetails.composedJob" class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-      </td>
-    <tr>
-    <tr>
       <td>Job Parameters</td>
       <td>{{jobExecutionDetails.jobParametersString}}</td>
     <tr>
@@ -108,35 +101,6 @@
                 >{{stepExecution.exitStatus.exitCode}}</a></td>
       <td class="action-column"><button type="button" class="btn btn-default" ng-click="viewStepExecutionDetails(jobExecutionDetails, stepExecution)" title="Details"><span class="glyphicon glyphicon-search"></span></button></td>
     </tr>
-  </tbody>
-</table>
-
-<h4 ng-show="jobExecutionDetails.composedJob">Composed Job - Child Job Executions</h4>
-
-<table class="table table-striped table-hover" ng-show="jobExecutionDetails.composedJob">
-  <thead>
-  <tr>
-    <th>Name</th><th class="text-center">Instance Id</th><th class="text-center">Execution Id</th><th>Job Start Time</th>
-    <th class="text-center">Step Executions Count</th><th>Status</th><th colspan="3" class="text-center">Actions</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr ng-repeat="item in jobExecutionDetails.childJobExecutions"
-      ng-show="!item.inactive">
-    <td>{{item.name}}&nbsp;<span dataflow-deployment-status="item"></span><span dataflow-composed-job-status="item"></span></td>
-    <td class="text-center">{{item.jobExecution.jobInstance.id}}</td>
-    <td class="text-center">{{item.jobExecution.id}}</td>
-    <td dataflow-date-time="{{item.jobExecution.startTime}}"></td>
-    <td class="text-center">{{item.stepExecutionCount}}</td>
-    <td ng-class="{'text-success': item.jobExecution.status === 'COMPLETED', 'text-danger': item.jobExecution.status === 'FAILED'}">{{item.jobExecution.status}}</td>
-    <td class="action-column"><button ng-disabled="!item.restartable" type="button" class="btn btn-default" ng-click="restartJob(item)" title="Restart Job Execution">
-      <span class="glyphicon glyphicon-retweet"></span></button></td>
-    <td class="action-column">
-      <button ng-disabled="!item.stoppable" type="button" class="btn btn-default" ng-click="stopJob(item)" title="Stop Job Execution">
-        <span class="glyphicon glyphicon-stop"></span></button>
-    </td>
-    <td class="action-column"><button type="button" class="btn btn-default" ng-click="viewJobExecutionDetails(item)" title="Details"><span class="glyphicon glyphicon-search"></span></button></td>
-  </tr>
   </tbody>
 </table>
 

--- a/ui/app/scripts/task/views/execution-details.html
+++ b/ui/app/scripts/task/views/execution-details.html
@@ -51,13 +51,6 @@
       <td dataflow-date-time="{{taskExecutionDetails.endTime}}"></td>
     <tr>
     <tr>
-      <td>Composed Task</td>
-      <td>
-        <span ng-show="taskExecutionDetails.composedTask" class="glyphicon glyphicon-ok text-info" aria-hidden="true"></span>
-        <span ng-hide="taskExecutionDetails.composedTask" class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-      </td>
-    <tr>
-    <tr>
       <td>Batch Job</td>
       <td>
         <span ng-show="taskExecutionDetails.jobExecutionIds.length > 0" class="glyphicon glyphicon-ok text-info" aria-hidden="true"></span>


### PR DESCRIPTION
- Since there is no info on composed task/job in task/job execution detail,
we can remove the html content to avoid confusion

Resolves spring-cloud/spring-cloud-dataflow-ui#186