### PR TITLE
Add tests to stream component

### DIFF
--- a/ui/src/app/streams/model/stream-definition.spec.ts
+++ b/ui/src/app/streams/model/stream-definition.spec.ts
@@ -1,0 +1,21 @@
+import {StreamDefinition} from './stream-definition';
+
+/**
+ * Test {@link StreamDefinition} model.
+ *
+ * @author Glenn Renfro
+ */
+describe('StreamsDefinition', () => {
+
+  describe('basicValidationCheck', () => {
+    it('Constructor should setup stream definition properly and expand toggle work correctly.', () => {
+      const streamDefinition = new StreamDefinition('foo', 'bar', 'baz');
+      expect(streamDefinition.name).toBe('foo');
+      expect(streamDefinition.dslText).toBe('bar');
+      expect(streamDefinition.status).toBe('baz');
+      expect(streamDefinition.isExpanded).toBe(false);
+      streamDefinition.toggleIsExpanded();
+      expect(streamDefinition.isExpanded).toBe(true);
+    });
+  });
+});

--- a/ui/src/app/streams/stream-create/stream-create.component.spec.ts
+++ b/ui/src/app/streams/stream-create/stream-create.component.spec.ts
@@ -1,25 +1,51 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {StreamCreateComponent} from './stream-create.component';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {MockActivatedRoute} from '../../tests/mocks/activated-route';
+import {MockStreamsService} from '../../tests/mocks/streams';
+import {RouterTestingModule} from '@angular/router/testing';
+import {StreamsService} from '../streams.service';
+import {ActivatedRoute} from '@angular/router';
+import { FloModule} from 'spring-flo';
 
