### PR TITLE
Add sorting to task executions table

### DIFF
--- a/ui/src/app/tasks/task-executions/task-executions.component.html
+++ b/ui/src/app/tasks/task-executions/task-executions.component.html
@@ -7,11 +7,11 @@
 <table *ngIf="taskExecutions?.items" class="table table-hover">
   <thead>
     <tr>
-        <th style="width: 200px">Execution Id</th>
-        <th style="width: 100px">Task Name</th>
-        <th style="width: 100px">Start Time</th>
-        <th style="width: 100px">End Time</th>
-        <th style="width: 100px">Exit Code</th>
+      <th style="width: 200px"><a (click)="toggleExecutionIdSort()"><span style="margin-right: 5px">Execution Id</span></a><i class="fa" [ngClass]="{'fa-sort': executionIdSort === undefined, 'fa-sort-asc': executionIdSort === false, 'fa-sort-desc': executionIdSort === true }" aria-hidden="true"></i></th>
+      <th style="width: 100px"><a (click)="toggleTaskNameSort()"><span style="margin-right: 5px">Task Name</span></a><i class="fa" [ngClass]="{'fa-sort': taskNameSort === undefined, 'fa-sort-asc': taskNameSort === false, 'fa-sort-desc': taskNameSort === true }" aria-hidden="true"></i></th>
+      <th style="width: 100px"><a (click)="toggleStartTimeSort()"><span style="margin-right: 5px">Start Time</span></a><i class="fa" [ngClass]="{'fa-sort': startTimeSort === undefined, 'fa-sort-asc': startTimeSort === false, 'fa-sort-desc': startTimeSort === true }" aria-hidden="true"></i></th>
+      <th style="width: 100px"><a (click)="toggleEndTimeSort()"><span style="margin-right: 5px">End Time</span></a><i class="fa" [ngClass]="{'fa-sort': endTimeSort === undefined, 'fa-sort-asc': endTimeSort === false, 'fa-sort-desc': endTimeSort === true }" aria-hidden="true"></i></th>
+      <th style="width: 100px"><a (click)="toggleExitCodeSort()"><span style="margin-right: 5px">Exit Code</span></a><i class="fa" [ngClass]="{'fa-sort': exitCodeSort === undefined, 'fa-sort-asc': exitCodeSort === false, 'fa-sort-desc': exitCodeSort === true }" aria-hidden="true"></i></th>
         <th style="width: 130px" class="text-center">Actions</th>
     </tr>
   </thead>

--- a/ui/src/app/tasks/task-executions/task-executions.component.ts
+++ b/ui/src/app/tasks/task-executions/task-executions.component.ts
@@ -14,6 +14,11 @@ export class TaskExecutionsComponent implements OnInit {
 
   taskExecutions: Page<TaskExecution>;
   busy: Subscription;
+  executionIdSort: boolean = undefined;
+  taskNameSort: boolean = undefined;
+  startTimeSort: boolean = undefined;
+  endTimeSort: boolean = undefined;
+  exitCodeSort: boolean = undefined;
 
   constructor(
     public tasksService: TasksService,
@@ -27,7 +32,8 @@ export class TaskExecutionsComponent implements OnInit {
   }
 
   loadTaskExecutions() {
-    this.busy = this.tasksService.getExecutions().subscribe(
+    this.busy = this.tasksService.getExecutions(this.executionIdSort, this.taskNameSort, this.startTimeSort,
+        this.endTimeSort, this.exitCodeSort).subscribe(
       data => {
         this.taskExecutions = data;
         this.toastyService.success('Task Executions loaded.');
@@ -43,5 +49,60 @@ export class TaskExecutionsComponent implements OnInit {
 
   details(item: TaskExecution) {
     this.router.navigate(['tasks/executions/' + item.executionId]);
+  }
+
+  toggleExecutionIdSort() {
+    if (this.executionIdSort === undefined) {
+      this.executionIdSort = true;
+    } else if (this.executionIdSort) {
+      this.executionIdSort = false;
+    } else {
+      this.executionIdSort = undefined;
+    }
+    this.loadTaskExecutions();
+  }
+
+  toggleTaskNameSort() {
+    if (this.taskNameSort === undefined) {
+      this.taskNameSort = true;
+    } else if (this.taskNameSort) {
+      this.taskNameSort = false;
+    } else {
+      this.taskNameSort = undefined;
+    }
+    this.loadTaskExecutions();
+  }
+
+  toggleStartTimeSort() {
+    if (this.startTimeSort === undefined) {
+      this.startTimeSort = true;
+    } else if (this.startTimeSort) {
+      this.startTimeSort = false;
+    } else {
+      this.startTimeSort = undefined;
+    }
+    this.loadTaskExecutions();
+  }
+
+  toggleEndTimeSort() {
+    if (this.endTimeSort === undefined) {
+      this.endTimeSort = true;
+    } else if (this.endTimeSort) {
+      this.endTimeSort = false;
+    } else {
+      this.endTimeSort = undefined;
+    }
+    this.loadTaskExecutions();
+  }
+
+  toggleExitCodeSort() {
+    if (this.exitCodeSort === undefined) {
+      this.exitCodeSort = true;
+    } else if (this.exitCodeSort) {
+      this.exitCodeSort = false;
+    } else {
+      this.exitCodeSort = undefined;
+    }
+    this.loadTaskExecutions();
   }
 }

--- a/ui/src/app/tasks/tasks.service.spec.ts
+++ b/ui/src/app/tasks/tasks.service.spec.ts
@@ -79,4 +79,48 @@ describe('TasksService', () => {
     });
   });
 
+  describe('getExecutions', () => {
+    it('should call the executions service with the right url [no sort params]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      // params.append('type', 'task');
+
+      this.tasksService.getExecutions();
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/executions', { search: params });
+    });
+
+    it('should call the executions service with the right url [null sort params]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      this.tasksService.getExecutions(null, null, null, null, null);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/executions', { search: params });
+    });
+
+    it('should call the executions service with the right url [desc desc desc asc desc sort]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const tocheck = params;
+      tocheck.append('sort', 'START_TIME,DESC');
+      tocheck.append('sort', 'END_TIME,DESC');
+      tocheck.append('sort', 'EXIT_CODE,DESC');
+      tocheck.append('sort', 'TASK_EXECUTION_ID,ASC');
+      tocheck.append('sort', 'TASK_NAME,DESC');
+      this.tasksService.getExecutions(false, true, true, true, true);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/executions', { search: tocheck });
+    });
+
+    it('should call the executions service with the right url [asc asc asc desc asc sort]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const tocheck = params;
+      tocheck.append('sort', 'START_TIME,ASC');
+      tocheck.append('sort', 'END_TIME,ASC');
+      tocheck.append('sort', 'EXIT_CODE,ASC');
+      tocheck.append('sort', 'TASK_EXECUTION_ID,DESC');
+      tocheck.append('sort', 'TASK_NAME,ASC');
+      this.tasksService.getExecutions(true, false, false, false, false);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/tasks/executions', { search: tocheck });
+    });
+  });
 });

