### PR TITLE
Revisit validation

### DIFF
--- a/ui/src/app/streams/flo/decoration/decoration.component.html
+++ b/ui/src/app/streams/flo/decoration/decoration.component.html
@@ -6,7 +6,7 @@
 </svg:g>
 
 <template #markerTooltip>
-  <div>
+  <ul class="marker-tooltip">
     <li *ngFor="let msg of getMessages()">{{msg}}</li>
-  </div>
+  </ul>
 </template>

--- a/ui/src/app/streams/flo/decoration/decoration.component.scss
+++ b/ui/src/app/streams/flo/decoration/decoration.component.scss
@@ -1,7 +1,26 @@
 .error-marker-tooltip .tooltip-inner {
   background-color: red;
   max-width: 400px;
+  padding: 2px;
 }
+
 .tooltip.error-marker-tooltip .tooltip-arrow {
   border-right-color: red;
+}
+
+.marker-tooltip {
+
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    border-bottom: 1px solid white;
+    text-align: left;
+  }
+
+  li:last-child {
+    border: none;
+  }
+
 }

--- a/ui/src/app/streams/flo/editor.service.spec.ts
+++ b/ui/src/app/streams/flo/editor.service.spec.ts
@@ -1,0 +1,379 @@
+import { dia } from 'jointjs';
+import * as _ from 'lodash';
+import { Flo } from 'spring-flo';
+import { convertGraphToText } from './graph-to-text';
+import { Shapes } from 'spring-flo';
+import * as _joint from 'jointjs';
+const joint: any = _joint;
+
+import { EditorService } from './editor.service';
+
+describe('editor.service', () => {
+
+    let graph: dia.Graph;
+    let editorService: EditorService;
+    let destinationMetadata: Flo.ElementMetadata;
+
+    beforeEach(() => {
+        editorService = new EditorService(null);
+        graph = new dia.Graph();
+    });
+
+    it('no problems on simple valid stream', (done) => {
+        const timeSource = createSource('time');
+        const transformProcessor = createProcessor('transform');
+        const logSink = createSink('log');
+        createLink(timeSource, transformProcessor);
+        createLink(transformProcessor, logSink);
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 0);
+            done();
+        });
+    });
+
+    it('bad stream - no primary output link from source', (done) => {
+        const timeSource = createSource('time');
+        const logSink = createSink('log');
+        createTap(timeSource, logSink);
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            const timeMarkers = getMarkersOn(markers, timeSource);
+            expectMarker(timeMarkers[0], Flo.Severity.Error, EditorService.VALMSG_NEEDS_NONTAP_OUTPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('bad stream - no primary output link from processor', (done) => {
+        const timeSource = createSource('time');
+        const transformProcessor = createProcessor('transform');
+        const logSink = createSink('log');
+        createLink(timeSource, transformProcessor);
+        createTap(transformProcessor, logSink);
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            expectMarker(getMarkersOn(markers, transformProcessor)[0],
+                Flo.Severity.Error, EditorService.VALMSG_NEEDS_NONTAP_OUTPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('link out of a sink', (done) => {
+        const logSink = createSink('log');
+        const transformProcessor = createProcessor('transform');
+        createLink(logSink, transformProcessor);
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 3);
+            let m = getMarkersOn(markers, transformProcessor);
+            expectMarker(m[0], Flo.Severity.Error, EditorService.VALMSG_NEEDS_OUTPUT_CONNECTION);
+            m = getMarkersOn(markers, logSink);
+            expectMarker(m[0], Flo.Severity.Error, EditorService.VALMSG_NEEDS_INPUT_CONNECTION);
+            expectMarker(m[1], Flo.Severity.Error, EditorService.VALMSG_SINK_SHOULD_BE_AT_END);
+            done();
+        });
+    });
+
+    it('too many primary links from source', (done) => {
+        const timeSource = createSource('time');
+        createLink(timeSource, createSink('log'));
+        createLink(timeSource, createSink('log'));
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            const m = getMarkersOn(markers, timeSource);
+            expectMarker(m[0], Flo.Severity.Error, EditorService.VALMSG_ONLY_ONE_NON_TAPLINK_FROM_SOURCE);
+            done();
+        });
+    });
+
+    it('too many primary links from processor', (done) => {
+        const transformProcessor = createProcessor('transform');
+        createLink(createSource('time'), transformProcessor);
+        createLink(transformProcessor, createSink('log'));
+        createLink(transformProcessor, createSink('log'));
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            const m = getMarkersOn(markers, transformProcessor);
+            expectMarker(m[0], Flo.Severity.Error, EditorService.VALMSG_ONLY_ONE_NON_TAPLINK_FROM_PROCESSOR);
+            done();
+        });
+    });
+
+    it('link in to a source', (done) => {
+        const timeSource = createSource('time');
+        const transformProcessor = createProcessor('transform');
+        const timeSource2 = createSource('time');
+        createLink(transformProcessor, timeSource);
+        createLink(timeSource2, transformProcessor);
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 2);
+            const timeMarkers = getMarkersOn(markers, timeSource);
+            expectMarker(timeMarkers[0], Flo.Severity.Error, EditorService.VALMSG_SOURCES_MUST_BE_AT_START);
+            expectMarker(timeMarkers[1], Flo.Severity.Error, EditorService.VALMSG_NEEDS_OUTPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('unfinished links', (done) => {
+        const timeSource = createSource('time');
+        const transformProcessor = createProcessor('transform');
+        // invalid links
+        let linkParams: Shapes.LinkCreationParams = {
+            source: {'id': timeSource.id, 'port': 'input', 'selector': '.output-port'}, // incorrect port
+            target: {'id': transformProcessor.id, 'port': 'input', 'selector': '.input-port'}
+        };
+        let link = Shapes.Factory.createLink(linkParams);
+        graph.addCell(link);
+
+        linkParams = {
+            source: {'id': timeSource.id, 'port': 'output', 'selector': '.output-port'},
+            target: {'id': transformProcessor.id, 'port': 'output', 'selector': '.input-port'} // incorrect port
+        };
+        link = Shapes.Factory.createLink(linkParams);
+        graph.addCell(link);
+
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 3);
+            let m = getMarkersOn(markers, timeSource);
+            expectMarker(m[0], Flo.Severity.Error, 'Invalid outgoing link');
+            m = getMarkersOn(markers, transformProcessor);
+            expectMarker(m[0], Flo.Severity.Error, 'Invalid incoming link');
+            expectMarker(m[1], Flo.Severity.Error, EditorService.VALMSG_NEEDS_OUTPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('source is missing sink connection', (done) => {
+        const timeSource = createSource('time');
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            const timeMarkers = getMarkersOn(markers, timeSource);
+            expectMarker(timeMarkers[0], Flo.Severity.Error, EditorService.VALMSG_NEEDS_OUTPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('sink is missing input connection', (done) => {
+        const logSink = createSink('log');
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            const logMarkers = getMarkersOn(markers, logSink);
+            expectMarker(logMarkers[0], Flo.Severity.Error, EditorService.VALMSG_NEEDS_INPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('processor is missing input and output connection', (done) => {
+        const transformProcessor = createProcessor('transform');
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 2);
+            const transformMarkers = getMarkersOn(markers, transformProcessor);
+            expectMarker(transformMarkers[0], Flo.Severity.Error, EditorService.VALMSG_NEEDS_INPUT_CONNECTION);
+            expectMarker(transformMarkers[1], Flo.Severity.Error, EditorService.VALMSG_NEEDS_OUTPUT_CONNECTION);
+            done();
+        });
+    });
+
+    it('destination should be named', (done) => {
+        // Calling createNode since do not want to set the name
+        const destination = createNode('destination', 'destination');
+        createLink(createSource('time'), destination);
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            expectMarker(getMarkersOn(markers, destination)[0], Flo.Severity.Error, EditorService.VALMSG_DESTINATION_SHOULD_BE_NAMED);
+            done();
+        });
+    });
+
+    it('no tap links on destinations', (done) => {
+        const destination = createDestination('d');
+        createTap(destination, createSink('log'));
+        editorService.validate(graph, null, null).then((markers) => {
+            printMarkers(markers);
+            expectMarkerCount(markers, 1);
+            expectMarker(getMarkersOn(markers, destination)[0], Flo.Severity.Error, EditorService.VALMSG_DESTINATION_CANNOT_BE_TAPPED);
+            done();
+        });
+    });
+
+    it('no tap links on tap sources', (done) => {
+        const tapSource = createTapNode('aaaa.time');
+        createTap(tapSource, createSink('log'));
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            expectMarker(getMarkersOn(markers, tapSource)[0], Flo.Severity.Error, EditorService.VALMSG_TAPSOURCE_CANNOT_BE_TAPPED);
+            done();
+        });
+    });
+
+    it('metadata validation', (done) => {
+        const madeupNode = createNode('madeup');
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            expectMarker(getMarkersOn(markers, madeupNode)[0], Flo.Severity.Error, 'Unknown element \'madeup\'');
+            done();
+        });
+    });
+
+    it('property validation', (done) => {
+        const formatPropertySpec = toPropertyMetadata('formatid', 'format', 'Format of the time', 'HHMM', 'string');
+        const timeMetadata = toMetadataWithCustomProperties('time', 'source', new Map([['format', formatPropertySpec]]));
+        const timeSource = createNodeFromMetadata(timeMetadata);
+        createLink(timeSource, createSink('log'));
+        setProperties(timeSource, new Map([['madeup', 'anyoldvalue']]));
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 1);
+            expectMarker(getMarkersOn(markers, timeSource)[0], Flo.Severity.Error, 'unrecognized option \'madeup\' for app \'time\'');
+            done();
+        });
+    });
+
+    function expectMarker(marker: Flo.Marker, severity: number, message: string) {
+        if (!marker) {
+            fail('missing marker');
+        } else {
+            expect(marker.message).toEqual(message);
+            expect(marker.severity).toEqual(severity);
+        }
+    }
+
+    function expectMarkerCount(markers: Map<string, Array<Flo.Marker>>, expectedCount: number) {
+        let count = 0;
+        Array.from(markers.keys()).forEach((k) => {
+            count += markers.get(k).length;
+        });
+        expect(count).toEqual(expectedCount);
+    }
+
+    function printMarkers(markers: Map<string, Array<Flo.Marker>>) {
+        console.log('Markers summary: ' + markers.size + ' map entries');
+        Array.from(markers.keys()).forEach((k) => {
+            const values = markers.get(k);
+            console.log('For ' + k + ' there are ' + values.length + ' markers');
+            for (let m = 0; m < values.length; m++) {
+                const marker = values[m];
+                console.log(' ' + m + ') ' + JSON.stringify(marker));
+            }
+        });
+    }
+
+    function getMarkersOn(markers: Map<string, Array<Flo.Marker>>, node: dia.Element): Flo.Marker[] {
+        return markers.get(node.id);
+    }
+
+    function setStreamName(node: dia.Element, name: string) {
+      node.attr('stream-name', name);
+    }
+
+    function createSource(appname: string): dia.Element {
+      return createNode(appname, 'source');
+    }
+
+    function createProcessor(appname: string): dia.Element {
+        return createNode(appname, 'processor');
+      }
+
+    function createSink(appname: string): dia.Element {
+      return createNode(appname, 'sink');
+    }
+
+    function getName(element: dia.Cell) {
+      return element.attr('metadata/name');
+    }
+
+    function setLabel(element: dia.Cell, label: string) {
+        element.attr('node-name', label);
+    }
+
+    function setProperties(element: dia.Cell, properties: Map<string, string>) {
+        Array.from(properties.keys()).forEach((k) => {
+            element.attr('props/' + k, properties.get(k));
+        });
+    }
+
+    function toPropertyMetadata(id: string, name: string, description?: string, defaultValue?: any, type?: string): Flo.PropertyMetadata {
+        return {
+            id: id,
+            name: name,
+            description: description,
+            defaultValue: defaultValue,
+            type: type
+            // readonly [propName: string]: any;
+        };
+    }
+
+    function toMetadataWithCustomProperties(
+        appname: string, group: string, properties: Map<string, Flo.PropertyMetadata>): Flo.ElementMetadata {
+        const propertiesCopy = new Map(properties);
+        const emd: Flo.ElementMetadata = {
+            name: appname,
+            group: group,
+            get(property: string): Promise<Flo.PropertyMetadata> {
+                return Promise.resolve(propertiesCopy.get(property));
+            },
+            properties(): Promise<Map<string, Flo.PropertyMetadata>> {
+                return Promise.resolve(propertiesCopy);
+            }
+        };
+        return emd;
+    }
+
+    function createNodeFromMetadata(metadata: Flo.ElementMetadata) {
+        return createNode(metadata.name, metadata.group, metadata);
+    }
+
+    // If you do not supply the group it is undefined and a way to check unresolved metadata
+    function createNode(appname: string, group?: string, metadata?: Flo.ElementMetadata): dia.Element {
+        const params: Shapes.ElementCreationParams = {};
+        if (metadata) {
+            params.metadata = metadata;
+        } else {
+            params.metadata = {
+                name: appname,
+                group: group,
+                get(property: String): Promise<Flo.PropertyMetadata> {
+                    return Promise.resolve(null);
+                },
+                properties(): Promise<Map<string, Flo.PropertyMetadata>> {
+                    return Promise.resolve(new Map());
+                }
+            };
+        }
+        if (!group) {
+          params.metadata.unresolved = true;
+        }
+        const newNode: dia.Element = Shapes.Factory.createNode(params);
+        graph.addCell(newNode);
+        return newNode;
+    }
+
+    function createTap(from, to): dia.Link {
+        return createLink(from, to, true);
+    }
+
+    function createLink(from, to, isTapLink?: boolean): dia.Link {
+        const linkParams: Shapes.LinkCreationParams = {
+            source: {'id': from.id, 'port': 'output', 'selector': '.output-port'},
+            target: {'id': to.id, 'port': 'input', 'selector': '.input-port'}
+        };
+        const link = Shapes.Factory.createLink(linkParams);
+        link.attr('props/isTapLink', isTapLink ? true : false);
+        graph.addCell(link);
+        return link;
+    }
+
+    function createTapNode(tappedStreamAndApp: string): dia.Element {
+        const tapNameMD = toPropertyMetadata('name', 'name', 'Tap name (stream.app format)', '', '');
+        const tapMD = toMetadataWithCustomProperties('tap', 'other', new Map([['name', tapNameMD]]));
+        const newTapNode: dia.Element = createNodeFromMetadata(tapMD);
+        newTapNode.attr('props/name', tappedStreamAndApp);
+        return newTapNode;
+    }
+
+    function createDestination(destinationname: string): dia.Element {
+        const destinationNameMD = toPropertyMetadata('name', 'name', 'Destination name', '', '');
+        const destinationMD = toMetadataWithCustomProperties('destination', 'other', new Map([['name', destinationNameMD]]));
+        const newDestinationNode: dia.Element = createNodeFromMetadata(destinationMD); // 'destination', 'destination');
+        newDestinationNode.attr('props/name', destinationname);
+        return newDestinationNode;
+    }
+
+});

