### PR TITLE
Fix issues in TaskCreateComponent

### DIFF
--- a/ui/src/app/tasks/task-create/task-create.component.html
+++ b/ui/src/app/tasks/task-create/task-create.component.html
@@ -3,12 +3,12 @@
 <form class="form-horizontal" novalidate (ngSubmit)="submitTaskDefinition()">
 
   <fieldset id="commonDefinitionParameters">
-    <div class="form-group" [ngClass]="form.controls.definitionName.errors ? 'has-warning has-feedback' : ''">
-      <label for="definitionName" class="col-sm-3 control-label">Definition Name</label>
-      <div class="col-sm-9" [formGroup]="form">
+    <div class="form-group" [ngClass]="mainForm.controls.definitionName.errors ? 'has-warning has-feedback' : ''">
+      <label for="definitionName" class="col-sm-4 control-label">Definition Name</label>
+      <div class="col-sm-10" [formGroup]="mainForm">
         <input type="text" id="definitionName" name="definitionName" autofocus
               class="form-control" placeholder="Enter a definition name" formControlName="definitionName">
-        <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="form.controls.definitionName.errors"></span>
+        <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="mainForm.controls.definitionName.errors"></span>
         <p class="help-block">The name of the definition must be different from the app name</p>
       </div>
     </div>
@@ -18,18 +18,18 @@
     <legend>Parameters</legend>
     <div class="form-group" *ngFor="let definitionParam of appInfo?.options">
 
-      <label for="{{definitionParam.name}}" class="col-sm-3 control-label">{{definitionParam.name}}</label>
-      <div class="col-sm-10" *ngIf="definitionParam.type !== 'Password' && definitionParam.type !== 'boolean'" [formGroup]="form">
+      <label for="{{definitionParam.name}}" class="col-sm-4 control-label">{{definitionParam.name}}</label>
+      <div class="col-sm-10" *ngIf="definitionParam.type !== 'Password' && definitionParam.type !== 'boolean'" [formGroup]="mainForm">
         <input type="text" id="{{definitionParam.name}}" name="{{definitionParam.name}}"
                class="form-control" [formControlName]="definitionParam.id">
         <p class="help-block">{{definitionParam.description}}</p>
       </div>
-      <div class="col-sm-10" *ngIf="definitionParam.type === 'Password'" [formGroup]="form">
+      <div class="col-sm-10" *ngIf="definitionParam.type === 'Password'" [formGroup]="mainForm">
         <input type="password" id="{{definitionParam.name}}" name="{{definitionParam.name}}"
                class="form-control" [formControlName]="definitionParam.id">
         <p class="help-block">{{definitionParam.description}}</p>
       </div>
-      <div class="col-sm-10" *ngIf="definitionParam.type === 'boolean'" [formGroup]="form">
+      <div class="col-sm-10" *ngIf="definitionParam.type === 'boolean'" [formGroup]="mainForm">
         <div class="checkbox">
           <label>
             <input type="checkbox" id="{{definitionParam.name}}" name="{{definitionParam.name}}"
@@ -38,7 +38,7 @@
           </label>
         </div>
       </div>
-      <div class="col-sm-4 checkbox" [formGroup]="iform">
+      <div class="col-sm-4 checkbox" [formGroup]="includeForm">
         <label>
           <input type="checkbox" id="{{definitionParam.name+'.include'}}"
                  [formControlName]="definitionParam.id+'.include'">Include
@@ -51,7 +51,7 @@
 
   <h2>Resulting Definition</h2>
   <div class="row">
-    <div class="col-xs-12"><pre>{{definition}}</pre></div>
+    <div class="col-xs-18"><pre>{{definition}}</pre></div>
   </div>
 
   <div class="row">
@@ -59,7 +59,7 @@
       <button type="button" class="btn btn-default" (click)="back()">Back</button>
     </div>
     <div class="col-md-12 text-left">
-      <button type="submit" class="btn btn-default" [disabled]="!form.valid">Submit</button>
+      <button type="submit" class="btn btn-default" [disabled]="!mainForm.valid">Submit</button>
     </div>
   </div>
 

--- a/ui/src/app/tasks/task-create/task-create.component.html
+++ b/ui/src/app/tasks/task-create/task-create.component.html
@@ -9,7 +9,7 @@
         <input type="text" id="definitionName" name="definitionName" autofocus
               class="form-control" placeholder="Enter a definition name" formControlName="definitionName">
         <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="mainForm.controls.definitionName.errors"></span>
