### PR TITLE
Change table layout css

### DIFF
--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -55,6 +55,14 @@ $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 
 @import '../node_modules/@compodoc/compodoc/src/resources/styles/font-awesome.min.css';
 
+// PUI sets this to fixed which completely
+// breaks table behaviour. With default setting
+// we seem to get better predictable layout
+// in all tables.
+table.table {
+  table-layout: auto;
+}
+
 .help-block {
   position: unset;
 }


### PR DESCRIPTION
- Changing table-layout from fixed back to default
  auto which is set by PUI. Fixed layout just doesn't
  seem to work overall if seeing all tables we use,
  ecpecially when narrowing browser size.
- While fixed might be better in some cases, we should
  not use it until we know better settings which
  works with all tables.
- Fixes #359