### PR TITLE
Add toasty message for duplicate definition

### DIFF
--- a/ui/src/app/tasks/task-create/task-create.component.ts
+++ b/ui/src/app/tasks/task-create/task-create.component.ts
@@ -71,7 +71,14 @@ export class TaskCreateComponent implements OnInit, OnDestroy {
 
   submitTaskDefinition() {
     const def = this.calculateDefinition();
-    this.tasksService.createDefinition(def, this.definitionName.value).subscribe();
+    this.tasksService.createDefinition(def, this.definitionName.value).subscribe(
+      data => {
+        this.toastyService.success('Task definition create requested');
+      },
+      error => {
+        this.toastyService.error(error);
+      }
+    );
     this.router.navigate(['tasks/definitions']);
   }
 


### PR DESCRIPTION
if definition already exists the server will return an error message and this PR will display the toasty message.

resolves #341