### PR TITLE
Add sorting to task definitions tables

### DIFF
--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -27,8 +27,8 @@
 <table *ngIf="taskDefinitions?.items" class="table table-hover">
   <thead>
   <tr>
-    <th style="width: 70px" table-sort sort-property="['DEFINITION_NAME', 'DEFINITION']" sort-state="pageable" sort-order-change-handler="sortChanged">Name</th>
-    <th style="width: 300px" table-sort sort-property="['DEFINITION','DEFINITION_NAME']"  sort-state="pageable" sort-order-change-handler="sortChanged">Definition</th>
+    <th style="width: 70px"><a (click)="toggleDefinitionNameSort()"><span style="margin-right: 5px">Name</span></a><i class="fa" [ngClass]="{'fa-sort': definitionNameSort === null, 'fa-sort-asc': definitionNameSort === false, 'fa-sort-desc': definitionNameSort === true }" aria-hidden="true"></i></th>
+    <th style="width: 300px"><a (click)="toggleDefinitionSort()"><span style="margin-right: 5px">Definitions</span></a><i class="fa" [ngClass]="{'fa-sort': definitionSort === null, 'fa-sort-asc': definitionSort === false, 'fa-sort-desc': definitionSort === true }" aria-hidden="true"></i></th>
     <th style="width: 240px" colspan="1" class="text-center">Actions</th>
   </tr>
   </thead>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.ts
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.ts
@@ -18,6 +18,13 @@ export class TaskDefinitionsComponent implements OnInit {
   busy: Subscription;
   taskDefinitionToDestroy: TaskDefinition;
 
+  // null indicates that order is not selected
+  // thus we simply show double arrow.
+  // for sorting toggles, we just switch
+  // and first sort with true which equals desc
+  definitionNameSort: boolean = null;
+  definitionSort: boolean = null;
+
   @ViewChild('childPopover')
   public childPopover: PopoverDirective;
 
@@ -50,7 +57,7 @@ export class TaskDefinitionsComponent implements OnInit {
   loadTaskDefinitions() {
     console.log('Loading Task Definitions...', this.taskDefinitions);
 
-    this.busy = this.tasksService.getDefinitions().subscribe(
+    this.busy = this.tasksService.getDefinitions(this.definitionNameSort, this.definitionSort).subscribe(
       data => {
         this.taskDefinitions = data;
         this.toastyService.success('Task definitions loaded.');
@@ -69,6 +76,28 @@ export class TaskDefinitionsComponent implements OnInit {
   destroyTask(item: TaskDefinition) {
     this.taskDefinitionToDestroy = item;
     this.showChildModal();
+  }
+
+  toggleDefinitionNameSort() {
+    if (this.definitionNameSort === null) {
+      this.definitionNameSort = true;
+    } else if (this.definitionNameSort) {
+      this.definitionNameSort = false;
+    } else {
+      this.definitionNameSort = null;
+    }
+    this.loadTaskDefinitions();
+  }
+
+  toggleDefinitionSort() {
+    if (this.definitionSort === null) {
+      this.definitionSort = true;
+    } else if (this.definitionSort) {
+      this.definitionSort = false;
+    } else {
+      this.definitionSort = null;
+    }
+    this.loadTaskDefinitions();
   }
 
   public proceed(taskDefinition: TaskDefinition): void {

--- a/ui/src/app/tasks/tasks.service.spec.ts
+++ b/ui/src/app/tasks/tasks.service.spec.ts
@@ -37,4 +37,43 @@ describe('TasksService', () => {
     });
   });
 
+  describe('getDefinitions', () => {
+    it('should call the definitions service with the right url [no sort params]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      // params.append('type', 'task');
+
+      this.tasksService.getDefinitions();
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/definitions', { search: params });
+    });
+
+    it('should call the definitions service with the right url [null sort params]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      this.tasksService.getDefinitions(null, null);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/definitions', { search: params });
+    });
+
+    it('should call the definitions service with the right url [desc asc sort]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const tocheck = params;
+      tocheck.append('sort', 'DEFINITION,ASC');
+      tocheck.append('sort', 'DEFINITION_NAME,DESC');
+      this.tasksService.getDefinitions(true, false);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/definitions', { search: tocheck });
+    });
+
+    it('should call the definitions service with the right url [asc desc sort]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const tocheck = params;
+      tocheck.append('sort', 'DEFINITION,DESC');
+      tocheck.append('sort', 'DEFINITION_NAME,ASC');
+      this.tasksService.getDefinitions(false, true);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/definitions', { search: tocheck });
+    });
+  });
+
 });

--- a/ui/src/app/tasks/tasks.service.ts
+++ b/ui/src/app/tasks/tasks.service.ts
@@ -67,10 +67,42 @@ export class TasksService {
         });
   }
 
-  getDefinitions(): Observable<Page<TaskDefinition>> {
+  /**
+   * Calls the Spring Cloud Data Flow server to get task definitions the specified {@link TaskDefinition}.
+   *
+   * If sort order is defined as true, desc order is used and if false, as order is used.
+   * If method is called without parameter or as null, sort properties are not added
+   * to the request.
+   *
+   * @param definitionNameSort the sort for DEFINITION_NAME
+   * @param definitionSort the sort for DEFINITION
+   * @returns {Observable<R|T>} that will call the subscribed funtions to handle
+   * the results when returned from the Spring Cloud Data Flow server.
+   */
+  getDefinitions(definitionNameSort?: boolean, definitionSort?: boolean): Observable<Page<TaskDefinition>> {
     const params = new URLSearchParams();
     params.append('page', this.taskDefinitions.pageNumber.toString());
     params.append('size', this.taskDefinitions.pageSize.toString());
+
+    // we can have asc and desc with multiple fields
+    // if sort param is sent multiple times.
+    // we put sort by definition first as
+    // names are always unique, making primary
+    // sort by name pointless.
+    if (definitionSort != null) {
+      if (definitionSort) {
+        params.append('sort', 'DEFINITION,DESC');
+      } else {
+        params.append('sort', 'DEFINITION,ASC');
+      }
+    }
+    if (definitionNameSort != null) {
+      if (definitionNameSort) {
+        params.append('sort', 'DEFINITION_NAME,DESC');
+      } else {
+        params.append('sort', 'DEFINITION_NAME,ASC');
+      }
+    }
 
     if (this.taskDefinitions.filter && this.taskDefinitions.filter.length > 0) {
       params.append('search', this.taskDefinitions.filter);

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -53,6 +53,8 @@ $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 @import '../node_modules/ng2-toasty/bundles/style.css';
 @import '../node_modules/ng2-toasty/bundles/style-bootstrap.css';
 
+@import '../node_modules/@compodoc/compodoc/src/resources/styles/font-awesome.min.css';
+
 .help-block {
   position: unset;
 }


### PR DESCRIPTION
- Add style font-awesome.min.css to get sorting arrows.
- Define individual states for sorting by name
  and definition. Toggle between null, true and false
  to indicate no sort, desc and asc.
- Modify tasks service to pass sorting param to where
  sorting by definition is primary as sort by name would
  be pointless as names are unique. Columns sort order has
  to be fixed as in UI it'd be too awkward to define whether
  name or definition is use as a primary sort.
- This commit only touches definitions table(not task apps table)
  to see if concept is ok to use in all other tables.
- Fixes #275