### PR TITLE
Implement passing arguments and properties to tasks

### DIFF
--- a/ui/src/app/shared/components/property-table/property-table.component.html
+++ b/ui/src/app/shared/components/property-table/property-table.component.html
@@ -1,0 +1,108 @@
+<div class="row" style="margin-top: 1em;">
+  <div class="col-xs-12 text-left">
+    <h2>{{titleText}}</h2>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-12">
+    <hr>
+  </div>
+</div>
+<table class="table table-hover" *ngIf="getProperties().length > 0">
+  <thead>
+    <tr>
+      <th style="width: 30px">
+        <app-tri-state-checkbox *ngIf="getProperties().length > 0" class="toggle-all" [items]="getPropertiesAsObservable()"></app-tri-state-checkbox>
+      </th>
+      <th>Key</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let property of getProperties()">
+      <td><input type="checkbox" [(ngModel)]="property.isSelected"/></td>
+      <td>{{property.key}}</td>
+      <td>{{property.value}}</td>
+    </tr>
+  </tbody>
+</table>
+<div class="row" *ngIf="getProperties().length === 0">
+  <div class="col-xs-24 text-center">
+    {{emptyText}}
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12 text-left">
+    <button type="button" class="btn btn-default" (click)="addProperty()">{{addText}}</button>
+    <app-tri-state-button *ngIf="getProperties().length > 0" class="toggle-all" [items]="getPropertiesAsObservable()" (eventHandler)="removeSelectedItems()"></app-tri-state-button>
+  </div>
+</div>
+
+<div bsModal #childModal="bs-modal" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">{{addText}}</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="hideChildModal()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <app-tabs>
+        <app-tab tabTitle="Single">
+          <form class="form-horizontal" novalidate (ngSubmit)="submitSingleProperty()" [formGroup]="singleForm">
+            <div class="modal-body">
+              <div class="form-group" [ngClass]="singleForm.controls.singlePropertyKey.errors ? 'has-warning has-feedback' : ''">
+                <label for="singlePropertyKey" class="col-sm-2 control-label">Key</label>
+                <div class="col-sm-18">
+                  <input id="singlePropertyKey" name="singlePropertyKey" formControlName="singlePropertyKey">
+                  <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="singleForm.controls.singlePropertyKey.errors"></span>
+                  <p class="help-block" *ngIf="singleForm.controls.singlePropertyKey.errors">The format is invalid. {{singleForm.controls.singlePropertyKey.errors.validateKeyOrValue.reason}}</p>
+                </div>
+              </div>
+              <div class="form-group" [ngClass]="singleForm.controls.singlePropertyValue.errors ? 'has-warning has-feedback' : ''">
+                <label for="singlePropertyValue" class="col-sm-2 control-label">Value</label>
+                <div class="col-sm-18">
+                  <input id="singlePropertyValue" name="singlePropertyValue" formControlName="singlePropertyValue">
+                  <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="singleForm.controls.singlePropertyValue.errors"></span>
+                  <p class="help-block" *ngIf="singleForm.controls.singlePropertyValue.errors">The format is invalid. {{singleForm.controls.singlePropertyValue.errors.validateKeyOrValue.reason}}</p>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
+              <button class="btn btn-primary" [disabled]="!singleForm.valid">Add</button>
+            </div>
+          </form>
+        </app-tab>
+        <app-tab tabTitle="Bulk">
+          <form class="form-horizontal" novalidate (ngSubmit)="submitBulkProperties()" [formGroup]="bulkForm">
+            <div class="modal-body">
+              <div class="form-group" [ngClass]="bulkForm.controls.bulkProperties.errors ? 'has-warning has-feedback' : ''">
+                <label for="bulkProperties" class="col-sm-2 control-label">Properties</label>
+                <div class="col-sm-18">
+                  <textarea class="form-control" id="bulkProperties" name="bulkProperties" formControlName="bulkProperties"
+                            autofocus rows="5"></textarea>
+                  <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="bulkForm.controls.bulkProperties.errors"></span>
+                  <p class="help-block" *ngIf="bulkForm.controls.bulkProperties.errors">The format of your {{titleText}} is invalid. {{bulkForm.controls.bulkProperties.errors.validateProperties.reason}}</p>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-6 control-label">Select Properties File</label>
+                <div class="col-sm-14">
+                  <input type="file" (change)="displayFileContents($event)"/>
+                  <p class="help-block">Please provide a text file containing {{titleText}}. This will be used to populate the text area above.</p>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
+              <button class="btn btn-primary" [disabled]="!bulkForm.valid">Add</button>
+            </div>
+          </form>
+        </app-tab>
+      </app-tabs>
+
+    </div>
+  </div>
+</div>

