### PR TITLE
Add sorting to stream definitions table

### DIFF
--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.html
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.html
@@ -33,8 +33,8 @@
   <thead>
     <tr>
       <th style="width: 20px"></th>
-      <th style="width: 70px" table-sort sort-property="['DEFINITION_NAME', 'DEFINITION']" sort-state="pageable" sort-order-change-handler="sortChanged">Name</th>
-      <th style="width: 130px" table-sort sort-property="['DEFINITION','DEFINITION_NAME']"  sort-state="pageable" sort-order-change-handler="sortChanged">Definition</th>
+      <th style="width: 70px"><a (click)="toggleDefinitionNameSort()"><span style="margin-right: 5px">Name</span></a><i class="fa" [ngClass]="{'fa-sort': definitionNameSort === undefined, 'fa-sort-asc': definitionNameSort === false, 'fa-sort-desc': definitionNameSort === true }" aria-hidden="true"></i></th>
+      <th style="width: 300px"><a (click)="toggleDefinitionSort()"><span style="margin-right: 5px">Definitions</span></a><i class="fa" [ngClass]="{'fa-sort': definitionSort === undefined, 'fa-sort-asc': definitionSort === false, 'fa-sort-desc': definitionSort === true }" aria-hidden="true"></i></th>
       <th style="width: 50px">Status
         <a #childPopover="bs-popover"
         [popover]="popTemplate"

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.ts
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.ts
@@ -28,6 +28,8 @@ export class StreamDefinitionsComponent implements OnInit {
   streamDefinitions: Page<StreamDefinition>;
   streamDefinitionToDestroy: StreamDefinition;
   busy: Subscription;
+  definitionNameSort: boolean = undefined;
+  definitionSort: boolean = undefined;
 
   @ViewChild('childPopover')
   public childPopover: PopoverDirective;
@@ -54,7 +56,7 @@ export class StreamDefinitionsComponent implements OnInit {
   loadStreamDefinitions() {
     console.log('Loading Stream Definitions...', this.streamDefinitions);
 
-    this.busy = this.streamsService.getDefinitions().subscribe(
+    this.busy = this.streamsService.getDefinitions(this.definitionNameSort, this.definitionSort).subscribe(
       data => {
         this.streamDefinitions = data;
         this.toastyService.success('Stream definitions loaded.');
@@ -116,6 +118,34 @@ export class StreamDefinitionsComponent implements OnInit {
   destroy(item: StreamDefinition) {
     this.streamDefinitionToDestroy = item;
     this.showChildModal();
+  }
+
+  /**
+   * Toggles definition name sort and updates table.
+   */
+  toggleDefinitionNameSort() {
+    if (this.definitionNameSort === undefined) {
+      this.definitionNameSort = true;
+    } else if (this.definitionNameSort) {
+      this.definitionNameSort = false;
+    } else {
+      this.definitionNameSort = undefined;
+    }
+    this.loadStreamDefinitions();
+  }
+
+  /**
+   * Toggles definition sort and updates table.
+   */
+  toggleDefinitionSort() {
+    if (this.definitionSort === undefined) {
+      this.definitionSort = true;
+    } else if (this.definitionSort) {
+      this.definitionSort = false;
+    } else {
+      this.definitionSort = undefined;
+    }
+    this.loadStreamDefinitions();
   }
 
   /**

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -43,6 +43,43 @@ describe('StreamsService', () => {
       expect(this.streamsService.streamDefinitions.filter).toBe('testFilter');
       expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', {search: params});
     });
+
+    it('should call the definitions service with the right url [no sort params]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      // params.append('type', 'task');
+
+      this.streamsService.getDefinitions();
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: params });
+    });
+
+    it('should call the definitions service with the right url [null sort params]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      this.streamsService.getDefinitions(null, null);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: params });
+    });
+
+    it('should call the definitions service with the right url [desc asc sort]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const tocheck = params;
+      tocheck.append('sort', 'DEFINITION,ASC');
+      tocheck.append('sort', 'DEFINITION_NAME,DESC');
+      this.streamsService.getDefinitions(true, false);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: tocheck });
+    });
+
+    it('should call the definitions service with the right url [asc desc sort]', () => {
+      this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
+      const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const tocheck = params;
+      tocheck.append('sort', 'DEFINITION,DESC');
+      tocheck.append('sort', 'DEFINITION_NAME,ASC');
+      this.streamsService.getDefinitions(false, true);
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: tocheck });
+    });
   });
 
   describe('destroyDefinition', () => {

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -37,10 +37,13 @@ export class StreamsService {
 
   /**
    * Retrieves the {@link StreamDefinition}s based on the page requested.
+   *
+   * @param definitionNameSort the sort for DEFINITION_NAME
+   * @param definitionSort the sort for DEFINITION
    * @returns {Observable<R|T>} that will call the subscribed funtions to handle
    * the results when returned from the Spring Cloud Data Flow server.
    */
-  getDefinitions(): Observable<Page<StreamDefinition>> {
+  getDefinitions(definitionNameSort?: boolean, definitionSort?: boolean): Observable<Page<StreamDefinition>> {
 
     console.log('Getting paged stream definitions', this.streamDefinitions);
     console.log(this.streamDefinitions.getPaginationInstance());
@@ -49,8 +52,21 @@ export class StreamsService {
       this.streamDefinitions.pageNumber,
       this.streamDefinitions.pageSize
     );
-      // TODO Implement Sorting
-      // params.sort = pageable.calculateSortParameter();
+
+    if (definitionSort != null) {
+      if (definitionSort) {
+        params.append('sort', 'DEFINITION,DESC');
+      } else {
+        params.append('sort', 'DEFINITION,ASC');
+      }
+    }
+    if (definitionNameSort != null) {
+      if (definitionNameSort) {
+        params.append('sort', 'DEFINITION_NAME,DESC');
+      } else {
+        params.append('sort', 'DEFINITION_NAME,ASC');
+      }
+    }
 
       // if (pageable.filterQuery && pageable.filterQuery.trim().length > 0) {
       //   params.search = pageable.filterQuery;


### PR DESCRIPTION
- Keep sorting states for definition and name
  which are added to request in this order.
- Fixes #385