-import { StreamCreateComponent } from './stream-create.component';
-
-xdescribe('StreamCreateComponent', () => {
+/**
+ * Test {@link StreamCreateComponent}.
+ *
+ * @author Glenn Renfro
+ */
+describe('StreamCreateComponent', () => {
   let component: StreamCreateComponent;
   let fixture: ComponentFixture<StreamCreateComponent>;
+  let activeRoute: MockActivatedRoute;
+  const streamsService = new MockStreamsService();
+  const commonTestParams = { id: '1' };
 
   beforeEach(async(() => {
+    activeRoute = new MockActivatedRoute();
+
     TestBed.configureTestingModule({
-      declarations: [ StreamCreateComponent ]
+      declarations: [
+        StreamCreateComponent
+      ],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        FloModule
+      ],
+      providers: [
+        {provide: StreamsService, useValue: streamsService},
+        {provide: ActivatedRoute, useValue: activeRoute },
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
+    activeRoute.testParams = commonTestParams;
     fixture = TestBed.createComponent(StreamCreateComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should be created', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 });

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.html
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.html
@@ -5,12 +5,12 @@
         <tr>
           <td class="col-xs-12">
             <button type="button" (click)="expandPage()"
-                    class="btn btn-default">
+                    class="btn btn-default"  id="expandAll">
               <span class="glyphicon glyphicon-collapse-down"></span>
               <span class="hidden-xs">Expand All</span>
             </button>
             <button type="button" (click)="collapsePage()"
-                    class="btn btn-default">
+                    class="btn btn-default"  id="collapseAll">
               <span class="glyphicon glyphicon-expand"></span>
               <span class="hidden-xs">Collapse All</span>
             </button>
@@ -29,7 +29,7 @@
   </div>
 </div>
 <div *ngIf="!streamDefinitions">No streams available.</div>
-<table *ngIf="streamDefinitions?.items" class="table table-hover">
+<table *ngIf="streamDefinitions?.items" class="table table-hover" id="streamDefinitionsTable">
   <thead>
     <tr>
       <th style="width: 20px"></th>

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.spec.ts
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.spec.ts
@@ -1,25 +1,154 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {BusyModule} from 'tixif-ngx-busy';
+import {NgxPaginationModule} from 'ngx-pagination';
+import {ToastyService} from 'ng2-toasty';
+import {ModalModule, PopoverModule} from 'ngx-bootstrap';
+import {MockToastyService} from '../../tests/mocks/toasty';
+import {KeyValuePipe} from '../../shared/pipes/key-value-filter.pipe';
+import {MockStreamsService} from '../../tests/mocks/streams';
+import {STREAM_DEFINITIONS} from '../../tests/mocks/mock-data';
+import {StreamDefinitionsComponent} from './stream-definitions.component';
+import {StreamsService} from '../streams.service';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {RouterTestingModule} from '@angular/router/testing';
+import {MockActivatedRoute} from '../../tests/mocks/activated-route';
+import {ActivatedRoute} from '@angular/router';
+import {DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {StreamDefinition} from '../model/stream-definition';
 
-import { StreamDefinitionsComponent } from './stream-definitions.component';
-
-xdescribe('StreamDefinitionsComponent', () => {
+/**
+ * Test {@link StreamDefinitionsComponent}.
+ *
+ * @author Glenn Renfro
+ */
+describe('StreamDefinitionsComponent', () => {
   let component: StreamDefinitionsComponent;
   let fixture: ComponentFixture<StreamDefinitionsComponent>;
+  const toastyService = new MockToastyService();
+  const streamsService = new MockStreamsService();
+  let activeRoute: MockActivatedRoute;
 
   beforeEach(async(() => {
+    activeRoute = new MockActivatedRoute();
+
     TestBed.configureTestingModule({
-      declarations: [ StreamDefinitionsComponent ]
+      declarations: [
+        StreamDefinitionsComponent,
+        KeyValuePipe
+      ],
+      imports: [
+        BusyModule,
+        NgxPaginationModule,
+        ModalModule.forRoot(),
+        PopoverModule.forRoot(),
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule.withRoutes([])
+      ],
+      providers: [
+        {provide: StreamsService, useValue: streamsService},
+        {provide: ActivatedRoute, useValue: activeRoute },
+        {provide: ToastyService, useValue: toastyService}
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StreamDefinitionsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    toastyService.clearAll();
   });
 
   it('should be created', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
+
+  it('should populate stream definitions', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table[id=streamDefinitionsTable] td'));
+    expect(des.length).toBe(5);
+    expect(des[1].nativeElement.textContent).toContain('foo2');
+    expect(des[2].nativeElement.textContent).toContain('time |log');
+    expect(des[3].nativeElement.textContent).toContain('undeployed');
+  });
+
+  it('Should navigate to the details page.', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[title=Details]'));
+    const el: HTMLElement = de.nativeElement;
+    const navigate = spyOn((<any>component).router, 'navigate');
+    el.click();
+
+    expect(navigate).toHaveBeenCalledWith(['streams/definitions/foo2']);
+  });
+
+  it('Should navigate to the deployment page.', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[title=Deploy]'));
+    const el: HTMLElement = de.nativeElement;
+    const navigate = spyOn((<any>component).router, 'navigate');
+    el.click();
+
+    expect(navigate).toHaveBeenCalledWith(['streams/definitions/foo2/deploy']);
+  });
+
+  it('Should navigate to the destroy popup.', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[title=Destroy]'));
+    const el: HTMLElement = de.nativeElement;
+    const showModal = spyOn(component, 'showChildModal');
+    el.click();
+
+    expect(showModal).toHaveBeenCalled();
+  });
+
+  it('Should show stream definition undeployed toasty message.', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    streamsService.streamDefinitions._embedded.streamDefinitionResourceList[0].status = 'deployed';
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[title=Undeploy]'));
+    const el: HTMLElement = de.nativeElement;
+    el.click();
+    expect(toastyService.testSuccess).toContain('Successfully undeployed stream definition "foo2"');
+  });
+
+  it('Should expand and collapse items on page', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    let de: DebugElement = fixture.debugElement.query(By.css('button[id=expandAll]'));
+    let el: HTMLElement = de.nativeElement;
+
+    expect(streamsService.streamDefinitions._embedded.streamDefinitionResourceList[0].isExpanded).toBe(undefined);
+    el.click();
+    expect(streamsService.streamDefinitions._embedded.streamDefinitionResourceList[0].isExpanded).toBe(true);
+
+    de = fixture.debugElement.query(By.css('button[id=collapseAll]'));
+    el = de.nativeElement;
+
+    el.click();
+    expect(streamsService.streamDefinitions._embedded.streamDefinitionResourceList[0].isExpanded).toBe(false);
+  });
+
+  it('Should give successful toasty message after retrieving another page', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    component.getPage(2);
+    expect(toastyService.testSuccess).toContain('Stream definitions loaded.');
+  });
+
+  it('Should give successful toasty message after destroying stream definition.', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const streamDefinition = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.proceed(streamDefinition);
+    expect(toastyService.testSuccess).toContain('Successfully destroyed stream definition "foo2"');
+  });
+
 });

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.ts
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.ts
@@ -94,7 +94,9 @@ export class StreamDefinitionsComponent implements OnInit {
         this.toastyService.success('Successfully undeployed stream definition "'
           + item.name + '"');
       },
-      error => {}
+      error => {
+        this.toastyService.error(error);
+      }
     );
   }
 
@@ -144,7 +146,9 @@ export class StreamDefinitionsComponent implements OnInit {
         this.toastyService.success('Successfully destroyed stream definition "'
           + streamDefinition.name + '"');
       },
-      error => {}
+      error => {
+        this.toastyService.error(error);
+      }
     );
   }
 

--- a/ui/src/app/streams/stream-deploy/stream-deploy-validators.spec.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy-validators.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Test Stream Validator functions.
+ *
+ * @author Glenn Renfro
+ */
+import {validateDeploymentProperties} from './stream-deploy-validators';
+import {FormControl} from '@angular/forms';
+
+describe('StreamsDefinition', () => {
+
+  describe('validateDeploymentProperties', () => {
+    it('Verifies validateDeploymentProperties works as expected.', () => {
+      const formControl = new FormControl();
+      formControl.setValue('app.bar=baz');
+
+      let result = validateDeploymentProperties(formControl);
+      expect(result).toBe(undefined);
+
+      formControl.setValue('bar=baz');
+      result = validateDeploymentProperties(formControl);
+      expect(result).toBe(undefined);
+
+      formControl.setValue('baz');
+      result = validateDeploymentProperties(formControl);
+      expect(result.validateDeploymentProperties.reason).toBe('Invalid deployment property "baz" must contain a single "=".');
+    });
+  });
+});

--- a/ui/src/app/streams/stream-deploy/stream-deploy-validators.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy-validators.ts
@@ -26,5 +26,5 @@ export function validateDeploymentProperties(formControl: FormControl) {
       }
     }
   }
-  return null;
+  return undefined;
 }

--- a/ui/src/app/streams/stream-deploy/stream-deploy.component.html
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.component.html
@@ -33,10 +33,10 @@ property2=Data Flow"></textarea>
   </div>
   <div class="row">
     <div class="col-md-12 text-right">
-      <button type="button" class="btn btn-default" (click)="cancelDefinitionDeploy()">Back</button>
+      <button type="button" class="btn btn-default" (click)="cancelDefinitionDeploy()" id="backBtn">Back</button>
     </div>
     <div class="col-md-12 text-left">
-      <button type="submit" class="btn btn-default" [disabled]="!form.valid">Deploy</button>
+      <button type="submit" class="btn btn-default" [disabled]="!form.valid" id="deployBtn">Deploy</button>
     </div>
   </div>
 </form>

--- a/ui/src/app/streams/stream-deploy/stream-deploy.component.spec.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.component.spec.ts
@@ -1,0 +1,101 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {BusyModule} from 'tixif-ngx-busy';
+import {ToastyService} from 'ng2-toasty';
+import {MockToastyService} from '../../tests/mocks/toasty';
+import {MockStreamsService} from '../../tests/mocks/streams';
+import {STREAM_DEFINITIONS} from '../../tests/mocks/mock-data';
+import {StreamsService} from '../streams.service';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {RouterTestingModule} from '@angular/router/testing';
+import {MockActivatedRoute} from '../../tests/mocks/activated-route';
+import {ActivatedRoute} from '@angular/router';
+import {DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {StreamDeployComponent} from './stream-deploy.component';
+import {MockComponent} from '../../tests/mocks/mock-component';
+
+/**
+ * Test {@link StreamDeployComponent}.
+ *
+ * @author Glenn Renfro
+ */
+describe('StreamDeployComponent', () => {
+  let component: StreamDeployComponent;
+  let fixture: ComponentFixture<StreamDeployComponent>;
+  const toastyService = new MockToastyService();
+  const streamsService = new MockStreamsService();
+  let activeRoute: MockActivatedRoute;
+  const commonTestParams = { id: '1' };
+
+
+  beforeEach(async(() => {
+    activeRoute = new MockActivatedRoute();
+
+    TestBed.configureTestingModule({
+      declarations: [
+        StreamDeployComponent
+      ],
+      imports: [
+        BusyModule,
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule.withRoutes([{ path: 'streams/definitions', component: MockComponent }])
+      ],
+      providers: [
+        {provide: StreamsService, useValue: streamsService},
+        {provide: ActivatedRoute, useValue: activeRoute },
+        {provide: ToastyService, useValue: toastyService}
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    activeRoute.testParams = commonTestParams;
+    fixture = TestBed.createComponent(StreamDeployComponent);
+    component = fixture.componentInstance;
+    toastyService.clearAll();
+  });
+
+  it('should be created', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('Should execute deploy for stream', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[id=deployBtn]'));
+    const el: HTMLElement = de.nativeElement;
+    const navigate = spyOn((<any>component).router, 'navigate');
+    el.click();
+
+    expect(navigate).toHaveBeenCalledWith(['streams/definitions']);
+    expect(toastyService.testSuccess).toContain('Successfully deployed stream definition "1"');
+  });
+
+  it('Should execute deploy for stream with properties', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[id=deployBtn]'));
+    const el: HTMLElement = de.nativeElement;
+    const navigate = spyOn((<any>component).router, 'navigate');
+    component.deploymentProperties.setValue('app.bar=foo');
+    el.click();
+
+    expect(navigate).toHaveBeenCalledWith(['streams/definitions']);
+    expect(toastyService.testSuccess).toContain('Successfully deployed stream definition "1"');
+  });
+
+  it('Should return back to stream definitions page', () => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture.detectChanges();
+    const de: DebugElement = fixture.debugElement.query(By.css('button[id=backBtn]'));
+    const el: HTMLElement = de.nativeElement;
+    const navigate = spyOn((<any>component).router, 'navigate');
+    el.click();
+
+    expect(navigate).toHaveBeenCalledWith(['streams/definitions']);
+    expect(toastyService.testSuccess.length).toBe(0);
+  });
+});

--- a/ui/src/app/streams/stream-details/stream-details.component.spec.ts
+++ b/ui/src/app/streams/stream-details/stream-details.component.spec.ts
@@ -1,29 +1,31 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import {ActivatedRoute} from '@angular/router';
-import {StreamsComponent} from './streams.component';
-import {MockStreamsService} from '../tests/mocks/streams';
-import {MockActivatedRoute} from '../tests/mocks/activated-route';
+
+import {StreamDetailsComponent} from './stream-details.component';
+import {MockStreamsService} from '../../tests/mocks/streams';
+import {MockActivatedRoute} from '../../tests/mocks/activated-route';
 import {RouterTestingModule} from '@angular/router/testing';
-import {StreamsService} from './streams.service';
+import {StreamsService} from '../streams.service';
+import {ActivatedRoute} from '@angular/router';
 
 /**
- * Test {@link StreamsComponent}.
+ * Test {@link StreamDetailsComponent}.
  *
  * @author Glenn Renfro
  */
-describe('StreamsComponent', () => {
-  let component: StreamsComponent;
-  let fixture: ComponentFixture<StreamsComponent>;
-  const streamsService = new MockStreamsService();
+describe('StreamDetailsComponent', () => {
+  let component: StreamDetailsComponent;
+  let fixture: ComponentFixture<StreamDetailsComponent>;
   let activeRoute: MockActivatedRoute;
+  const streamsService = new MockStreamsService();
+  const commonTestParams = { id: '1' };
 
   beforeEach(async(() => {
     activeRoute = new MockActivatedRoute();
 
     TestBed.configureTestingModule({
       declarations: [
-        StreamsComponent
+        StreamDetailsComponent
       ],
       imports: [
         RouterTestingModule.withRoutes([])
@@ -37,7 +39,8 @@ describe('StreamsComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(StreamsComponent);
+    activeRoute.testParams = commonTestParams;
+    fixture = TestBed.createComponent(StreamDetailsComponent);
     component = fixture.componentInstance;
   });
 

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -1,0 +1,103 @@
+import {ErrorHandler} from '../shared/model/error-handler';
+import {StreamsService} from './streams.service';
+import {Observable} from 'rxjs/Observable';
+import {HttpUtils} from '../shared/support/http.utils';
+import {StreamDefinition} from './model/stream-definition';
+import {Headers, RequestOptions} from '@angular/http';
+import {MockResponse} from '../tests/mocks/response';
+import {STREAM_DEFINITIONS} from '../tests/mocks/mock-data';
+
+/**
+ * Test Streams Services.
+ *
+ * @author Glenn Renfro
+ */
+describe('StreamsService', () => {
+
+  beforeEach(() => {
+    this.mockHttp = jasmine.createSpyObj('mockHttp', ['delete', 'get', 'post']);
+    this.jsonData = {};
+    const errorHandler = new ErrorHandler();
+    this.streamsService = new StreamsService(this.mockHttp, errorHandler);
+  });
+
+  describe('getDefinitions', () => {
+    it('should call the streams service with the right url to get stream definitions', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+
+      expect(this.streamsService.streamDefinitions).toBeDefined();
+
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+
+      this.streamsService.getDefinitions();
+
+      const defaultPageNumber: number = this.streamsService.streamDefinitions.pageNumber;
+      const defaultPageSize: number = this.streamsService.streamDefinitions.pageSize;
+
+      expect(defaultPageNumber).toBe(0);
+      expect(defaultPageSize).toBe(10);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', {search: params});
+
+      this.streamsService.streamDefinitions.filter = 'testFilter';
+      this.streamsService.getDefinitions();
+      expect(this.streamsService.streamDefinitions.filter).toBe('testFilter');
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', {search: params});
+    });
+  });
+
+  describe('destroyDefinition', () => {
+    it('should call the streams service to destroy stream definition', () => {
+      this.mockHttp.delete.and.returnValue(Observable.of(this.jsonData));
+
+      expect(this.streamsService.streamDefinitions).toBeDefined();
+
+      const streamDefinition = new StreamDefinition('test', 'time|log', 'undeployed');
+      this.streamsService.destroyDefinition(streamDefinition);
+      const headers = new Headers({'Content-Type': 'application/json'});
+      const options = new RequestOptions({headers: headers});
+      expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/definitions/test', options);
+    });
+
+   describe('undeployDefinition', () => {
+      it('should call the streams service to undeploy stream definition', () => {
+        this.mockHttp.delete.and.returnValue(Observable.of(this.jsonData));
+
+        expect(this.streamsService.streamDefinitions).toBeDefined();
+
+        const streamDefinition = new StreamDefinition('test', 'time|log', 'deployed');
+        this.streamsService.undeployDefinition(streamDefinition);
+        const headers = new Headers({'Content-Type': 'application/json'});
+        const options = new RequestOptions({headers: headers});
+        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/deployments/test', options);
+      });
+    });
+
+    describe('deployDefinition', () => {
+      it('should call the streams service to deploy stream definition', () => {
+        this.mockHttp.post.and.returnValue(Observable.of(this.jsonData));
+
+        expect(this.streamsService.streamDefinitions).toBeDefined();
+
+        this.streamsService.deployDefinition('test', {});
+        const headers = new Headers({'Content-Type': 'application/json'});
+        const options = new RequestOptions({headers: headers});
+        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/test', {}, options);
+      });
+    });
+
+    describe('extractDefinition', () => {
+      it('should call the streams service to extract stream definition', () => {
+        const response = new MockResponse();
+        response.body = STREAM_DEFINITIONS;
+        let streamDefinitions = this.streamsService.extractData(response);
+        expect(streamDefinitions.pageNumber).toBe(0);
+        expect(streamDefinitions.pageSize).toBe(1);
+        expect(streamDefinitions.items[0].name).toBe('foo2');
+
+        response.body = {};
+        streamDefinitions = this.streamsService.extractData(response);
+        expect(streamDefinitions.items.length).toBe(0);
+      });
+    });
+  });
+});

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -107,7 +107,7 @@ export class StreamsService {
       .catch(this.errorHandler.handleError);
   }
 
-  private extractData(res: Response): Page<StreamDefinition> {
+  extractData(res: Response): Page<StreamDefinition> {
     const body = res.json();
     let items: StreamDefinition[];
     if (body._embedded && body._embedded.streamDefinitionResourceList) {

--- a/ui/src/app/tests/mocks/activated-route.ts
+++ b/ui/src/app/tests/mocks/activated-route.ts
@@ -18,6 +18,7 @@ export class MockActivatedRoute {
   private _testParams: {};
   private subject = new BehaviorSubject(this.testParams);
   params = this.subject.asObservable();
+  snapshot = {};
 
   get testParams() {
     return this._testParams;

--- a/ui/src/app/tests/mocks/mock-component.ts
+++ b/ui/src/app/tests/mocks/mock-component.ts
@@ -1,0 +1,18 @@
+import {OnDestroy, OnInit} from '@angular/core';
+
+
+/**
+ * Mock for Response Object.
+ *
+ * Provide mocked component can be used with a RouterTestingModule.
+ * RouterTestingModule.withRoutes([{ path: 'streams/definitions', component: MockComponent }])
+ *
+ * @author Glenn Renfro
+ */
+export class MockComponent implements OnInit, OnDestroy {
+  ngOnInit(): void {
+  }
+
+  ngOnDestroy(): void {
+  }
+}

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -654,3 +654,32 @@ export const RUNTIME_APPS = {
     number: 0
   }
 };
+
+export const STREAM_DEFINITIONS = {
+  _embedded: {
+    streamDefinitionResourceList: [
+      {
+        name: 'foo2',
+        dslText: 'time |log ',
+        status: 'undeployed',
+        statusDescription: 'The app or group is known to the system, but is not currently deployed',
+        _links: {
+          self: {
+            href: 'http://localhost:9393/streams/definitions/foo2'
+          }
+        }
+      }
+    ]
+  },
+  _links: {
+    self: {
+      href: 'http://localhost:9393/streams/definitions?page=0&size=20'
+    }
+  },
+  page: {
+    size: 1,
+    totalElements: 1,
+    totalPages: 1,
+    number: 0
+  }
+};

--- a/ui/src/app/tests/mocks/response.ts
+++ b/ui/src/app/tests/mocks/response.ts
@@ -1,0 +1,26 @@
+/**
+ * Mock for Response Object.
+ *
+ * Provide mocked response to allow extract methods in services to retrieve a json object:
+ * const response = new MockResponse();
+ * response.body = {some json};
+ *
+ * @author Glenn Renfro
+ */
+export class MockResponse {
+
+  private _body: any;
+
+  get body(): any {
+    return this._body;
+  }
+
+  set body(value: any) {
+    this._body = value;
+  }
+
+  public json(): any {
+    return this.body;
+  }
+
+}

--- a/ui/src/app/tests/mocks/streams.ts
+++ b/ui/src/app/tests/mocks/streams.ts
@@ -1,0 +1,64 @@
+import {Observable} from 'rxjs/Observable';
+import {PageInfo} from '../../shared/model/pageInfo';
+import {Page} from '../../shared/model/page';
+import {StreamDefinition} from '../../streams/model/stream-definition';
+
+/**
+ * Mock for StreamsService.
+ *
+ * Create a mocked service:
+ * const streamsService = new MockStreamsService();
+ * TestBed.configureTestingModule({
+ *   providers: [
+ *     { provide: StreamsService, useValue: streamsService }
+ *   ]
+ * }).compileComponents();
+ *
+ * Set streamDefinition app infos:
+ * runtimeAppsService._testRuntimeApps = STREAM_DEFINITIONS;//Stream Definitions json
+ *
+ * @author Glenn Renfro
+ */
+export class MockStreamsService {
+
+  get streamDefinitions(): any {
+    return this._streamDefinitions;
+  }
+
+  set streamDefinitions(value: any) {
+    this._streamDefinitions = value;
+  }
+
+  private _streamDefinitions: any;
+
+  getDefinitions(): Observable<Page<StreamDefinition>> {
+    const page = new Page<StreamDefinition>();
+    if (this.streamDefinitions) {
+      const response = this.streamDefinitions;
+      let items: StreamDefinition[];
+      if (response._embedded && response._embedded.streamDefinitionResourceList) {
+        items = response._embedded.streamDefinitionResourceList as StreamDefinition[];
+      } else {
+        items = [];
+      }
+      page.items = items;
+      page.totalElements = response.page.totalElements;
+      page.totalPages = response.page.totalPages;
+      page.pageNumber = response.page.number;
+      page.pageSize = response.page.size;
+    }
+    return Observable.of(page);
+  }
+
+  undeployDefinition(streamDefinition: StreamDefinition): Observable<Response> {
+    return Observable.of({});
+  }
+
+  destroyDefinition(streamDefinition: StreamDefinition): Observable<Response> {
+    return Observable.of({});
+  }
+
+  deployDefinition(streamDefinitionName: String, propertiesAsMap: any): Observable<Response> {
+    return Observable.of({});
+  }
+}


### PR DESCRIPTION
* Adds base toBeTruthy to stubbed out components.  As a baseline.
* Added specs with tests to all completed stream components, services, validator and model.
* Added Added toasty error messages to subscribes that were missing error closures.
* Replaced null with undefined where found.
* Added new mocks to support tests.
resolves #355