--- a/ui/src/app/shared/components/property-table/property-table.component.html
+++ b/ui/src/app/shared/components/property-table/property-table.component.html
@@ -27,7 +27,7 @@
   </tbody>
 </table>
 <div class="row" *ngIf="getProperties().length === 0">
-  <div class="col-xs-24 text-center">
+  <div class="col-xs-24 text-left">
     {{emptyText}}
   </div>
 </div>
@@ -90,7 +90,7 @@
               <div class="form-group">
                 <label class="col-sm-6 control-label">Select Properties File</label>
                 <div class="col-sm-14">
-                  <input type="file" (change)="displayFileContents($event)"/>
+                  <input type="file" (change)="displayFileContents($event)" formControlName="bulkFile"/>
                   <p class="help-block">Please provide a text file containing {{titleText}}. This will be used to populate the text area above.</p>
                 </div>
               </div>

--- a/ui/src/app/shared/components/property-table/property-table.component.ts
+++ b/ui/src/app/shared/components/property-table/property-table.component.ts
@@ -22,6 +22,7 @@ export class PropertyTableComponent {
   singleForm: FormGroup;
   bulkForm: FormGroup;
   bulkProperties = new FormControl('', validateProperties);
+  bulkFile  = new FormControl('');
   singlePropertyKey = new FormControl('', validateKeyOrValue);
   singlePropertyValue = new FormControl('', validateKeyOrValue);
 
@@ -32,7 +33,8 @@ export class PropertyTableComponent {
       'singlePropertyValue': this.singlePropertyValue
     });
     this.bulkForm = fb.group({
-      'bulkProperties': this.bulkProperties
+      'bulkProperties': this.bulkProperties,
+      'bulkFile': this.bulkFile
     });
   }
 