-        <p class="help-block">The name of the definition must be different from the app name</p>
+        <p class="help-block" *ngIf="mainForm.controls.definitionName.errors">The format is invalid. {{mainForm.controls.definitionName.errors.validateDefinitionName.reason}}</p>
       </div>
     </div>
   </fieldset>

--- a/ui/src/app/tasks/task-create/task-create.component.spec.ts
+++ b/ui/src/app/tasks/task-create/task-create.component.spec.ts
@@ -1,0 +1,162 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { BusyModule } from 'tixif-ngx-busy';
+import { ToastyService } from 'ng2-toasty';
+import { ActivatedRoute } from '@angular/router';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TasksService } from '../tasks.service';
+import { TaskCreateComponent } from './task-create.component';
+import { MockActivatedRoute } from '../../tests/mocks/activated-route';
+import { MockToastyService } from '../../tests/mocks/toasty';
+import { MockTasksService } from '../../tests/mocks/tasks';
+
+describe('TaskCreateComponent', () => {
+  let component: TaskCreateComponent;
+  let fixture: ComponentFixture<TaskCreateComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+  let activeRoute: MockActivatedRoute;
+  const toastyService = new MockToastyService();
+  const tasksService = new MockTasksService();
+  const commonTestParams = { id: 'faketask' };
+  const commonTestAppInfos = { faketask: {
+    name: 'fakename',
+    options: [
+      {id: 'fakename.opt1', name: 'opt1', defaultValue: 'val1'}
+    ]}};
+
+
+  beforeEach(async(() => {
+    activeRoute = new MockActivatedRoute();
+    TestBed.configureTestingModule({
+      declarations: [
+        TaskCreateComponent
+      ],
+      imports: [
+        BusyModule,
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule.withRoutes([])
+      ],
+      providers: [
+        { provide: TasksService, useValue: tasksService },
+        { provide: ActivatedRoute, useValue: activeRoute },
+        { provide: ToastyService, useValue: toastyService }
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TaskCreateComponent);
+    component = fixture.componentInstance;
+  });
+
+  function updateDefinitionName(definitionName: string) {
+    component.definitionName.setValue(definitionName);
+  }
+
+  it('task create component should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have matching app title with given param id', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('h1'));
+    el = de.nativeElement;
+    fixture.detectChanges();
+
+    expect(el.textContent).toContain('Create Definition for Task App faketask');
+    expect(toastyService.testSuccess.length).toBe(1);
+    expect(toastyService.testSuccess).toContain('App info loaded.');
+  });
+
+  it('should warn about empty initial definition name', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('[id=commonDefinitionParameters] > div'));
+    el = de.nativeElement;
+
+    fixture.detectChanges();
+    expect(el.classList.contains('has-warning')).toBe(true);
+    expect(el.classList.contains('has-feedback')).toBe(true);
+  });
+
+  it('should warn about empty illegal definition name', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('[id=commonDefinitionParameters] > div'));
+    el = de.nativeElement;
+
+    updateDefinitionName('fake task');
+    fixture.detectChanges();
+    expect(el.classList.contains('has-warning')).toBe(true);
+    expect(el.classList.contains('has-feedback')).toBe(true);
+  });
+
+  it('should warn about same definition name', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('[id=commonDefinitionParameters] > div'));
+    el = de.nativeElement;
+
+    updateDefinitionName('validtaskname');
+    fixture.detectChanges();
+    expect(el.classList.contains('has-warning')).toBe(false);
+    expect(el.classList.contains('has-feedback')).toBe(false);
+
+    updateDefinitionName('faketask');
+    fixture.detectChanges();
+    expect(el.classList.contains('has-warning')).toBe(true);
+    expect(el.classList.contains('has-feedback')).toBe(true);
+  });
+
+  it('should have plain initial resulting definition', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('pre'));
+    el = de.nativeElement;
+
+    fixture.detectChanges();
+    expect(el.textContent).toContain('fakename');
+  });
+
+  it('should add parameter to resulting definition if included', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('pre'));
+    el = de.nativeElement;
+
+    fixture.detectChanges();
+    component.includeForm.controls['fakename.opt1.include'].setValue(true);
+    fixture.detectChanges();
+    expect(el.textContent).toContain('fakename --fakename.opt1="val1"');
+  });
+
+  it('should have submit disabled until valid', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('button[type=submit]'));
+    el = de.nativeElement;
+    fixture.detectChanges();
+    expect(de.nativeElement.disabled).toBe(true);
+
+    updateDefinitionName('validtaskname');
+    fixture.detectChanges();
+    expect(de.nativeElement.disabled).toBe(false);
+  });
+
+  it('should navigate to tasks definitions with submit', () => {
+    activeRoute.testParams = commonTestParams;
+    tasksService.testAppInfos = commonTestAppInfos;
+    const navigate = spyOn((<any>component).router, 'navigate');
+
+    updateDefinitionName('validtaskname');
+    fixture.detectChanges();
+    component.submitTaskDefinition();
+    expect(navigate).toHaveBeenCalledWith(['tasks/definitions']);
+  });
+});

