### PR TITLE
[POC DO NOT MERGE] ngrx/store for tasks definitions page

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,8 @@
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
+    "@ngrx/store": "^4.0.0",
+    "@ngrx/effects": "^4.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.4.2",
     "zone.js": "^0.8.14",

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,6 +1,8 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RequestOptions } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
 import { SecurityAwareRequestOptions } from './auth/support/security-aware-request-options';
 
 /* Feature Modules */
@@ -20,6 +22,7 @@ import { BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 import { AuthService } from './auth/auth.service';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { reducers } from "./store/app-reducer";
 
 /**
  * Executed when the app starts up. Will load the security
@@ -52,7 +55,9 @@ export function init(authService: AuthService) {
     SharedModule,
     StreamsModule,
     TasksModule,
-    BsDropdownModule.forRoot()
+    BsDropdownModule.forRoot(),
+    StoreModule.forRoot(reducers),
+    EffectsModule.forRoot([])
   ],
   providers: [
     {

--- a/ui/src/app/store/app-reducer.ts
+++ b/ui/src/app/store/app-reducer.ts
@@ -1,0 +1,16 @@
+import { ActionReducerMap } from '@ngrx/store';
+
+/**
+ * Top level state interface is just a map of keys to inner state types
+ * and optional root app state i.e. navigation and toasts(not yet implemented).
+ */
+export interface AppState {
+}
+
+/**
+ * Our state is composed of a map of action reducer functions.
+ * These reducer functions are called with each dispatched action
+ * and the current or initial state and return a new immutable state.
+ */
+export const reducers: ActionReducerMap<AppState> = {
+};

--- a/ui/src/app/tasks/store/definitions-effects.ts
+++ b/ui/src/app/tasks/store/definitions-effects.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Actions, Effect } from '@ngrx/effects';
+import { Observable } from 'rxjs/Observable';
+import {
+  TASK_DEFINITIONS_FILTER, TASK_DEFINITIONS_FILTER_DEBOUNCE, TASK_DEFINITIONS_PAGE, TASK_DEFINITIONS_RESET,
+  TASK_DEFINITIONS_SORT, TASK_DEFINITIONS_UPDATE, TaskDefinitionsFilterAction, TaskDefinitionsFilterDebounceAction,
+  TaskDefinitionsLoadedAction
+} from './tasks-actions';
+import { TasksService } from '../tasks.service';
+import { getTaskDefinitionsState, TasksState } from './tasks-reducer';
+
+@Injectable()
+export class DefinitionsEffects {
+
+  /**
+   * Effect which debounces given input filter strings
+   * and passes new actual action for filter.
+   *
+   * @type {Observable<TaskDefinitionsFilterAction>}
+   */
+  @Effect() filterdebounce$: Observable<TaskDefinitionsFilterAction> = this.actions
+    .ofType<TaskDefinitionsFilterDebounceAction>(TASK_DEFINITIONS_FILTER_DEBOUNCE)
+    // debounce raw inputs for not every key stroke
+    // causing update
+    .debounceTime(500)
+    // then return new action to cause filtering
+    .map(action => new TaskDefinitionsFilterAction(action.payload));
+
+  /**
+   * Effect which is used to listen all other related actions
+   * and result a call to backend tasks service to update definitions.
+   *
+   * @type {Observable<TaskDefinitionsLoadedAction>}
+   */
+  @Effect() load$: Observable<TaskDefinitionsLoadedAction> = this.actions
+    .ofType<TaskDefinitionsFilterDebounceAction>(TASK_DEFINITIONS_FILTER, TASK_DEFINITIONS_PAGE, TASK_DEFINITIONS_SORT,
+      TASK_DEFINITIONS_UPDATE, TASK_DEFINITIONS_RESET)
+    // compine action(which we don't use) with selector from
+    // store having needed stuff for definitions state needed
+    // to talk with tasks service.
+    .withLatestFrom(this.store.select(getTaskDefinitionsState))
+    // switch map to observable from service
+    .switchMap(([action, state]) => this.tasksService.getDefinitions(state.sort['DEFINITION_NAME'],
+      state.sort['DEFINITION'], state.page, 10, state.filter))
+    // return paged definitions
+    .map(definitions => new TaskDefinitionsLoadedAction(definitions));
+
+  constructor(private actions: Actions, private tasksService: TasksService, private store: Store<TasksState>) {
+  }
+}