--- a/ui/src/app/streams/flo/graph-to-text.spec.ts
+++ b/ui/src/app/streams/flo/graph-to-text.spec.ts
@@ -58,6 +58,16 @@ describe('graph-to-text', () => {
         }
     });
 
+    it('incorrect graph - single node tapped into', () => {
+        const timeSource = createSource('time');
+        const logSink = createSink('log');
+        createTap(timeSource, logSink);
+        // 'timeSource' is missing a real connected (not via tap) sink
+        dsl = convertGraphToText(graph);
+        console.log('DSL is ... ' + dsl);
+        expect(dsl).toEqual('STREAM_1=time\n:STREAM_1.time > log');
+    });
+
     it('incorrect graph - no tap links from channels', () => {
         const d = createDestination('d');
         createLink(createSource('time'), d);

--- a/ui/src/app/streams/flo/graph-to-text.ts
+++ b/ui/src/app/streams/flo/graph-to-text.ts
@@ -71,6 +71,12 @@ class GraphToTextConverter {
                     // Isolated node, let's put it in the DSL so it is not lost, the graph is a work in progress.
                     streams.push([node]);
                 } else {
+                    if (this.areAllTapLinks(linksOut)) {
+                        // Special case, a bit like above it is an isolated node (the stream is actually
+                        // in error because a source must have an input) but for now create a solo node just
+                        // to produce slightly better (although invalid) DSL.
+                        streams.push([node]);
+                    }
                     // Only outgoing links. This is the head of a stream.
                     for (let l = 0; l < linksOut.length; l++) {
                         const link = linksOut[l];
@@ -292,6 +298,15 @@ class GraphToTextConverter {
 
     private isTapLink(link): boolean {
         return link.attr('props/isTapLink') === true;
+    }
+
+    private areAllTapLinks(links: dia.Link[]): boolean {
+        for (let i = 0; i < links.length; i++) {
+            if (!this.isTapLink(links[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private getName(node: dia.Cell): string {

--- a/ui/src/app/streams/flo/node/node.component.html
+++ b/ui/src/app/streams/flo/node/node.component.html
@@ -1,12 +1,27 @@
-<svg:g class="stream-module">
-  <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
-    <svg:rect class="box"/>
-    <svg:text class="label1"/>
-    <svg:text class="label2"/>
-   </svg:g>
-  <svg:text class="stream-label"/>
-  <svg:rect class="input-port" tooltip="Input Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
-  <svg:rect class="output-port" tooltip="Output Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+<svg:g [ngSwitch]="metaName">
+
+  <svg:g *ngSwitchCase="'destination'" class="destination">
+    <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
+      <svg:path d="m6,10 a12,12 0 0,0 0,20 l108,0 a12,12 0 0,0 0,-20 l0,0 z" class="box"/>
+      <svg:text class="label1"/>
+      <svg:text class="label2"/>
+    </svg:g>
+    <svg:text class="stream-label"/>
+    <svg:circle class="input-port" tooltip="Input Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+    <svg:circle class="output-port" tooltip="Output Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+  </svg:g>
+
+  <svg:g *ngSwitchDefault class="stream-module">
+    <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
+      <svg:rect class="box"/>
+      <svg:text class="label1"/>
+      <svg:text class="label2"/>
+    </svg:g>
+    <svg:text class="stream-label"/>
+    <svg:rect class="input-port" tooltip="Input Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+    <svg:rect class="output-port" tooltip="Output Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+  </svg:g>
+
 </svg:g>
 
 <template #canvasNodeTooltip>

--- a/ui/src/app/streams/flo/render.service.ts
+++ b/ui/src/app/streams/flo/render.service.ts
@@ -319,7 +319,7 @@ export class RenderService implements Flo.Renderer {
                 const linkView = paper.findViewByModel(link);
                 console.log('Adjusting link class isTapLink? ' + isTapLink);
                 // TODO: Check if need to switch bacl to _.each(...)
-                if (isTapLink) {
+                if (isTapLink === true) {
                     linkView.el.querySelectorAll('.connection, .marker-source, .marker-target')
                       .forEach(connection => joint.V(connection).addClass('tapped-output-from-app'));
                 } else {
@@ -532,12 +532,20 @@ export class RenderService implements Flo.Renderer {
         });
     }
 
+    isChannel(e: dia.Cell): boolean {
+        return e && (e.attr('metadata/name') === 'tap' || e.attr('metadata/name') === 'destination');
+    }
+
     handleLinkSwitch(link: dia.Link, flo: Flo.EditorContext) {
         const graph = flo.getGraph();
         const source = graph.getCell(link.get('source').id);
         // var target = graph.getCell(link.get('target').id);
         const isTapLink = link.attr('props/isTapLink');
-        if (isTapLink) {
+        // This does nothing if the source is a destination/tap - there are no tap links allowed from destinations
+        if (this.isChannel(source)) {
+            return;
+        }
+        if (isTapLink === true) {
             console.log(`Converting link ${this.toLinkString(graph, link)} into a primary link`);
             link.attr('props/isTapLink', false);
             // Need to ensure no other links are still primary, that isn't allowed
@@ -559,11 +567,14 @@ export class RenderService implements Flo.Renderer {
         const source = graph.getCell(link.get('source').id);
         const target = graph.getCell(link.get('target').id);
         console.log('render-service.handleLinkAdded');
-        if (source) {
+        if (!target && source && !this.isChannel(source)) {
+            // this is a new link being drawn in the UI (it is not connected to anything yet).
+            // Need to decide whether to make it a tap link
             const outgoingLinks = graph.getConnectedLinks(source, {outbound: true});
-            const primaryLink = outgoingLinks.find(ol => ol !== link && !ol.attr('props/isTapLink'));
-
-            link.attr('props/isTapLink', primaryLink ? true : false);
+            const primaryLinkExists = outgoingLinks.find(ol => ol !== link && !ol.attr('props/isTapLink')) ? true : false;
+            link.attr('props/isTapLink', primaryLinkExists ? true : false);
+        }
+        if (link.attr('props/isTapLink') === true) {
             this.refreshVisuals(link, 'props/isTapLink', flo.getPaper());
         }
         if (source && source.attr('metadata/name') === 'destination' && target) {

--- a/ui/src/app/streams/flo/text-to-graph.spec.ts
+++ b/ui/src/app/streams/flo/text-to-graph.spec.ts
@@ -95,6 +95,20 @@ describe('text-to-graph', () => {
         expect(graph.links[0].to).toEqual(1);
     });
 
+    it('jsongraph: incomplete stream with tap', () => {
+        graph = getGraph('STREAM_1=time\n:STREAM_1.time > log');
+        expect(graph.streamdefs[0].def).toEqual('time');
+        expect(graph.streamdefs[1].def).toEqual(':STREAM_1.time > log');
+        expect(graph.nodes[0].name).toEqual('time');
+        expect(graph.nodes[0]['stream-id']).toEqual(1);
+        expect(graph.nodes[1].name).toEqual('log');
+        expect(graph.nodes[1]['stream-id']).toEqual(2);
+        expect(graph.links.length).toEqual(1);
+        expect(graph.links[0].from).toEqual(0);
+        expect(graph.links[0].to).toEqual(1);
+        expect(graph.links[0].linkType).toEqual('tap');
+    });
+
     it('jsongraph: name set on sink channel in some cases', () => {
         graph = getGraph(':aaa > :foo\n:aaa > :bar');
         expect(graph.streamdefs[0].def).toEqual(':aaa > :foo');

--- a/ui/src/app/streams/flo/text-to-graph.ts
+++ b/ui/src/app/streams/flo/text-to-graph.ts
@@ -390,8 +390,8 @@ class TextToGraphConverter {
         const inputlinksCount = inputlinks ? inputlinks.length : 0;
         for (let l = 0; l < inputlinksCount; l++) {
             link = inputlinks[l];
-            const props: Map<string, string> = new Map();
-            props['isTapLink'] = (link.linkType && link.linkType === 'tap') ? true : false;
+            const props: Map<string, any> = new Map();
+            props.set('isTapLink', (link.linkType && link.linkType === 'tap') ? true : false);
             this.floEditorContext.createLink(
                 {'id': nodesIndex[link.from], 'selector': '.output-port', 'port': 'output' },
                 {'id': nodesIndex[link.to], 'selector': '.input-port', 'port': 'input'},


### PR DESCRIPTION
EditorService
- Tests added (verifying validation of graph)
- Moved some messages to constants
- Altered validation to make full use of promises (rather than promises
  to a certain depth then async)
- More validation rules related to fan-in/out scenarios

graph-to-text
- Adjustments to cope better with 'bad input' and try to create some
  kind of graph (tests added for this case)

RenderService
- Prevents creation of tap links from destinations (channels/taps)
- Prevents link switching working for links from destinations

text-to-graph
- Fixed handling of map (use setter)

markup
- no bullet lists on error tooltips if only one entry
- tooltips working for destinations

Fixes #395