### PR TITLE
gh-459 Fix: Analytics - Adding a second counter resets name in first graph

### DIFF
--- a/ui/src/app/analytics/dashboard/dashboard.component.html
+++ b/ui/src/app/analytics/dashboard/dashboard.component.html
@@ -27,7 +27,7 @@
         <select #counterName="ngModel" name="counterName_{{item.id}}" [(ngModel)]="item.counter"
                 [compareWith]="compareCounter" required (ngModelChange)="onCounterNameChange(item)">
             <option [ngValue]="undefined" disabled="disabled">Please select a counter...</option>
-            <option *ngFor="let counter of counters"
+            <option *ngFor="let counter of item.counters"
                     [ngValue]="counter">{{counter.name}}</option>
           </select>
           <span class="help-block" *ngIf="counterName.invalid && counterName.touched">Please select a counter.</span>

--- a/ui/src/app/analytics/dashboard/dashboard.component.ts
+++ b/ui/src/app/analytics/dashboard/dashboard.component.ts
@@ -18,7 +18,6 @@ import { Counter } from './../model/counter.model';
 export class DashboardComponent implements OnInit {
 
   busy: Subscription;
-  public counters: Counter[] = [];
 
   public get dashboardItems() {
     return this.analyticsService.dashboardItems;
@@ -78,10 +77,11 @@ export class DashboardComponent implements OnInit {
    * Retrieves metrics for specific type.
    * @param {MetricType} metricType to retrieve.
    */
-  onMetricTypeChange(metricType: MetricType) {
+  onMetricTypeChange(metricType: MetricType, dashBoardItem: DashboardItem) {
     console.log('Selected Metric Type:', metricType);
+    dashBoardItem.counters = [];
     this.analyticsService.getStreamsForMetricType(metricType).subscribe(result => {
-      this.counters = result.items;
+      dashBoardItem.counters = result.items;
     });
   }
 

--- a/ui/src/app/analytics/model/dashboard-item.model.ts
+++ b/ui/src/app/analytics/model/dashboard-item.model.ts
@@ -1,6 +1,7 @@
 import { Serializable } from '../../shared/model';
 import { MetricType } from './metric-type.model';
 import { Counter } from './counter.model';
+import { Page } from '../../shared/model';
 import { Subscription } from 'rxjs/Subscription';
 
 /**
@@ -19,6 +20,8 @@ export class DashboardItem implements Serializable<DashboardItem> {
   public counterPoller: Subscription;
   public chartHeight = 140;
   public barSize = 2;
+
+  public counters: Counter[] = [];
 
   constructor(
   ) { }


### PR DESCRIPTION
* Make the counter collection part of each `DashboardItem`

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/459