--- a/ui/src/app/tasks/store/tasks-actions.ts
+++ b/ui/src/app/tasks/store/tasks-actions.ts
@@ -1,0 +1,91 @@
+import { Action } from '@ngrx/store';
+import { Page } from '../../shared/model/page';
+import { TaskDefinition } from '../model/task-definition';
+
+// constants identifying actions types
+export const TASK_DEFINITIONS_FILTER = 'tasks:definitions:filter';
+export const TASK_DEFINITIONS_FILTER_DEBOUNCE = 'tasks:definitions:filter:debounce';
+export const TASK_DEFINITIONS_PAGE = 'tasks:definitions:page';
+export const TASK_DEFINITIONS_SORT = 'tasks:definitions:sort';
+export const TASK_DEFINITIONS_LOADED = 'tasks:definitions:loaded';
+export const TASK_DEFINITIONS_UPDATE = 'tasks:definitions:update';
+export const TASK_DEFINITIONS_RESET = 'tasks:definitions:reset';
+
+/**
+ * Action indicating that tasks definitions should be updated.
+ */
+export class TaskDefinitionsUpdateAction implements Action {
+  readonly type = TASK_DEFINITIONS_UPDATE;
+}
+
+/**
+ * Action indicating that tasks definitions filter
+ * and sorting is reseted.
+ */
+export class TaskDefinitionsResetAction implements Action {
+  readonly type = TASK_DEFINITIONS_RESET;
+}
+
+/**
+ * Action which sends raw filter string similar to
+ * TaskDefinitionsFilterAction except we use different action
+ * for effect to able to debounce.
+ */
+export class TaskDefinitionsFilterDebounceAction implements Action {
+  readonly type = TASK_DEFINITIONS_FILTER_DEBOUNCE;
+
+  constructor(public payload: string) {
+  }
+}
+
+/**
+ * Action which sends filter string.
+ */
+export class TaskDefinitionsFilterAction implements Action {
+  readonly type = TASK_DEFINITIONS_FILTER;
+
+  constructor(public payload: string) {
+  }
+}
+
+/**
+ * Action notifying new page number.
+ */
+export class TaskDefinitionsPageAction implements Action {
+  readonly type = TASK_DEFINITIONS_PAGE;
+
+  constructor(public page: number) {
+  }
+}
+
+/**
+ * Action notifying new sort field.
+ */
+export class TaskDefinitionsSortAction implements Action {
+  readonly type = TASK_DEFINITIONS_SORT;
+
+  constructor(public id: string) {
+  }
+}
+
+/**
+ * Action notifying new loaded task definitions.
+ */
+export class TaskDefinitionsLoadedAction implements Action {
+  readonly type = TASK_DEFINITIONS_LOADED;
+
+  constructor(public items: Page<TaskDefinition>) {
+  }
+}
+
+/**
+ * Type having all supported actions.
+ */
+export type Actions =
+  TaskDefinitionsFilterAction
+  | TaskDefinitionsFilterDebounceAction
+  | TaskDefinitionsPageAction
+  | TaskDefinitionsSortAction
+  | TaskDefinitionsLoadedAction
+  | TaskDefinitionsUpdateAction
+  | TaskDefinitionsResetAction;