--- a/ui/src/app/tasks/task-create/task-create.component.spec.ts
+++ b/ui/src/app/tasks/task-create/task-create.component.spec.ts
@@ -52,6 +52,7 @@ describe('TaskCreateComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TaskCreateComponent);
     component = fixture.componentInstance;
+    toastyService.clearAll();
   });
 
   function updateDefinitionName(definitionName: string) {
@@ -152,11 +153,13 @@ describe('TaskCreateComponent', () => {
   it('should navigate to tasks definitions with submit', () => {
     activeRoute.testParams = commonTestParams;
     tasksService.testAppInfos = commonTestAppInfos;
+    de = fixture.debugElement.query(By.css('button[type=submit]'));
+    el = de.nativeElement;
     const navigate = spyOn((<any>component).router, 'navigate');
 
     updateDefinitionName('validtaskname');
     fixture.detectChanges();
-    component.submitTaskDefinition();
+    el.click();
     expect(navigate).toHaveBeenCalledWith(['tasks/definitions']);
   });
 });

--- a/ui/src/app/tasks/task-create/task-create.component.spec.ts
+++ b/ui/src/app/tasks/task-create/task-create.component.spec.ts
@@ -84,6 +84,10 @@ describe('TaskCreateComponent', () => {
     fixture.detectChanges();
     expect(el.classList.contains('has-warning')).toBe(true);
     expect(el.classList.contains('has-feedback')).toBe(true);
+
+    de = fixture.debugElement.query(By.css('[id=commonDefinitionParameters] p.help-block'));
+    el = de.nativeElement;
+    expect(el.textContent).toContain('Cannot be empty');
   });
 
   it('should warn about empty illegal definition name', () => {
@@ -96,6 +100,10 @@ describe('TaskCreateComponent', () => {
     fixture.detectChanges();
     expect(el.classList.contains('has-warning')).toBe(true);
     expect(el.classList.contains('has-feedback')).toBe(true);
+
+    de = fixture.debugElement.query(By.css('[id=commonDefinitionParameters] p.help-block'));
+    el = de.nativeElement;
+    expect(el.textContent).toContain('Cannot have spaces');
   });
 
   it('should warn about same definition name', () => {
@@ -113,6 +121,10 @@ describe('TaskCreateComponent', () => {
     fixture.detectChanges();
     expect(el.classList.contains('has-warning')).toBe(true);
     expect(el.classList.contains('has-feedback')).toBe(true);
+
+    de = fixture.debugElement.query(By.css('[id=commonDefinitionParameters] p.help-block'));
+    el = de.nativeElement;
+    expect(el.textContent).toContain('Cannot be same as faketask');
   });
 
   it('should have plain initial resulting definition', () => {

--- a/ui/src/app/tests/mocks/tasks.ts
+++ b/ui/src/app/tests/mocks/tasks.ts
@@ -48,6 +48,10 @@ export class MockTasksService {
   getAppInfo(id: string): Observable<AppInfo> {
     const appInfo = new AppInfo();
     appInfo.name = this.testAppInfos[id].name;
+    // TODO: polish related pojos for not need for this check
+    if (this.testAppInfos[id].options) {
+      appInfo.options = this.testAppInfos[id].options;
+    }
     return Observable.of(appInfo);
   }
 
@@ -57,5 +61,10 @@ export class MockTasksService {
       p.items.push(new AppRegistration(r.name, r.type, r.uri));
     });
     return Observable.of(p);
+  }
+
+  createDefinition(definition: string, name: string) {
+    // TODO: when needed in tests return something useful
+    return Observable.of({});
   }
 }


### PR DESCRIPTION
- Generic polish of both component ts and html.
- Add definition name validation and reflect that
  to the UI.
- Fix definition preview so that its shown immediately.
- Add logical tests to verify functionality.
- Tweak TasksService mock to return empty response when
  task is created.
- Fixes #329