@@ -69,6 +71,7 @@ export class PropertyTableComponent {
     this.singlePropertyKey.setValue('');
     this.singlePropertyValue.setValue('');
     this.bulkProperties.setValue('');
+    this.bulkFile.setValue('');
   }
 
   submitBulkProperties(): void {

--- a/ui/src/app/shared/components/property-table/property-table.component.ts
+++ b/ui/src/app/shared/components/property-table/property-table.component.ts
@@ -4,6 +4,13 @@ import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { Selectable } from '../../model/selectable';
 
+/**
+ * Component representing key/values in a table
+ * and have functionality to import those as
+ * single or bulk modes.
+ *
+ * @author Janne Valkealahti
+ */
 @Component({
   selector: 'app-property-table',
   templateUrl: './property-table.component.html'
@@ -104,6 +111,11 @@ export class PropertyTableComponent {
   }
 }
 
+/**
+ * Class which is used in property table component as table item.
+ *
+ * @author Janne Valkealahti
+ */
 export class PropertyTableItem implements Selectable {
 
   key: string;

--- a/ui/src/app/shared/components/property-table/property-table.component.ts
+++ b/ui/src/app/shared/components/property-table/property-table.component.ts
@@ -1,0 +1,139 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import { ModalDirective } from 'ngx-bootstrap';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { Observable } from 'rxjs/Observable';
+import { Selectable } from '../../model/selectable';
+
+@Component({
+  selector: 'app-property-table',
+  templateUrl: './property-table.component.html'
+})
+export class PropertyTableComponent {
+
+  @Input() id: string;
+  @Input() titleText: string;
+  @Input() emptyText: string;
+  @Input() addText: string;
+
+  @ViewChild('childModal')
+  public childModal: ModalDirective;
+
+  private properties: Array<PropertyTableItem>;
+  singleForm: FormGroup;
+  bulkForm: FormGroup;
+  bulkProperties = new FormControl('', validateProperties);
+  singlePropertyKey = new FormControl('', validateKeyOrValue);
+  singlePropertyValue = new FormControl('', validateKeyOrValue);
+
+  constructor(fb: FormBuilder) {
+    this.properties = new Array();
+    this.singleForm = fb.group({
+      'singlePropertyKey': this.singlePropertyKey,
+      'singlePropertyValue': this.singlePropertyValue
+    });
+    this.bulkForm = fb.group({
+      'bulkProperties': this.bulkProperties
+    });
+  }
+
+  getProperties(): Array<PropertyTableItem> {
+    return this.properties;
+  }
+
+  getPropertiesAsObservable(): Observable<Array<PropertyTableItem>> {
+    return Observable.of(this.properties);
+  }
+
+  removeSelectedItems() {
+    this.properties = this.properties.filter(item => !item.isSelected);
+  }
+
+  addProperty() {
+    this.showChildModal();
+  }
+
+  public showChildModal(): void {
+    this.childModal.show();
+  }
+
+  public hideChildModal(): void {
+    this.childModal.hide();
+  }
+
+  cancel(): void {
+    this.hideChildModal();
+    this.clear();
+  }
+
+  clear(): void {
+    this.singlePropertyKey.setValue('');
+    this.singlePropertyValue.setValue('');
+    this.bulkProperties.setValue('');
+  }
+
+  submitBulkProperties(): void {
+    if (this.bulkProperties.value) {
+      for (const prop of this.bulkProperties.value.split('\n')) {
+        if (prop && prop.length > 0 && !prop.startsWith('#')) {
+          const keyValue = prop.split('=');
+          if (keyValue.length === 2) {
+            this.properties.push(new PropertyTableItem(keyValue[0], keyValue[1]));
+          }
+        }
+      }
+    }
+    this.cancel();
+  }
+
+  submitSingleProperty(): void {
+    this.properties.push(new PropertyTableItem(this.singlePropertyKey.value, this.singlePropertyValue.value));
+    this.cancel();
+  }
+
+  displayFileContents(event: any) {
+    const file: File = event.target.files[0];
+    const reader: FileReader = new FileReader();
+    const _form = this.bulkForm;
+    reader.onloadend = function(e){
+      _form.patchValue({bulkProperties: reader.result});
+    }
+    reader.readAsText(file);
+  }
+}
+
+export class PropertyTableItem implements Selectable {
+
+  key: string;
+  value: string;
+  isSelected = false;
+
+  constructor(key: string, value: string) {
+    this.key = key;
+    this.value = value;
+  }
+}
+
+function validateProperties(formControl: FormControl) {
+  const properties = formControl.value.split('\n');
+
+  if (properties) {
+    for (const prop of properties) {
+      if (prop && prop.length > 0 && !prop.startsWith('#')) {
+        const keyValue = prop.split('=');
+        if (keyValue.length !== 2) {
+          return {validateProperties: {reason: '"' + prop + '" must contain a single "=".' }};
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function validateKeyOrValue(formControl: FormControl) {
+  if (formControl.value.length > 0) {
+    return null;
+  }
+  else {
+    return {validateKeyOrValue: {reason: 'Cannot be empty'}};
+  }
+}

--- a/ui/src/app/shared/components/tabs.component.ts
+++ b/ui/src/app/shared/components/tabs.component.ts
@@ -1,0 +1,49 @@
+import {AfterContentInit, Component, ContentChildren, Input, QueryList} from '@angular/core';
+
+@Component({
+  selector: 'app-tab',
+  styles: [`
+    .pane{
+      padding: 1em;
+    }
+  `],
+  template: `
+    <div [hidden]="!active" class="pane">
+      <ng-content></ng-content>
+    </div>
+  `
+})
+export class TabComponent {
+  @Input() tabTitle: string;
+  @Input() active = false;
+}
+
+@Component({
+  selector: 'app-tabs',
+  template: `
+    <div class="tab-simple">
+      <ul class="nav nav-tabs">
+        <li *ngFor="let tab of tabs" (click)="selectTab(tab)" role="presentation" [class.active]="tab.active">
+          <a>{{tab.tabTitle}}</a>
+        </li>
+      </ul>
+      <ng-content></ng-content>
+    </div>
+  `
+})
+export class TabsComponent implements AfterContentInit {
+
+  @ContentChildren(TabComponent) tabs: QueryList<TabComponent>;
+
+  ngAfterContentInit() {
+    const activeTabs = this.tabs.filter((tab) => tab.active);
+    if (activeTabs.length === 0) {
+      this.selectTab(this.tabs.first);
+    }
+  }
+
+  selectTab(tab: TabComponent) {
+    this.tabs.toArray().forEach((t) => t.active = false);
+    tab.active = true;
+  }
+}

--- a/ui/src/app/shared/components/tabs.component.ts
+++ b/ui/src/app/shared/components/tabs.component.ts
@@ -1,5 +1,10 @@
 import {AfterContentInit, Component, ContentChildren, Input, QueryList} from '@angular/core';
 
+/**
+ * Generic tab component representing one tab in tabs.
+ *
+ * @author Janne Valkealahti
+ */
 @Component({
   selector: 'app-tab',
   styles: [`
@@ -18,6 +23,11 @@ export class TabComponent {
   @Input() active = false;
 }
 
+/**
+ * Generic tabs component to layout panes.
+ *
+ * @author Janne Valkealahti
+ */
 @Component({
   selector: 'app-tabs',
   template: `

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import { HttpModule } from '@angular/http';
 
@@ -15,6 +15,9 @@ import { TriStateButtonComponent } from './components/tri-state-button.component
 import { ClickOutsideDirective } from '../shared/directives/click-outside.directive'
 
 import { KeyValuePipe } from './pipes/key-value-filter.pipe';
+import { PropertyTableComponent } from './components/property-table/property-table.component';
+import { ModalModule } from 'ngx-bootstrap';
+import {TabComponent, TabsComponent} from './components/tabs.component';
 
 const busyConfig: BusyConfig = {
     message: 'Processing..',
@@ -36,14 +39,19 @@ const busyConfig: BusyConfig = {
     CommonModule,
     FormsModule,
     HttpModule,
+    ReactiveFormsModule,
     BusyModule.forRoot(busyConfig),
+    ModalModule.forRoot(),
     ToastyModule.forRoot() ],
   declarations: [
     CapitalizePipe,
     KeyValuePipe,
     TriStateButtonComponent,
     TriStateCheckboxComponent,
-    ClickOutsideDirective],
+    ClickOutsideDirective,
+    PropertyTableComponent,
+    TabsComponent,
+    TabComponent],
   providers: [
     StompService,
     ErrorHandler],
@@ -56,7 +64,8 @@ const busyConfig: BusyConfig = {
     CapitalizePipe,
     KeyValuePipe,
     TriStateCheckboxComponent,
-    TriStateButtonComponent
+    TriStateButtonComponent,
+    PropertyTableComponent
   ]
 })
 export class SharedModule { }

--- a/ui/src/app/tasks/task-launch/task-launch.component.html
+++ b/ui/src/app/tasks/task-launch/task-launch.component.html
@@ -1,6 +1,13 @@
 <h1>Launch task '{{id}}'</h1>
-
-<div class="row">
+<app-property-table id="arguments"
+                    titleText="Task Arguments"
+                    emptyText="No Arguments added. If needed, please add a task arguments before launching the task."
+                    addText="Add Arguments"></app-property-table>
+<app-property-table id="properties"
+                    titleText="Task Properties"
+                    emptyText="No properties added. If needed, please add a task property before launching the task."
+                    addText="Add Properties"></app-property-table>
+<div class="row" style="margin-top: 20px">
   <div class="col-md-12 text-right">
     <button type="button" class="btn btn-default" (click)="launch(id)"><span class="glyphicon glyphicon-play"></span>Launch Task</button>
   </div>

--- a/ui/src/app/tasks/tasks.service.ts
+++ b/ui/src/app/tasks/tasks.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {Http, Response, Headers, RequestOptions, URLSearchParams} from '@angular/http';
+import { Http, Response, Headers, RequestOptions, URLSearchParams } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
@@ -86,11 +86,15 @@ export class TasksService {
       .catch(this.errorHandler.handleError);
   }
 
-  launchDefinition(name: string) {
-    // TODO: add arguments and properties
-    // POST http://localhost:9393/tasks/executions?arguments=&name=bartask2&properties=
+  launchDefinition(name: string, taskArguments?: string, taskProperties?: string) {
     const params = new URLSearchParams();
     params.append('name', name);
+    if (taskArguments) {
+      params.append('arguments', taskArguments);
+    }
+    if (taskProperties) {
+      params.append('properties', taskProperties);
+    }
     const headers = new Headers({'Content-Type': 'application/json'});
     const options = new RequestOptions({headers: headers, params: params});
     return this.http.post(this.taskExecutionsUrl, {}, options)


### PR DESCRIPTION
NOTE: removing arguments/properties using tri-state components is a bit messy/broken until #291 and #292 gets fixed.

- Rewrite of how arguments and properties are
  defined in a launch page. Now using table and
  separate dialog where either single or bulk
  properties can be added.
- Re-useable property-table component used separately
  for properties and arguments.
- Simple tab component so that dialog can show
  separate forms for single/bulk import.
- Fixes #273