### PR TITLE
gh-455 Fix: Stream fails to deploy with security enabled

### DIFF
--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -3,7 +3,7 @@ import {StreamsService} from './streams.service';
 import {Observable} from 'rxjs/Observable';
 import {HttpUtils} from '../shared/support/http.utils';
 import {StreamDefinition} from './model/stream-definition';
-import {Headers, RequestOptions} from '@angular/http';
+import {Headers, RequestOptions, URLSearchParams} from '@angular/http';
 import {MockResponse} from '../tests/mocks/response';
 import {STREAM_DEFINITIONS} from '../tests/mocks/mock-data';
 
@@ -28,56 +28,62 @@ describe('StreamsService', () => {
       expect(this.streamsService.streamDefinitions).toBeDefined();
 
       const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
-
-      this.streamsService.getDefinitions();
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      requestOptionsArgs.search = params;
+      this.streamsService.getDefinitions()  ;
 
       const defaultPageNumber: number = this.streamsService.streamDefinitions.pageNumber;
       const defaultPageSize: number = this.streamsService.streamDefinitions.pageSize;
 
       expect(defaultPageNumber).toBe(0);
       expect(defaultPageSize).toBe(10);
-      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', {search: params});
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', requestOptionsArgs);
 
       this.streamsService.streamDefinitions.filter = 'testFilter';
       this.streamsService.getDefinitions();
       expect(this.streamsService.streamDefinitions.filter).toBe('testFilter');
-      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', {search: params});
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', requestOptionsArgs);
     });
 
     it('should call the definitions service with the right url [no sort params]', () => {
       this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
 
       const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
-
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      requestOptionsArgs.search = params;
       this.streamsService.getDefinitions();
-      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: params });
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', requestOptionsArgs);
     });
 
     it('should call the definitions service with the right url [null sort params]', () => {
       this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
       const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      requestOptionsArgs.search = params;
       this.streamsService.getDefinitions(undefined, undefined);
-      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: params });
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', requestOptionsArgs);
     });
 
     it('should call the definitions service with the right url [desc asc sort]', () => {
       this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
       const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
-      const tocheck = params;
-      tocheck.append('sort', 'DEFINITION,ASC');
-      tocheck.append('sort', 'DEFINITION_NAME,DESC');
+      params.append('sort', 'DEFINITION,ASC');
+      params.append('sort', 'DEFINITION_NAME,DESC');
       this.streamsService.getDefinitions(true, false);
-      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: tocheck });
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      requestOptionsArgs.search = params;
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', requestOptionsArgs);
     });
 
     it('should call the definitions service with the right url [asc desc sort]', () => {
       this.mockHttp.get.and.returnValue(Observable.of(this.jsonData));
       const params: URLSearchParams = HttpUtils.getPaginationParams(0, 10);
-      const tocheck = params;
-      tocheck.append('sort', 'DEFINITION,DESC');
-      tocheck.append('sort', 'DEFINITION_NAME,ASC');
+      params.append('sort', 'DEFINITION,DESC');
+      params.append('sort', 'DEFINITION_NAME,ASC');
       this.streamsService.getDefinitions(false, true);
-      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', { search: tocheck });
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      requestOptionsArgs.search = params;
+      expect(this.mockHttp.get).toHaveBeenCalledWith('/streams/definitions', requestOptionsArgs);
     });
   });
 
@@ -89,9 +95,8 @@ describe('StreamsService', () => {
 
       const streamDefinition = new StreamDefinition('test', 'time|log', 'undeployed');
       this.streamsService.destroyDefinition(streamDefinition);
-      const headers = new Headers({'Content-Type': 'application/json'});
-      const options = new RequestOptions({headers: headers});
-      expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/definitions/test', options);
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/definitions/test', requestOptionsArgs);
     });
 
    describe('undeployDefinition', () => {
@@ -102,9 +107,8 @@ describe('StreamsService', () => {
 
         const streamDefinition = new StreamDefinition('test', 'time|log', 'deployed');
         this.streamsService.undeployDefinition(streamDefinition);
-        const headers = new Headers({'Content-Type': 'application/json'});
-        const options = new RequestOptions({headers: headers});
-        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/deployments/test', options);
+        const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/deployments/test', requestOptionsArgs);
       });
     });
 
