### PR TITLE
Validate against duplicate stream names on the form

### DIFF
--- a/ui/src/app/streams/flo/support/utils.spec.ts
+++ b/ui/src/app/streams/flo/support/utils.spec.ts
@@ -139,4 +139,19 @@ describe('utils', () => {
     expect(Utils.generateStreamName(graph, http)).toEqual('unique-name');
   });
 
+  it('find duplicates: no elements', () => {
+    expect(Utils.findDuplicates([])).toEqual([]);
+  });
+
+  it('find duplicates: no duplicates', () => {
+    expect(Utils.findDuplicates(['1', '2', '3'])).toEqual([]);
+  });
+
+  it('find duplicates: multiple duplicates', () => {
+    expect(Utils.findDuplicates(['1', '2', '1', '3', '2'])).toEqual(['2', '1']);
+  });
+
+  it('find duplicates: multiple duplicates numbers', () => {
+    expect(Utils.findDuplicates([1, 2, 1, 3, 2])).toEqual([2, 1]);
+  });
 });

--- a/ui/src/app/streams/flo/support/utils.ts
+++ b/ui/src/app/streams/flo/support/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { dia } from 'jointjs';
+import {dia} from 'jointjs';
 
 /**
  * Utilities for Flo based Stream Definition graph editor.
@@ -23,37 +23,53 @@ import { dia } from 'jointjs';
  */
 export class Utils {
 
-     static canBeHeadOfStream(graph: dia.Graph, element: dia.Element): boolean {
-       if (element.attr('metadata')) {
-         if (!element.attr('.input-port') || element.attr('.input-port/display') === 'none') {
-           return true;
-         } else {
-           const incoming = graph.getConnectedLinks(element, { inbound: true });
-           const tapLink = incoming.find(l => l.attr('props/isTapLink'));
-           if (tapLink) {
-             return true;
-           }
-         }
-       }
-       return false;
+  static canBeHeadOfStream(graph: dia.Graph, element: dia.Element): boolean {
+    if (element.attr('metadata')) {
+      if (!element.attr('.input-port') || element.attr('.input-port/display') === 'none') {
+        return true;
+      } else {
+        const incoming = graph.getConnectedLinks(element, {inbound: true});
+        const tapLink = incoming.find(l => l.attr('props/isTapLink'));
+        if (tapLink) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static generateStreamName(graph: dia.Graph, element: dia.Element) {
+    const streamNames: Array<string> = graph.getElements()
+      .filter(e => element !== e && e.attr('stream-name') && this.canBeHeadOfStream(graph, e))
+      .map(e => e.attr('stream-name'));
+
+    // Check if current element stream name is unique
+    if (element && element.attr('stream-name') && streamNames.indexOf(element.attr('stream-name')) === -1) {
+      return element.attr('stream-name');
     }
 
-    static generateStreamName(graph: dia.Graph, element: dia.Element) {
-        const streamNames: Array<string> = graph.getElements()
-            .filter(e => element !== e && e.attr('stream-name') && this.canBeHeadOfStream(graph, e))
-            .map(e => e.attr('stream-name'));
-
-        // Check if current element stream name is unique
-        if (element && element.attr('stream-name') && streamNames.indexOf(element.attr('stream-name')) === -1) {
-            return element.attr('stream-name');
-        }
-
-        const name = 'STREAM_';
-        let index = 1;
-        while (streamNames.indexOf(name + index) >= 0) {
-            index++;
-        }
-        return name + index;
+    const name = 'STREAM_';
+    let index = 1;
+    while (streamNames.indexOf(name + index) >= 0) {
+      index++;
     }
+    return name + index;
+  }
+
+  static findDuplicates<T>(elements: T[]): T[] {
+    const duplicates: T[] = [];
+    while (elements.length !== 0) {
+      const e = elements.pop();
+      let idx = elements.indexOf(e);
+      if (idx >= 0) {
+        duplicates.push(e);
+      }
+      while (idx >= 0) {
+        elements.splice(idx, 1);
+        idx = elements.indexOf(e);
+      }
+    }
+    return duplicates;
+  }
 
 }

--- a/ui/src/app/streams/stream-create/stream-create-dialog.component.html
+++ b/ui/src/app/streams/stream-create/stream-create-dialog.component.html
@@ -7,8 +7,7 @@
 <div class="modal-body" [formGroup]="form">
   <div *ngIf="errors && errors.length > 0" class="dialog-validation">
     <div *ngFor="let error of errors">
-      <label class="glyphicon glyphicon-exclamation-sign dialog-error-sign"></label>
-      <label>{{error}}</label>
+      <label class="glyphicon glyphicon-exclamation-sign dialog-error-sign">{{error}}</label>
     </div>
   </div>
   <div *ngIf="!(errors && errors.length) && warnings && warnings.length > 0" class="dialog-validation">
@@ -18,30 +17,36 @@
     </div>
   </div>
   <p>This action will create stream(s):</p>
-  <table class="table table-striped table-hover table-fixed table-compact">
-    <!--<col width="300px"/>-->
-    <!--<col width="auto"/>-->
-    <tbody>
-      <tr *ngFor="let def of streamDefsToCreate()" [ngClass]="{'has-warning': !getControl(def.index.toString()).valid}">
-        <td>
-          <input [disabled]="isStreamCreationInProgress()" class="form-control" [id]="def.index.toString()" [name]="def.index.toString()" [formControlName]="def.index.toString()"
-                 type="text" placeholder="<Stream Name>" [ngModel]="def.name" (ngModelChange)="changeStreamName(def.index, $event)"/>
-          <p *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.required" class="help-block validation-block">Stream name is required!</p>
-          <p *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.uniqueResource" class="help-block validation-block">Stream name is already taken!</p>
-          <p *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.pattern" class="help-block validation-block">Invalid stream name!</p>
-          <!--<p *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.uniqueFieldValues" class="help-block validation-block">Duplicate stream name on the form!</p>-->
-        </td>
-        <td>
-          <label class="control-label">{{def.def}}</label>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <label class="dialog-control"><input [disabled]="isStreamCreationInProgress()" type="checkbox" [(ngModel)]="deploy" [ngModelOptions]="{standalone: true}"/>Deploy stream(s)</label>
+  <tbody>
+    <tr *ngFor="let def of streamDefsToCreate()" [ngClass]="{'has-warning': invalidStreamRow(def)}">
+      <td class="stream-name-form-control-cell">
+        <input [disabled]="isStreamCreationInProgress()" class="form-control" [id]="def.index.toString()"
+               [name]="def.index.toString()" [formControlName]="def.index.toString()"
+               type="text" placeholder="<Stream Name>" [ngModel]="def.name"
+               (ngModelChange)="changeStreamName(def.index, $event)"/>
+        <p>
+          <span *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.required"
+             class="help-block validation-block">Stream name is required!</span>
+          <span *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.uniqueResource"
+             class="help-block validation-block">Stream name is already taken!</span>
+          <span *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.pattern"
+             class="help-block validation-block">Invalid stream name!</span>
+          <span *ngIf="hasDuplicateName(def)"
+             class="help-block validation-block">Duplicate stream name on the form</span>
+        </p>
+      </td>
+      <td class="stream-definition-label-cell">
+        <label class="control-label">{{def.def}}</label>
+      </td>
+    </tr>
+  </tbody>
+  <label class="dialog-control"><input [disabled]="isStreamCreationInProgress()" type="checkbox" [(ngModel)]="deploy"
+                                       [ngModelOptions]="{standalone: true}"/>Deploy stream(s)</label>
   <div *ngIf="progressData">
     <hr/>
     <div>Creating Streams...</div>
-    <progressbar animate="true" [value]="progressData.percent" type="success"><b>{{progressData.percent}}%</b></progressbar>
+    <progressbar animate="true" [value]="progressData.percent" type="success"><b>{{progressData.percent}}%</b>
+    </progressbar>
   </div>
 </div>
 <div class="modal-footer">

--- a/ui/src/app/streams/stream-create/stream-create-dialog.component.scss
+++ b/ui/src/app/streams/stream-create/stream-create-dialog.component.scss
@@ -1,0 +1,25 @@
+.modal-body {
+  tbody {
+    width: 100%;
+    display: inline-table;
+  }
+  tr {
+    width: 100%;
+    display: inline-table;
+  }
+  .stream-definition-label-cell {
+    vertical-align: top;
+    padding: 4px 8px;
+  }
+  .stream-name-form-control-cell {
+    width: 50%;
+  }
+  .dialog-error-sign {
+    color: red;
+  }
+  .dialog-validation {
+    margin-bottom: 4px;
+    font-size: smaller;
+    line-height: 1em;
+  }
+}


### PR DESCRIPTION
Validate against duplicate names on the form

Fixes #402 

If "Create stream dialog" has duplicate stream names on the from validation error should be displayed under the form controls having duplicate names