### PR TITLE
Add test coverage for Runtime

### DIFF
--- a/ui/src/app/runtime/runtime-apps.component.spec.ts
+++ b/ui/src/app/runtime/runtime-apps.component.spec.ts
@@ -1,14 +1,38 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { BusyModule } from 'tixif-ngx-busy';
+import { NgxPaginationModule } from 'ngx-pagination';
+import { ToastyService } from 'ng2-toasty';
+import { ModalModule } from 'ngx-bootstrap';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { RuntimeAppsComponent } from './runtime-apps.component';
+import { MockToastyService } from '../tests/mocks/toasty';
+import { KeyValuePipe } from '../shared/pipes/key-value-filter.pipe';
+import { MockRuntimeAppsService } from '../tests/mocks/runtime';
+import { RuntimeAppsService } from './runtime-apps.service';
+import { RUNTIME_APPS } from '../tests/mocks/mock-data';
 
-xdescribe('RuntimeAppsComponent', () => {
+describe('RuntimeAppsComponent', () => {
   let component: RuntimeAppsComponent;
   let fixture: ComponentFixture<RuntimeAppsComponent>;
+  const toastyService = new MockToastyService();
+  const runtimeAppsService = new MockRuntimeAppsService();
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ RuntimeAppsComponent ]
+      declarations: [
+        RuntimeAppsComponent,
+        KeyValuePipe
+      ],
+      imports: [
+        BusyModule,
+        NgxPaginationModule,
+        ModalModule.forRoot()
+      ],
+      providers: [
+        { provide: RuntimeAppsService, useValue: runtimeAppsService },
+        { provide: ToastyService, useValue: toastyService }
+      ]
     })
     .compileComponents();
   }));
@@ -16,10 +40,38 @@ xdescribe('RuntimeAppsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RuntimeAppsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should be created', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should populate runtime apps', () => {
+    runtimeAppsService.testRuntimeApps = RUNTIME_APPS;
+    fixture.detectChanges();
+
+    const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table td'));
+    expect(des.length).toBe(6);
+    expect(des[0].nativeElement.textContent).toContain('foostream.log');
+    expect(des[1].nativeElement.textContent).toContain('deployed');
+    expect(des[2].nativeElement.textContent).toContain('1');
+    expect(des[3].nativeElement.textContent).toContain('foostream.time');
+    expect(des[4].nativeElement.textContent).toContain('deployed');
+    expect(des[5].nativeElement.textContent).toContain('1');
+  });
+
+  it('should call open modal', () => {
+    runtimeAppsService.testRuntimeApps = RUNTIME_APPS;
+    fixture.detectChanges();
+
+    const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table td'));
+    const showModal = spyOn(component, 'showChildModal');
+
+    des[0].query(By.css('a')).nativeElement.click();
+    expect(showModal).toHaveBeenCalled();
+    // looks like this is as far as we can go. content for
+    // modal is not populated which might be a limitation of
+    // jasmine. should probably test via selenium.
   });
 });

--- a/ui/src/app/runtime/runtime-apps.service.spec.ts
+++ b/ui/src/app/runtime/runtime-apps.service.spec.ts
@@ -1,0 +1,26 @@
+import { Observable } from 'rxjs/Observable';
+import { ErrorHandler } from '../shared/model/error-handler';
+import { SharedAppsService } from '../shared/services/shared-apps.service';
+import { RuntimeAppsService } from './runtime-apps.service';
+import { PageInfo } from '../shared/model/pageInfo';
+
+describe('RuntimeAppsService', () => {
+
+  let runtimeAppsService: RuntimeAppsService;
+
+  beforeEach(() => {
+    this.mockHttp = jasmine.createSpyObj('mockHttp', ['delete', 'get', 'post']);
+    this.jsonData = { };
+    const errorHandler = new ErrorHandler();
+    const sharedServices = new SharedAppsService(this.mockHttp, errorHandler);
+    runtimeAppsService = new RuntimeAppsService(this.mockHttp, errorHandler);
+  });
+
+  describe('getRuntimeApps', () => {
+    it('should call the runtime apps service with the right url to get apps', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      runtimeAppsService.getRuntimeApps(new PageInfo());
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/runtime/apps', {params: {page: '0', size: '10'}});
+    });
+  });
+});

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -570,3 +570,87 @@ export const JOBS_EXECUTIONS_1_STEPS_1_PROGRESS = {
     }
   }
 };