--- a/ui/src/app/tasks/tasks.service.ts
+++ b/ui/src/app/tasks/tasks.service.ts
@@ -31,10 +31,62 @@ export class TasksService {
     this.appRegistrations = new Page<AppRegistration>();
   }
 
-  getExecutions(): Observable<Page<TaskExecution>> {
+  /**
+   * Calls the Spring Cloud Data Flow server to get paged task executions specified in {@link TaskExecution}.
+   *
+   * If sort order is defined as true, desc order is used and if false, as order is used.
+   * If method is called without parameter or as null, sort properties are not added
+   * to the request.
+   *
+   * @param {boolean} executionIdSort the sort for TASK_EXECUTION_ID
+   * @param {boolean} taskNameSort the sort for TASK_NAME
+   * @param {boolean} startTimeSort the sort for START_TIME
+   * @param {boolean} endTimeSort the sort for END_TIME
+   * @param {boolean} exitCodeSort the sort for EXIT_CODE
+   * @returns {Observable<Page<TaskExecution>>} that will call the subscribed funtions to handle
+   * the results when returned from the Spring Cloud Data Flow server.
+   */
+  getExecutions(executionIdSort?: boolean, taskNameSort?: boolean, startTimeSort?: boolean, endTimeSort?: boolean,
+      exitCodeSort?: boolean): Observable<Page<TaskExecution>> {
     const params = new URLSearchParams();
     params.append('page', this.taskExecutions.pageNumber.toString());
     params.append('size', this.taskExecutions.pageSize.toString());
+
+    if (startTimeSort != null) {
+      if (startTimeSort) {
+        params.append('sort', 'START_TIME,DESC');
+      } else {
+        params.append('sort', 'START_TIME,ASC');
+      }
+    }
+    if (endTimeSort != null) {
+      if (endTimeSort) {
+        params.append('sort', 'END_TIME,DESC');
+      } else {
+        params.append('sort', 'END_TIME,ASC');
+      }
+    }
+    if (exitCodeSort != null) {
+      if (exitCodeSort) {
+        params.append('sort', 'EXIT_CODE,DESC');
+      } else {
+        params.append('sort', 'EXIT_CODE,ASC');
+      }
+    }
+    if (executionIdSort != null) {
+      if (executionIdSort) {
+        params.append('sort', 'TASK_EXECUTION_ID,DESC');
+      } else {
+        params.append('sort', 'TASK_EXECUTION_ID,ASC');
+      }
+    }
+    if (taskNameSort != null) {
+      if (taskNameSort) {
+        params.append('sort', 'TASK_NAME,DESC');
+      } else {
+        params.append('sort', 'TASK_NAME,ASC');
+      }
+    }
 
     if (this.taskExecutions.filter && this.taskExecutions.filter.length > 0) {
       params.append('search', this.taskExecutions.filter);


### PR DESCRIPTION
- Keep sorting states for start time, end time,
  exit code, execution id and task name which are
  added to request in this order.
- Fixes #377