### PR TITLE
Fix tri-state components

### DIFF
--- a/ui/src/app/apps/apps.component.html
+++ b/ui/src/app/apps/apps.component.html
@@ -9,7 +9,14 @@
     Register Application(s)
 </button>
 
-<app-tri-state-button *ngIf="appRegistrations?.items" class="toggle-all" [items]="appRegistrations.getItemsAsObservable()" (eventHandler)="unregisterMultipleApps(appRegistrations.items)"></app-tri-state-button>
+<app-tri-state-button *ngIf="appRegistrations?.items" class="toggle-all"
+                      [items]="appRegistrations.getItemsAsObservable()"
+                      (eventHandler)="unregisterMultipleApps(appRegistrations.items)"
+                      noneSelectedLabel="No app selected to unregister"
+                      oneSelectedLabel="Unregister {selectedCount} selected app"
+                      manySelectedLabel="Unregister {selectedCount} selected apps"
+                      allSelectedLabel="Unregister all {selectedCount} selected apps"
+></app-tri-state-button>
 
 <button id="showAboutDetailsButton" type="button" (click)="bulkImportApps()"
         class="btn btn-default"

--- a/ui/src/app/shared/components/property-table/property-table.component.html
+++ b/ui/src/app/shared/components/property-table/property-table.component.html
@@ -34,7 +34,14 @@
 <div class="row">
   <div class="col-md-12 text-left">
     <button type="button" class="btn btn-default" (click)="addProperty()">{{addText}}</button>
-    <app-tri-state-button *ngIf="getProperties().length > 0" class="toggle-all" [items]="getPropertiesAsObservable()" (eventHandler)="removeSelectedItems()"></app-tri-state-button>
+    <app-tri-state-button *ngIf="getProperties().length > 0"class="toggle-all"
+                          [items]="getPropertiesAsObservable()"
+                          (eventHandler)="removeSelectedItems()"
+                          noneSelectedLabel="No item selected to remove"
+                          oneSelectedLabel="Remove {selectedCount} selected item"
+                          manySelectedLabel="Remove {selectedCount} selected items"
+                          allSelectedLabel="Remove all {selectedCount} selected items"
+    ></app-tri-state-button>
   </div>
 </div>
 

--- a/ui/src/app/shared/components/tri-state-checkbox.component.ts
+++ b/ui/src/app/shared/components/tri-state-checkbox.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, AfterViewInit, DoCheck,
-         ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, AfterViewInit, DoCheck, ViewChild } from '@angular/core';
 import { Observable, Subscription } from 'rxjs/Rx';
 import { Selectable } from '../../shared/model/selectable';
 
@@ -27,7 +26,7 @@ export class TriStateCheckboxComponent implements AfterViewInit, DoCheck  {
   @Input() items: Observable<any[]>;
   @ViewChild('theCheckbox') checkbox;
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef) { }
+  constructor() { }
 
   private setState() {
     if (!this._items) {
@@ -46,7 +45,7 @@ export class TriStateCheckboxComponent implements AfterViewInit, DoCheck  {
   }
 
   ngDoCheck() {
-    this.setState();
+    this.getItems();
   }
 
   public topLevelChange() {
@@ -56,11 +55,23 @@ export class TriStateCheckboxComponent implements AfterViewInit, DoCheck  {
   }
 
   ngAfterViewInit() {
-    console.log('ngAfterViewInit', this.items);
-    this._subscription = this.items.subscribe(res => {
-      this._items = res;
-      this.setState();
-      this._changeDetectorRef.detectChanges();
-    });
+    this.getItems();
+  }
+
+  private getItems() {
+    if (this._subscription) {
+      this._subscription.unsubscribe();
+    }
+    this._subscription = this.items.subscribe(
+      res => {
+        this._items = res;
+      },
+      error => {
+        console.log('error', error);
+        this.setState();
+      },
+      () => {
+        this.setState();
+      });
   }
 }


### PR DESCRIPTION
- Fix tri button state check so that when
  all items are selected, button is enabled.
- Remove use of ChangeDetectorRef as it should
  not be needed.
- With button, pass in 4 state strings which
  are used to generalize its usage. In those
  label strings use {xxx} format to replace
  selected count as it turned out angular/typescript
  doesn't provide anything better.
- Fix apps and property editor components to used
  this modified button version.
- Fix callbacks with lifecycle methods so that
  button is reset to correct state when
  its delete action happens. Previously
  items were not removed from its internal store
  vs. what was reflected from observer which subscribed
  only once.
- Checkbox version is also modified with similar
  tweaks for it to reset its state.
- Fixes #282
- Fixes #291
- Fixes #292 

Just note about `{xxx}` format I used. I originally thought I was able to come up with nice angular trick shown below, but it ended with `ExpressionChangedAfterItHasBeenCheckedError`. Doing simple regex replace in a component made things simples but is not angular way. 
```
@Component({
  selector: 'app-tri-state-button',
  template:
  `<button *ngIf="state < 0" #theButton name="topLevel" type="button" (click)="onClick()"
         class="btn btn-default"><span class="glyphicon glyphicon-trash"></span>
    {{noneSelectedLabel}}
  </button>
  <button *ngIf="state === 0" #theButton name="topLevel" type="button" (click)="onClick()"
          class="btn btn-default"><span class="glyphicon glyphicon-trash"></span>
    {{allSelectedLabel}}
  </button>
  <button *ngIf="state === 1" #theButton name="topLevel" type="button" (click)="onClick()"
          class="btn btn-default"><span class="glyphicon glyphicon-trash"></span>
    {{oneSelectedLabel}}
  </button>
  <button *ngIf="state > 1" #theButton name="topLevel" type="button" (click)="onClick()"
          class="btn btn-default"><span class="glyphicon glyphicon-trash"></span>
    {{manySelectedLabel}}
  </button>
  `
})	


<app-tri-state-button *ngIf="appRegistrations?.items" class="toggle-all"
                      #theTriStateButton
                      [items]="appRegistrations.getItemsAsObservable()"
                      (eventHandler)="unregisterMultipleApps(appRegistrations.items)"
                      noneSelectedLabel="No app selected to unregister"
                      oneSelectedLabel="Unregister {{theTriStateButton.selectedCount}} selected app"
                      manySelectedLabel="Unregister {{theTriStateButton.selectedCount}} selected apps"
                      allSelectedLabel="Unregister all {{theTriStateButton.selectedCount}} selected apps"
></app-tri-state-button>

```