@@ -115,9 +119,8 @@ describe('StreamsService', () => {
         expect(this.streamsService.streamDefinitions).toBeDefined();
 
         this.streamsService.deployDefinition('test', {});
-        const headers = new Headers({'Content-Type': 'application/json'});
-        const options = new RequestOptions({headers: headers});
-        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/test', {}, options);
+        const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/test', {}, requestOptionsArgs);
       });
     });
 

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -70,13 +70,17 @@ export class StreamsService {
     if (this.streamDefinitions.filter && this.streamDefinitions.filter.length > 0) {
       params.append('search', this.streamDefinitions.filter);
     }
-    return this.http.get(this.streamDefinitionsUrl, {search: params})
+
+    const options = HttpUtils.getDefaultRequestOptions();
+    options.params = params;
+    return this.http.get(this.streamDefinitionsUrl, options)
       .map(this.extractData.bind(this))
       .catch(this.errorHandler.handleError);
   }
 
   getDefinition(name: string): Observable<StreamDefinition> {
-    return this.http.get(`${this.streamDefinitionsUrl}/${name}`)
+    const options = HttpUtils.getDefaultRequestOptions();
+    return this.http.get(`${this.streamDefinitionsUrl}/${name}`, options)
       .map(res => {
         const json = res.json();
         return new StreamDefinition(json.name, json.dslText, json.status);
@@ -85,13 +89,15 @@ export class StreamsService {
   }
 
   createDefinition(name: string, dsl: string, deploy?: boolean): Observable<Response> {
+    const options = HttpUtils.getDefaultRequestOptions();
     const params =  new URLSearchParams('', URL_QUERY_ENCODER);
     params.append('name', name);
     params.append('definition', dsl);
     if (deploy) {
       params.set('deploy', deploy.toString());
     }
-    return this.http.post(this.streamDefinitionsUrl, null, {params: params});
+    options.search = params;
+    return this.http.post(this.streamDefinitionsUrl, null, options);
   }
 
   /**
@@ -101,8 +107,7 @@ export class StreamsService {
    */
   destroyDefinition(streamDefinition: StreamDefinition): Observable<Response> {
     console.log('Destroying...', streamDefinition);
-    const headers = new Headers({'Content-Type': 'application/json'});
-    const options = new RequestOptions({headers: headers});
+    const options = HttpUtils.getDefaultRequestOptions();
     return this.http.delete('/streams/definitions/' + streamDefinition.name, options)
       .map(data => {
         this.streamDefinitions.items = this.streamDefinitions.items.filter(item => item.name !== streamDefinition.name);
@@ -117,8 +122,7 @@ export class StreamsService {
    */
   undeployDefinition(streamDefinition: StreamDefinition): Observable<Response> {
     console.log('Undeploying...', streamDefinition);
-    const headers = new Headers({'Content-Type': 'application/json'});
-    const options = new RequestOptions({headers: headers});
+    const options = HttpUtils.getDefaultRequestOptions();
     return this.http.delete('/streams/deployments/' + streamDefinition.name, options)
       .catch(this.errorHandler.handleError);
   }
@@ -131,8 +135,7 @@ export class StreamsService {
    */
   deployDefinition(streamDefinitionName: String, propertiesAsMap: any): Observable<Response> {
     console.log('Deploying...', streamDefinitionName);
-    const headers = new Headers({'Content-Type': 'application/json'});
-    const options = new RequestOptions({headers: headers});
+    const options = HttpUtils.getDefaultRequestOptions();
     return this.http.post('/streams/deployments/' + streamDefinitionName, propertiesAsMap, options)
       .catch(this.errorHandler.handleError);
   }


### PR DESCRIPTION
- Ensure that we send the respective default headers:
  * `Content-Type`: `application/json`
  * `Accept`: `application/json`
- Fix tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/455