### PR TITLE
Make rendering PhantomJS compatible to run complex tests

### DIFF
--- a/ui/src/app/streams/flo/render.service.ts
+++ b/ui/src/app/streams/flo/render.service.ts
@@ -318,12 +318,11 @@ export class RenderService implements Flo.Renderer {
                 const isTapLink = link.attr('props/isTapLink');
                 const linkView = paper ? paper.findViewByModel(link) : undefined;
                 if (linkView) {
-                  // TODO: Check if need to switch bacl to _.each(...)
-                  if (isTapLink === true) {
-                    linkView.el.querySelectorAll('.connection, .marker-source, .marker-target')
+                  if (isTapLink) {
+                    linkView.$('.connection, .marker-source, .marker-target').toArray()
                       .forEach(connection => joint.V(connection).addClass('tapped-output-from-app'));
                   } else {
-                    linkView.el.querySelectorAll('.connection, .marker-source, .marker-target')
+                    linkView.$('.connection, .marker-source, .marker-target').toArray()
                       .forEach(connection => joint.V(connection).removeClass('tapped-output-from-app'));
                   }
                 }

--- a/ui/src/app/streams/stream-graph-view/stream-graph-view.component.spec.ts
+++ b/ui/src/app/streams/stream-graph-view/stream-graph-view.component.spec.ts
@@ -52,11 +52,12 @@ describe('StreamGraphViewComponent', () => {
   });
 
   it('check stream in the view', (done) => {
-    component.dsl = 'http';
+    component.dsl = 'http | filter | null';
     fixture.detectChanges();
     const subscription = component.flo.textToGraphConversionSubject.subscribe(() => {
       subscription.unsubscribe();
-      expect(component.flo.getGraph().getElements().length).toEqual(1);
+      expect(component.flo.getGraph().getElements().length).toEqual(3);
+      expect(component.flo.getGraph().getLinks().length).toEqual(2);
       done();
     });
   });


### PR DESCRIPTION
Make Render service compatible with PhantomJS. Should allow for more complex tests. Made one test a bit more complex.