--- a/ui/src/app/tasks/store/tasks-reducer.ts
+++ b/ui/src/app/tasks/store/tasks-reducer.ts
@@ -1,0 +1,190 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import {
+  Actions, TASK_DEFINITIONS_FILTER, TASK_DEFINITIONS_FILTER_DEBOUNCE, TASK_DEFINITIONS_LOADED, TASK_DEFINITIONS_PAGE,
+  TASK_DEFINITIONS_RESET,
+  TASK_DEFINITIONS_SORT, TASK_DEFINITIONS_UPDATE
+} from './tasks-actions';
+import { AppState } from '../../store/app-reducer';
+import {Page} from "../../shared/model/page";
+import {TaskDefinition} from "../model/task-definition";
+
+/**
+ * Main tasks state keeping its sub-feature states.
+ */
+export interface TasksState extends AppState {
+  definitions: TaskDefinitionsState;
+}
+
+/**
+ * State keeping related information about
+ * tasks definitions page.
+ */
+export interface TaskDefinitionsState {
+  filter: string;
+  page: number;
+  sort: { [id: string]: boolean };
+  items: Page<TaskDefinition>;
+}
+
+/**
+ * Initial state for TaskDefinitionsState.
+ *
+ * @type {{filter: string; page: number; sort: {}}}
+ */
+const initialState: TaskDefinitionsState = {
+  filter: '',
+  page: 0,
+  sort: {},
+  items: undefined
+};
+
+export function DefinitionsReducer(state: TaskDefinitionsState, action: Actions): TaskDefinitionsState {
+  switch (action.type) {
+    case TASK_DEFINITIONS_UPDATE:
+      // in terms of state same as debounce but update
+      // is just causing load in effect
+    case TASK_DEFINITIONS_FILTER_DEBOUNCE:
+      // return state as is for state not to change
+      // effect will debounce and cause TaskDefinitionsFilterAction
+      return state;
+    case TASK_DEFINITIONS_FILTER:
+      // simply update filter field
+      return Object.assign({}, state, {
+        filter: action.payload
+      });
+    case TASK_DEFINITIONS_PAGE:
+      // simply update page number field
+      return Object.assign({}, state, {
+        page: action.page
+      });
+    case TASK_DEFINITIONS_SORT:
+      // depending on arbitrary field flip its status
+      let sortState = state.sort[action.id];
+      if (sortState === undefined) {
+        sortState = true;
+      } else if (sortState) {
+        sortState = false;
+      } else {
+        sortState = undefined;
+      }
+      return Object.assign({}, state, {
+        sort: Object.assign({}, state.sort, {[action.id]: sortState})
+      });
+    case TASK_DEFINITIONS_LOADED:
+      // we get items to show, so update that field
+      return Object.assign({}, state, {
+        items: action.items
+      });
+    case TASK_DEFINITIONS_RESET:
+      // reset filter and sort
+      return Object.assign({}, state, {
+        filter: '',
+        sort: {}
+      });
+    default:
+      // just need to have some initial state
+      return initialState;
+  }
+}
+
+export const reducers = {
+  definitions: DefinitionsReducer
+};
+
+/**
+ * Main tasks feature selector.
+ *
+ * @type {MemoizedSelector<Object, TasksState>}
+ */
+export const getTasksState = createFeatureSelector<TasksState>('tasks');
+
+/**
+ * Get filter from task definition state.
+ *
+ * @param {TaskDefinitionsState} state
+ */
+export const getFilter = (state: TaskDefinitionsState) => state.filter;
+
+/**
+ * Get page number from task definition state.
+ *
+ * @param {TaskDefinitionsState} state
+ */
+export const getPage = (state: TaskDefinitionsState) => state.page;
+
+/**
+ * Get sort from task definition state.
+ *
+ * @param {TaskDefinitionsState} state
+ */
+export const getSort = (state: TaskDefinitionsState) => state.sort;
+
+/**
+ * Get paged items from task definition state.
+ *
+ * @param {TaskDefinitionsState} state
+ */
+export const getItems = (state: TaskDefinitionsState) => state.items;
+
+/**
+ * Get pagination instance from task definition state. If this is not
+ * yet initialised then return undefined.
+ *
+ * @param {TaskDefinitionsState} state
+ * @returns {PaginationInstance}
+ */
+export const getPaginationInstance = (state: TaskDefinitionsState) => {
+  if (state.items) {
+    return state.items.getPaginationInstance();
+  }
+};
+
+/**
+ * Create selector from tasks selecting tasks definition state.
+ *
+ * @type {MemoizedSelector<Object, TaskDefinitionsState>}
+ */
+export const getTaskDefinitionsState = createSelector(
+  getTasksState,
+  (state: TasksState) => state.definitions
+);
+
+/**
+ * Create selector from tasks selecting filter string.
+ *
+ * @type {MemoizedSelector<Object, string>}
+ */
+export const getTaskDefinitionsFilter = createSelector(
+  getTaskDefinitionsState,
+  getFilter
+);
+
+/**
+ * Create selector from tasks selecting paged tasks definitions.
+ *
+ * @type {MemoizedSelector<Object, Page<TaskDefinition>>}
+ */
+export const getTaskDefinitions = createSelector(
+  getTaskDefinitionsState,
+  getItems
+);
+
+/**
+ * Create selector from tasks selecting pagination instance.
+ *
+ * @type {MemoizedSelector<Object, PaginationInstance>}
+ */
+export const getTaskDefinitionsPaginationInstance = createSelector(
+  getTaskDefinitionsState,
+  getPaginationInstance
+);
+
+/**
+ * Create selector from tasks selecting map of sorting states.
+ *
+ * @type {MemoizedSelector<Object, {[p: string]: boolean}>}
+ */
+export const getTaskDefinitionsSort = createSelector(
+  getTaskDefinitionsState,
+  getSort
+);

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -11,20 +11,23 @@
             </button>
           </td>
           <td>