+
+export const RUNTIME_APPS = {
+  _embedded: {
+    appStatusResourceList: [
+      {
+        deploymentId: 'foostream.log',
+        state: 'deployed',
+        instances: {
+          _embedded: {
+            appInstanceStatusResourceList: [
+              {
+                instanceId: 'foostream.log-0',
+                state: 'deployed',
+                attributes: {
+                  guid: '36395',
+                  pid: '18337',
+                  port: '36395',
+                  stderr: '/tmp/spring-cloud-dataflow-6123292284556332480/foostream-1503384837599/foostream.log/stderr_0.log',
+                  stdout: '/tmp/spring-cloud-dataflow-6123292284556332480/foostream-1503384837599/foostream.log/stdout_0.log',
+                  url: 'http://127.0.1.1:36395',
+                  'working.dir': '/tmp/spring-cloud-dataflow-6123292284556332480/foostream-1503384837599/foostream.log'
+                },
+                _links: {
+                  self: {
+                    href: 'http://localhost:9393/runtime/apps/foostream.log/instances/foostream.log-0'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        _links: {
+          self: {
+            href: 'http://localhost:9393/runtime/apps/foostream.log'
+          }
+        }
+      },
+      {
+        deploymentId: 'foostream.time',
+        state: 'deployed',
+        instances: {
+          _embedded: {
+            appInstanceStatusResourceList: [
+              {
+                instanceId: 'foostream.time-0',
+                state: 'deployed',
+                attributes: {
+                  guid: '49401',
+                  pid: '18395',
+                  port: '49401',
+                  stderr: '/tmp/spring-cloud-dataflow-6123292284556332480/foostream-1503384843640/foostream.time/stderr_0.log',
+                  stdout: '/tmp/spring-cloud-dataflow-6123292284556332480/foostream-1503384843640/foostream.time/stdout_0.log',
+                  url: 'http://127.0.1.1:49401',
+                  'working.dir': '/tmp/spring-cloud-dataflow-6123292284556332480/foostream-1503384843640/foostream.time'
+                },
+                _links: {
+                  self: {
+                    href: 'http://localhost:9393/runtime/apps/foostream.time/instances/foostream.time-0'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        _links: {
+          self: {
+            href: 'http://localhost:9393/runtime/apps/foostream.time'
+          }
+        }
+      }
+    ]
+  },
+  _links: {
+    self: {
+      href: 'http://localhost:9393/runtime/apps?page=0&size=10'
+    }
+  },
+  page: {
+    size: 10,
+    totalElements: 2,
+    totalPages: 1,
+    number: 0
+  }
+};

--- a/ui/src/app/tests/mocks/runtime.ts
+++ b/ui/src/app/tests/mocks/runtime.ts
@@ -1,0 +1,39 @@
+import { Observable } from 'rxjs/Observable';
+import { PageInfo } from '../../shared/model/pageInfo';
+import { Page } from '../../shared/model/page';
+import { RuntimeApp } from '../../runtime/model/runtime-app';
+
+export class MockRuntimeAppsService {
+
+  private _testRuntimeApps: any;
+
+  get testRuntimeApps() {
+    return this._testRuntimeApps;
+  }
+
+  set testRuntimeApps(params: any) {
+    this._testRuntimeApps = params;
+  }
+
+  public getRuntimeApps(pageInfo: PageInfo): Observable<Page<RuntimeApp>> {
+    const page = new Page<RuntimeApp>();
+    if (this.testRuntimeApps) {
+      const response = this.testRuntimeApps;
+      let items: RuntimeApp[];
+      if (response._embedded && response._embedded.appStatusResourceList) {
+        items = response._embedded.appStatusResourceList as RuntimeApp[];
+        for (const item of items) {
+          item.appInstances = item.instances._embedded.appInstanceStatusResourceList;
+        }
+      } else {
+        items = [];
+      }
+      page.items = items;
+      page.totalElements = response.page.totalElements;
+      page.totalPages = response.page.totalPages;
+      page.pageNumber = response.page.number;
+      page.pageSize = response.page.size;
+    }
+    return Observable.of(page);
+  }
+}


### PR DESCRIPTION
- Add tests for RuntimeAppsComponent and
  RuntimeAppsService.
- Testing for modal content seem to be
  limited in jasmine, so only very limited
  test is added.
- Fixes #337