### PR TITLE
Resolves bugs identified in lint.

### DIFF
--- a/ui/src/app/about/about-details.component.html
+++ b/ui/src/app/about/about-details.component.html
@@ -141,8 +141,11 @@
 
 <table class="table table-hover">
   <tbody>
-  <tr *ngIf="!isEmpty(dataflowVersionInfo.runtimeEnvironment.appDeployer.platformSpecificInfo)" ng-repeat="(key, value) in dataflowVersionInfo.runtimeEnvironment.appDeployer.platformSpecificInfo">
-    <td class="col-xs-6">{{key}}</td><td>{{value}}</td>
+  <tr *ngIf="!isEmpty(dataflowVersionInfo.runtimeEnvironment.appDeployer.platformSpecificInfo)">
+      <ng-template ngFor let-item
+                   [ngForOf]="dataflowVersionInfo.runtimeEnvironment.appDeployer.platformSpecificInfo | keyvalues">
+        <td class="col-xs-6">{{item.key}}</td><td>{{item.value}}</td>
+      </ng-template>
   </tr>
   <tr *ngIf="isEmpty(dataflowVersionInfo.runtimeEnvironment.appDeployer.platformSpecificInfo)">
     <td class="col-xs-12 text-center" colspan="2">No platform-specific app deployer information available.</td>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -29,13 +29,6 @@
   <tr>
     <th style="width: 70px" table-sort sort-property="['DEFINITION_NAME', 'DEFINITION']" sort-state="pageable" sort-order-change-handler="sortChanged">Name</th>
     <th style="width: 300px" table-sort sort-property="['DEFINITION','DEFINITION_NAME']"  sort-state="pageable" sort-order-change-handler="sortChanged">Definition</th>
-    <th style="width: 50px">Status
-      <a #childPopover="bs-popover"
-         [popover]="popTemplate"
-         placement="bottom"
-         (clickOutside)="closePopOver()"
-         title="Available Deployment Statuses"><span class="glyphicon glyphicon-question-sign"></span></a>
-    </th>
     <th style="width: 240px" colspan="1" class="text-center">Actions</th>
   </tr>
   </thead>
@@ -45,7 +38,6 @@
     <tr>
       <td>{{item.name}}</td>
       <td>{{item.dslText}}</td>
-      <td>{{item.status}}</td>
       <td class="action-column">
         <button type="button" (click)="launchTask(item)"
                 class="btn btn-default" title="Launch">
@@ -85,3 +77,4 @@
     </div>
   </div>
 </div>
+

--- a/ui/src/app/tasks/task-details/task-details.component.html
+++ b/ui/src/app/tasks/task-details/task-details.component.html
@@ -41,9 +41,7 @@
     </tr>
     <tr>
       <td>Job Execution Ids</td>
-      <td>
-        <span *ngFor="let jobExecutionId of taskExecution.jobExecutionIds"><button type="button" class="btn btn-default" (click)="viewJobExecutionDetails(jobExecutionId)" title="Details">{{jobExecutionId}}</button>{{$last ? '' : '&nbsp;'}}</span>
-      </td>
+      <td></td>
     </tr>
     <tr>
       <td>Start Time</td>


### PR DESCRIPTION
* Removes the status column in task definition page.  The missing popup was missing and when researching what was to be put in it, it was incorrect in the 1.2.x line.  And since task status  made no sense in the previous release nor here so it was removed.
* Removed code to retrieve job execution ids since it is not implemented in the class.
* Used a for loop to populate the platform specific information in the about detail.  Please review this for style, took a swag at what we wanted.

resolves #319