-            <label *ngIf="taskDefinitions" class="control">Filter Task Definitions
-              <input type="text" class="input" placeholder="Filter definitions" [(ngModel)]="taskDefinitions.filter">
+            <label class="control">Filter Task Definitions
+              <input type="text" class="input" placeholder="Filter definitions" (keyup)="filter($event.target.value)" [(ngModel)]="definitionFilter" >
             </label>
-            <button *ngIf="taskDefinitions" type="button" (click)="loadTaskDefinitions()"
+            <button type="button" (click)="loadTaskDefinitions()"
                     class="btn btn-default">
               <span class="glyphicon glyphicon-refresh"></span></button>
+            <button type="button" (click)="reset()"
+                    class="btn btn-default">
+              <span class="glyphicon glyphicon-erase"></span></button>
           </td>
         </tr>
       </table>
     </div>
   </div>
 </div>
-<div *ngIf="!taskDefinitions">No tasks available.</div>
-<table *ngIf="taskDefinitions?.items" class="table table-hover">
+
+<table class="table table-hover">
   <thead>
   <tr>
     <th style="width: 70px"><a (click)="toggleDefinitionNameSort()"><span style="margin-right: 5px">Name</span></a><i class="fa" [ngClass]="{'fa-sort': definitionNameSort === undefined, 'fa-sort-asc': definitionNameSort === false, 'fa-sort-desc': definitionNameSort === true }" aria-hidden="true"></i></th>
@@ -34,7 +37,7 @@
   </thead>
 
   <tbody>
-  <ng-template ngFor let-item [ngForOf]="taskDefinitions.items | paginate: taskDefinitions.getPaginationInstance()">
+  <ng-template ngFor let-item [ngForOf]="(taskDefinitions | async)?.items | paginate: paginationInstance">
     <tr>
       <td>{{item.name}}</td>
       <td>{{item.dslText}}</td>
@@ -54,7 +57,7 @@
   </ng-template>
   </tbody>
 </table>
-<pagination-controls *ngIf="taskDefinitions?.items" (pageChange)="getPage($event)" [id]="taskDefinitions.getPaginationInstance().id"></pagination-controls>
+<pagination-controls (pageChange)="getPage($event)"></pagination-controls>
 
 <div bsModal #childModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-sm">

--- a/ui/src/app/tasks/tasks.module.ts
+++ b/ui/src/app/tasks/tasks.module.ts
@@ -1,4 +1,6 @@
 import { NgModule } from '@angular/core';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
 import { SharedModule } from '../shared/shared.module';
 import { NgxPaginationModule } from 'ngx-pagination';
 
@@ -17,6 +19,8 @@ import { TasksRoutingModule } from './tasks-routing.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ModalModule, PopoverModule } from 'ngx-bootstrap';
 import { AuthModule } from '../auth/auth.module';
+import { reducers } from './store/tasks-reducer';
+import { DefinitionsEffects } from './store/definitions-effects';
 
 @NgModule({
   imports: [
@@ -26,7 +30,9 @@ import { AuthModule } from '../auth/auth.module';
     ReactiveFormsModule,
     ModalModule.forRoot(),
     PopoverModule.forRoot(),
-    AuthModule
+    AuthModule,
+    StoreModule.forFeature('tasks', reducers),
+    EffectsModule.forFeature([DefinitionsEffects])
   ],
   declarations: [
     TasksComponent,


### PR DESCRIPTION
- You need to `npm update` due changes in package.json.
- Play with filtering, paging and sorting, go back to other tab
  and come back to definitions tab. State should be restored.
- Some good resources:
  https://github.com/ngrx/platform/blob/master/docs/store/README.md
  https://github.com/ngrx/platform/tree/master/example-app
  https://www.sitepoint.com/managing-state-angular-2-ngrx
- Showing concept of using ngrx store to keep global hierachical
  states with impl of state for tasks definitions page.
- State for filter, sorting and pagination are kept in store
  so that when you nagivate out from a page and go back,
  state is restored.
- Pagination state removed from TasksService.
- Adding ngrx store, recusers, actions and effects.
- Whole state for tasks definitions are kept in store
  and asynchronously selected from there and updated
  into a page structure.
- There are different action to send raw inputs for filter,
  bounce that filter action, sorts, paging, update and reset.
- As a simple POC, doesn't address tests!