### PR TITLE
gh-368 Migrate OAuth2 UI Security

### DIFF
--- a/ui/.angular-cli.json
+++ b/ui/.angular-cli.json
@@ -9,7 +9,8 @@
       "outDir": "dist",
       "assets": [
         "assets",
-        "favicon.ico"
+        "favicon.ico",
+        "logout-success-oauth.html"
       ],
       "index": "index.html",
       "main": "main.ts",

--- a/ui/proxy.conf.json
+++ b/ui/proxy.conf.json
@@ -24,6 +24,11 @@
         "secure": false,
         "logLevel": "debug"
     },
+    "/logout" : {
+        "target": "http://localhost:9393/",
+        "secure": false,
+        "logLevel": "debug"
+    },
     "/metrics" : {
         "target": "http://localhost:9393/",
         "secure": false,

--- a/ui/src/app/auth/auth.service.ts
+++ b/ui/src/app/auth/auth.service.ts
@@ -107,9 +107,7 @@ export class AuthService {
     const options = HttpUtils.getDefaultRequestOptions();
     return this.http.get(this.logoutUrl, options)
                     .map(response => {
-                      this.securityInfo.reset();
-                      const o: SecurityAwareRequestOptions = this.options as SecurityAwareRequestOptions;
-                      o.xAuthToken = null;
+                      this.clearLocalSecurity();
                       return response;
                     })
                     .flatMap((response: Response) => {
@@ -117,6 +115,20 @@ export class AuthService {
                       return this.loadSecurityInfo();
                     })
                     .catch(this.errorHandler.handleError);
+  }
+
+  /**
+   * Clears all security-relevant information from the local application:
+   *
+   * - Calls `securityInfo.reset()`
+   * - Deletes a persisted XAuthToken (Session Storage)
+   *
+   */
+  public clearLocalSecurity() {
+    this.securityInfo.reset();
+    const o: SecurityAwareRequestOptions = this.options as SecurityAwareRequestOptions;
+    o.xAuthToken = null;
+    this.deletePersistedXAuthToken();
   }
 
   private retrievePersistedXAuthToken(): string {

--- a/ui/src/app/auth/logout.component.ts
+++ b/ui/src/app/auth/logout.component.ts
@@ -6,6 +6,13 @@ import { Subscription } from 'rxjs/Subscription';
 import { ToastyService } from 'ng2-toasty';
 import { AuthService } from './auth.service';
 
+/**
+ * Handles logouts. Logouts are handled differently depending on whether
+ * traditional Spring Security is used on the server-side or whether
+ * OAuth2 security is used.
+ *
+ * @author Gunnar Hillert
+ */
 @Component({
   template: ''
 })
@@ -34,14 +41,24 @@ export class LogoutComponent implements OnInit {
     }
 
     console.log('Logging out ...');
-    this.authService.logout().subscribe(
-      result => {
-        this.toastyService.success('Logged out.');
-        this.router.navigate(['login']);
-      },
-      error => {
-        this.toastyService.error(error);
-      },
-    );
+
+    if (this.authService.securityInfo.isFormLogin) {
+      this.authService.logout().subscribe(
+        result => {
+          this.toastyService.success('Logged out.');
+          this.router.navigate(['login']);
+        },
+        error => {
+          this.toastyService.error(error);
+        },
+      );
+    } else {
+      console.log(`Logging out user ${this.authService.securityInfo.username} (OAuth)`);
+      this.authService.clearLocalSecurity();
+
+      var logoutUrl = '//' + window.location.host + '/logout';
+      console.log('Redirecting to ' + logoutUrl);
+      window.open(logoutUrl, '_self');
+    }
   }
 }

--- a/ui/src/logout-success-oauth.html
+++ b/ui/src/logout-success-oauth.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Spring Cloud Data Flow</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <style>
+    body {
+      background-color: #243641;
+    }
+
+    .flex-box-container {
+      display: flex;
+      align-items: center;
+      min-height: 24em;
+      justify-content: center;
+    }
+
+    .flex-box-item {
+      width: 500px;
+    }
+  </style>
+</head>
+<body>
+    <div class="container text-center flex-box-container">
+        <div class="row">
+          <div class="col-md-8 col-md-offset-2" style="background-color: #ffffff">
+            <h4>
+              You have successfully logged out from the Spring Cloud Data Flow Dashboard.
+            </h4>
+            <p class="inverted">
+              Please keep in mind that you are most likely still logged in with your oauth
+              provider. Therefore, going to the main Dashboard URL will log you back in,
+              unless you also log out from your oauth provider.
+            </p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
* Add Logout success page
* Add logout functionality (Differentiate between traditional logouts and OAuth2 logouts)

-> For testing with UAA https://gist.github.com/ghillert/5f2fba0ee412f8e82c86daf59e610c12

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/368