### PR TITLE
Initial infra for composed tasks

### DIFF
--- a/ui/proxy.conf.json
+++ b/ui/proxy.conf.json
@@ -49,6 +49,11 @@
         "secure": false,
         "logLevel": "debug"
     },
+    "/tools" : {
+        "target": "http://localhost:9393/",
+        "secure": false,
+        "logLevel": "debug"
+    },
     "/runtime/apps" : {
         "target": "http://localhost:9393/",
         "secure": false,

--- a/ui/src/app/tasks/flo/editor.service.ts
+++ b/ui/src/app/tasks/flo/editor.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { BsModalService } from 'ngx-bootstrap';
+import { Constants, Flo } from 'spring-flo';
+import { CONTROLNODES_GROUP_TYPE } from './support/shapes';
+import { dia } from 'jointjs';
+import * as _joint from 'jointjs';
+import { PropertiesDialogComponent } from '../../streams/flo/properties/properties-dialog.component';
+
+const joint: any = _joint;
+
+@Injectable()
+export class EditorService implements Flo.Editor {
+
+  constructor(
+    private bsModalService: BsModalService
+  ) {}
+
+  createHandles(flo: Flo.EditorContext, createHandle: (owner: dia.CellView, kind: string,
+                                                       action: () => void, location: dia.Point) => void, owner: dia.CellView): void {
+    if (owner.model instanceof joint.dia.Link) {
+      return;
+    } else if (owner.model instanceof joint.dia.Element) {
+      const element = <dia.Element> owner.model;
+      const bbox = element.getBBox();
+
+      // Delete handle
+      let pt = (<any>bbox).origin().offset(bbox.width + 3, bbox.height + 3);
+      createHandle(owner, Constants.REMOVE_HANDLE_TYPE, flo.deleteSelectedNode, pt);
+
+      // Properties handle
+      if (!element.attr('metadata/unresolved')) {
+        pt = (<any>bbox).origin().offset(-14, bbox.height + 3);
+        createHandle(owner, Constants.PROPERTIES_HANDLE_TYPE, () => {
+          const modalRef = this.bsModalService.show(PropertiesDialogComponent);
+          modalRef.content.title = `Properties for ${element.attr('metadata/name').toUpperCase()}`;
+          modalRef.content.setData(element, flo.getGraph());
+        }, pt);
+      }
+    }
+  }
+
+  setDefaultContent(editorContext: Flo.EditorContext,
+                    elementMetadata: Map<string, Map<string, Flo.ElementMetadata>>): void {
+    editorContext.createNode(this.createMetadata('START',
+      CONTROLNODES_GROUP_TYPE,
+      '',
+      new Map<string, Flo.PropertyMetadata>(), {
+        'fixed-name': true,
+      }));
+
+    editorContext.createNode(this.createMetadata('END',
+      CONTROLNODES_GROUP_TYPE,
+      '',
+      new Map<string, Flo.PropertyMetadata>(), {
+        'fixed-name': true,
+      }));
+
+    editorContext.performLayout();
+  }
+
+  private createMetadata(name: string, group: string, description: string,
+                         properties: Map<string, Flo.PropertyMetadata>,
+                         metadata?: Flo.ExtraMetadata): Flo.ElementMetadata {
+    return {
+      name: name,
+      group: group,
+      metadata: metadata,
+      description: () => Promise.resolve(description),
+      get: (property: string) => Promise.resolve(properties.get(property)),
+      properties: () => Promise.resolve(properties)
+    };
+
+  }
+
+}

--- a/ui/src/app/tasks/flo/metamodel.service.ts
+++ b/ui/src/app/tasks/flo/metamodel.service.ts
@@ -1,0 +1,372 @@
+import { Flo } from 'spring-flo';
+import { Injectable } from '@angular/core';
+import { ApplicationType } from '../../shared/model/application-type';
+import { SharedAppsService } from '../../shared/services/shared-apps.service';
+import { CONTROLNODES_GROUP_TYPE } from './support/shapes';
+import { Http } from '@angular/http';
+import { HttpUtils } from '../../shared/support/http.utils';
+import { Observable } from 'rxjs/Observable';
+
+class TaskAppMetadata implements Flo.ElementMetadata {
+
+  private _propertiesPromise: Promise<Map<string, Flo.PropertyMetadata>>;
+
+  constructor(
+    private _group: string,
+    private _name: string,
+    private _metadata?: Flo.ExtraMetadata
+  ) {}
+
+  get propertiesPromise(): Promise<Map<string, Flo.PropertyMetadata>> {
+    return this._propertiesPromise;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get group(): string {
+    return this._group;
+  }
+
+  properties(): Promise<Map<string, Flo.PropertyMetadata>> {
+    return this.propertiesPromise;
+  }
+
+  get(property: string): Promise<Flo.PropertyMetadata> {
+    return this.propertiesPromise.then(properties => properties.get(property));
+  }
+
+}
+
+@Injectable()
+export class MetamodelService implements Flo.Metamodel {
+
+  private COMPOSED_TASK_LABEL = 'label';
+
+  private request: Promise<Map<string, Map<string, Flo.ElementMetadata>>>;
+
+  constructor(
+    private appsService: SharedAppsService,
+    private http: Http
+  ) {}
+
+  textToGraph(flo: Flo.EditorContext, dsl: string): Promise<any> {
+    flo.getGraph().clear();
+
+    const options = HttpUtils.getDefaultRequestOptions();
+    const json: Observable<any> = this.http.post('/tools/parseTaskTextToGraph',
+        JSON.stringify({ dsl: dsl || ' ', name: 'unknown' }), options)
+      .map(data => {
+        console.log('graphToText4', data);
+        return data.json();
+      });
+
+
+    return new Promise(resolve => {
+      json.toPromise().then(
+        (jsondata) => this.load().then(
+          (metamodel) => resolve(this.buildGraphFromJson(flo, jsondata.graph, metamodel))));
+    });
+  }
+
+  graphToText(flo: Flo.EditorContext): Promise<string> {
+    const graphInInternalFormat = flo.getGraph();
+    const graphInCommonFormat = this.toCommonGraphFormat(graphInInternalFormat);
+    console.log('graphToText1', graphInCommonFormat);
+    console.log('graphToText2', JSON.stringify(graphInCommonFormat));
+
+    const options = HttpUtils.getDefaultRequestOptions();
+    const dsl: Observable<any> = this.http.post('/tools/convertTaskGraphToText',
+        JSON.stringify(graphInCommonFormat), options)
+      .map(data => {
+        console.log('graphToText3', data);
+        return data.json().dsl;
+      });
+    return dsl.toPromise();
+  }
+
+  load(): Promise<Map<string, Map<string, Flo.ElementMetadata>>> {
+    return this.refresh();
+  }
+
+  groups(): Array<string> {
+    return [CONTROLNODES_GROUP_TYPE, 'task'];
+  }
+
+  refresh(): Promise<Map<string, Map<string, Flo.ElementMetadata>>> {
+    const metamodel = new Map<string, Map<string, Flo.ElementMetadata>>();
+    this.addOtherGroup(metamodel);
+    return new Promise(resolve => {
+      this.appsService.getApps({page: 0, size: 1000}).subscribe(
+        data => {
+          data.items.filter(item => {
+            return item.type.toString() === ApplicationType[ApplicationType.task];
+          }).forEach(item => {
+
+            if (!metamodel.has(item.type.toString())) {
+              metamodel.set(item.type.toString(), new Map<string, Flo.ElementMetadata>());
+            }
+            const group: Map<string, Flo.ElementMetadata> = metamodel.get(item.type.toString());
+            if (group.has(item.name)) {
+              console.error(`Group '${item.type}' has duplicate element '${item.name}'`);
+            } else {
+              group.set(item.name, this.createEntry(item.type, item.name));
+            }
+          });
+          resolve(metamodel);
+        },
+        error => {
+          console.error(error);
+          resolve(metamodel);
+        }
+      );
+    });
+  }
+
+  private addOtherGroup(metamodel: Map<string, Map<string, Flo.ElementMetadata>>): void {
+    const elements = new Map<string, Flo.ElementMetadata>()
+      .set('START', this.createMetadata('START',
+        CONTROLNODES_GROUP_TYPE,
+        'Start element for the composed task. Global options for the task are set on this element.',
+        new Map<string, Flo.PropertyMetadata>(), {
+          'noPaletteEntry': true,
+          'fixed-name': true,
+        })
+      )
+      .set('END', this.createMetadata('END',
+        CONTROLNODES_GROUP_TYPE,
+        'End element for a flow or the entire composed task.',
+        new Map<string, Flo.PropertyMetadata>(), {
+          'noPaletteEntry': true,
+          'fixed-name': true,
+        })
+      )
+      .set('sync', this.createMetadata('sync',
+        CONTROLNODES_GROUP_TYPE,
+        'After a split, a sync node pulls the threads of parallel tasks back together',
+        new Map<string, Flo.PropertyMetadata>(), {
+          'fixed-name': true,
+        })
+      );
+    metamodel.set(CONTROLNODES_GROUP_TYPE, elements);
+  }
+
+  private createEntry(type: ApplicationType, name: string, metadata?: Flo.ExtraMetadata): Flo.ElementMetadata {
+    return new TaskAppMetadata(
+      type.toString(),
+      name,
+      metadata
+    );
+  }
+
+  private createMetadata(name: string, group: string, description: string,
+                         properties: Map<string, Flo.PropertyMetadata>, metadata?: Flo.ExtraMetadata): Flo.ElementMetadata {
+    return {
+      name: name,
+      group: group,
+      metadata: metadata,
+      description: () => Promise.resolve(description),
+      get: (property: string) => Promise.resolve(properties.get(property)),
+      properties: () => Promise.resolve(properties)
+    };
+
+  }
+
+  private toCommonGraphFormat(graphInInternalFormat) {
+    const elements = graphInInternalFormat.attributes.cells.models;
+    const nodes = [];
+    const links = [];
+    let globalOptions;
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      if (element.attributes.type === 'sinspctr.IntNode') {
+        const attrs = element.attributes.attrs;
+        const newNode = {};
+        newNode['name'] = attrs.metadata.name;
+        newNode['id'] = element.attributes.id;
+        if (element.attributes.attrs.props) {
+          if (newNode['name'] === 'START') {
+            // Global options are held on the START node during graph editing
+            globalOptions = element.attributes.attrs.props;
+          } else {
+            newNode['properties'] = element.attributes.attrs.props;
+            if (element.attr('node-label')) {
+              newNode['metadata'] = {};
+              newNode['metadata'][this.COMPOSED_TASK_LABEL] = element.attr('node-label');
+            }
+          }
+        }
+        nodes.push(newNode);
+      } else if (element.attributes.type === 'sinspctr.Link' || element.attributes.type === 'link') {
+        const newlink = {'from': element.attributes.source.id, 'to': element.attributes.target.id};
+        if (element.attributes.attrs.metadata && element.attributes.attrs.props &&
+          element.attributes.attrs.props.ExitStatus) {
+          newlink['properties'] = {'transitionName': element.attributes.attrs.props.ExitStatus};
+        }
+        links.push(newlink);
+      }
+    }
+    const graph = {'nodes': nodes, 'links': links};
+    if (globalOptions) {
+      graph['properties'] = globalOptions;
+    }
+    return graph;
+  }
+
+  private buildGraphFromJson(flo, jsonFormatData, metamodel) {
+    if (jsonFormatData === undefined || jsonFormatData === null) {
+      // TODO handle this better when we have service for metadata
+      return;
+    }
+    const inputnodes = jsonFormatData.nodes;
+    const inputlinks = jsonFormatData.links;
+
+    const incoming = {};
+    const outgoing = {};
+    let link;
+    for (let i = 0; i < inputlinks.length; i++) {
+      link = inputlinks[i];
+      if (typeof link.from === 'number') {
+        if (typeof outgoing[link.from] !== 'number') {
+          outgoing[link.from] = 0;
+        }
+        outgoing[link.from]++;
+      }
+      if (typeof link.to === 'number') {
+        if (typeof incoming[link.to] !== 'number') {
+          incoming[link.to] = 0;
+        }
+        incoming[link.to]++;
+      }
+    }
+
+    const inputnodesCount = inputnodes ? inputnodes.length : 0;
+    const nodesIndex = [];
+    const builtNodesMap = {};
+    for (let n = 0; n < inputnodesCount; n++) {
+      const name = inputnodes[n].name;
+      const label = inputnodes[n].label || inputnodes[n].name;
+      let group = inputnodes[n].group;
+      if (!group) {
+        // TODO matchGroup port as is doesn't work
+        // group = this.matchGroup(metamodel, name, incoming[n], outgoing[n]);
+        if (name === 'START' || name === 'END' || name === 'SYNC') {
+          group = 'control nodes';
+        } else {
+          group = 'task';
+        }
+      }
+      // TODO fix this metadata usage
+      // var metadata = metamodelUtils.getMetadata(metamodel, name, group);
+      // if (metadata.unresolved) {
+      //   metadata.metadata = {
+      //     titleProperty: 'metadata/name'
+      //   };
+      // }
+      const metadata = this.createMetadata(name, group, '', new Map<string, Flo.PropertyMetadata>());
+
+      let nodeProperties = inputnodes[n].properties;
+      const metadataProperties = inputnodes[n].metadata;
+      // Put the global properties onto the start node if there are any
+      if (n === 0 && name === 'START' && jsonFormatData.properties) {
+        nodeProperties = jsonFormatData.properties;
+      }
+      const newNode = flo.createNode(metadata, nodeProperties);
+      // Hang the properties off the start node!
+      newNode.attr('.label/text', label);
+      if (inputnodes[n].range) {
+        newNode.attr('range', inputnodes[n].range);
+      }
+      if (inputnodes[n].propertiesranges) {
+        newNode.attr('propertiesranges', inputnodes[n].propertiesranges);
+      }
+      if (inputnodes[n]['stream-id']) {
+        newNode.attr('stream-id', inputnodes[n]['stream-id']);
+      }
+      if (metadataProperties && metadataProperties[this.COMPOSED_TASK_LABEL]) {
+        newNode.attr('node-label', metadataProperties[this.COMPOSED_TASK_LABEL]);
+      }
+      nodesIndex.push(newNode.id);
+      builtNodesMap[inputnodes[n].id] = newNode.id;
+    }
+
+    const inputlinksCount = inputlinks ? inputlinks.length : 0;
+    for (let l = 0; l < inputlinksCount; l++) {
+      link = inputlinks[l];
+      const props = {};
+      if (link.properties) {
+        // TODO fix when properties supported
+        // Copy the transitionName from the properties in the JSON form
+        // as task exit status in the built link
+        // props.ExitStatus = link.properties.transitionName;
+      }
+      // TODO safe to delete from/to/nodesIndex now?
+      const otherfrom = { 'id': builtNodesMap[link.from], 'selector': '.output-port'};
+      const otherto = { 'id': builtNodesMap[link.to], 'selector': '.input-port'};
+
+      const metadata2 = this.createMetadata('link', 'links', '', new Map<string, Flo.PropertyMetadata>());
+      flo.createLink(otherfrom, otherto, metadata2, new Map<string, any>());
+    }
+
+    flo.performLayout();
+
+    // Graph is empty? Ensure there are at least start and end nodes created!
+    const promise = nodesIndex.length ? flo.performLayout() : flo.clearGraph();
+
+    if (promise && promise.then && promise.then.call) {
+      promise.then(function() {
+        flo.fitToPage();
+      });
+    } else {
+      flo.fitToPage();
+    }
+
+  }
+
+  private matchGroup(metamodel, type, incoming, outgoing) {
+    // TODO simple port of this function doesn't work
+    console.log('matchGroup', type, incoming, outgoing);
+    incoming = typeof incoming === 'number' ? incoming : 0;
+    outgoing = typeof outgoing === 'number' ? outgoing : 0;
+    const matches = [];
+    let i;
+    if (type) {
+      for (i in metamodel) {
+        if (metamodel[i][type]) {
+          matches.push(metamodel[i][type]);
+        }
+      }
+    }
+    let group;
+    let score = Number.MIN_VALUE;
+    for (i = 0; i < matches.length; i++) {
+      const constraints = matches[i].constraints;
+      if (constraints) {
+        let failedConstraintsNumber = 0;
+        if (typeof constraints.maxOutgoingLinksNumber === 'number' && constraints.maxOutgoingLinksNumber < outgoing) {
+          failedConstraintsNumber++;
+        }
+        if (typeof constraints.minOutgoingLinksNumber === 'number' && constraints.minOutgoingLinksNumber > outgoing) {
+          failedConstraintsNumber++;
+        }
+        if (typeof constraints.maxIncomingLinksNumber === 'number' && constraints.maxIncomingLinksNumber < incoming) {
+          failedConstraintsNumber++;
+        }
+        if (typeof constraints.minIncomingLinksNumber === 'number' && constraints.minIncomingLinksNumber > incoming) {
+          failedConstraintsNumber++;
+        }
+
+        if (failedConstraintsNumber === 0) {
+          return matches[i].group;
+        } else if (failedConstraintsNumber > score) {
+          score = failedConstraintsNumber;
+          group = matches[i].group;
+        }
+      } else {
+        return matches[i].group;
+      }
+    }
+    return group;
+  }
+}

--- a/ui/src/app/tasks/flo/node/node.component.html
+++ b/ui/src/app/tasks/flo/node/node.component.html
@@ -1,0 +1,56 @@
+<svg:g [ngSwitch]="metaName">
+
+  <svg:g *ngSwitchCase="'START'" class="composed-task">
+    <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
+      <svg:circle class="border"/>
+      <svg:text class="label"/>
+    </svg:g>
+    <svg:circle class="output-port" tooltip="Output Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+  </svg:g>
+
+  <svg:g *ngSwitchCase="'END'" class="composed-task">
+    <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
+      <svg:circle class="inner"/>
+      <svg:circle class="outer"/>
+      <svg:text class="label"/>
+    </svg:g>
+    <svg:circle class="input-port" tooltip="Input Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+  </svg:g>
+
+  <svg:g *ngSwitchCase="'sync'" class="composed-task">
+    <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
+      <svg:circle class="border"/>
+      <svg:text class="label"/>
+    </svg:g>
+    <svg:circle class="input-port" tooltip="Input Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+    <svg:circle class="output-port" tooltip="Output Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+  </svg:g>
+
+  <svg:g *ngSwitchDefault class="composed-task">
+    <svg:g class="shape" [tooltip]="canvasNodeTooltip" container="body" placement="bottom" containerClass="app-tooltip" [isDisabled]="isDisabled">
+      <svg:rect class="border"/>
+      <svg:text class="label"/>
+    </svg:g>
+    <svg:circle class="input-port" tooltip="Input Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+    <svg:circle class="output-port" tooltip="Output Port" container="body" [isDisabled]="!isCanvas() && canvasNodeTooltip"/>
+  </svg:g>
+
+</svg:g>
+
+<template #canvasNodeTooltip>
+  <div ng-if="cell.attr('metadata/name')">
+    <span><strong>{{metaName | uppercase}}</strong></span>
+    <span><strong>{{'(' + (metaGroup | capitalize) + ')'}}</strong></span>
+  </div>
+  <div *ngIf="description">
+    <span>{{description}}</span>
+  </div>
+  <table class="table-condensed" *ngIf="allProperties && isPropertiesShown">
+    <tbody>
+    <tr *ngFor="let property of keys(allProperties).sort()">
+      <td class="tooltip-property-key"><strong>{{property}}</strong></td>
+      <td class="tooltip-property-value" [ngClass]="{'tooltip-property-value-code': isCode(property)}">{{getPropertyValue(property)}}</td>
+    </tr>
+    </tbody>
+  </table>
+</template>

--- a/ui/src/app/tasks/flo/node/node.component.scss
+++ b/ui/src/app/tasks/flo/node/node.component.scss
@@ -1,0 +1,11 @@
+.app-tooltip .tooltip-inner {
+  max-width: 400px;
+}
+
+.tooltip-property-value {
+  word-break: break-all;
+}
+
+.tooltip-property-key {
+  vertical-align: top;
+}

--- a/ui/src/app/tasks/flo/node/node.component.ts
+++ b/ui/src/app/tasks/flo/node/node.component.ts
@@ -1,0 +1,80 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { dia } from 'jointjs';
+import { Flo, Constants } from 'spring-flo';
+import { BaseShapeComponent } from '../../../streams/flo/support/shape-component';
+
+/**
+* Component for displaying application properties and capturing their values.
+*
+* @author Alex Boyko
+* @author Andy Clement
+*/
+@Component({
+  selector: 'app-flo-node',
+  templateUrl: 'node.component.html',
+  styleUrls: [ './node.component.scss' ],
+  encapsulation: ViewEncapsulation.None
+})
+export class NodeComponent extends BaseShapeComponent {
+
+  _description: string;
+
+  constructor() {
+    super();
+  }
+
+  getPropertyValue(property: string): any {
+    return this.view ? this.view.model.attr(`props/${property}`) : '';
+  }
+
+  isCanvas(): boolean {
+    return this.paper.model.get('type') === Constants.CANVAS_CONTEXT;
+  }
+
+  get paper(): dia.Paper {
+    return this.view ? (<any>this.view).paper : undefined;
+  }
+
+  get metadata(): Flo.ElementMetadata {
+    return this.view ? this.view.model.attr('metadata') : undefined;
+  }
+
+  get metaName(): string {
+    return this.metadata ? this.metadata.name : 'Unknown';
+  }
+
+  get metaGroup(): string {
+    return this.metadata ? this.metadata.group : 'Unknown';
+  }
+
+  get allProperties(): any {
+    return this.view ? this.view.model.attr('props') : {};
+  }
+
+  get isPropertiesShown(): boolean {
+    return this.view ? !this.view.model.attr('metadata/metadata/hide-tooltip-options') : false;
+  }
+
+  get description(): string {
+    if (this._description === undefined) {
+      if (this.metadata && this.metadata.description) {
+        this.metadata.description().then(d => this._description = d);
+      }
+    }
+    return this._description;
+  }
+
+  get isDisabled(): boolean {
+    return !this.metadata || this.metadata.unresolved || this.cannotShowToolTip;
+  }
+
+  isCode(property: string): boolean {
+    return false;
+  }
+
+  keys(o: any): Array<string> {
+    return Object.keys(o);
+  }
+
+}
+

--- a/ui/src/app/tasks/flo/render.service.ts
+++ b/ui/src/app/tasks/flo/render.service.ts
@@ -1,0 +1,162 @@
+import { ApplicationRef, ComponentFactoryResolver, ComponentRef, Injectable, Injector, Type } from '@angular/core';
+import { Constants, Flo } from 'spring-flo';
+import { dia } from 'jointjs';
+import { defaultsDeep } from 'lodash';
+import { TaskAppShape, BatchSyncShape, BatchLink, BatchStartShape, BatchEndShape } from './support/shapes';
+import { layout } from '../../streams/flo/support/layout';
+import { ShapeComponent } from '../../streams/flo/support/shape-component';
+import { NodeComponent } from './node/node.component';
+import { DecorationComponent } from '../../streams/flo/decoration/decoration.component';
+import { HandleComponent } from '../../streams/flo/handle/handle.component';
+import * as _joint from 'jointjs';
+const joint: any = _joint;
+
+const HANDLE_ICON_MAP = new Map<string, string>()
+  .set(Constants.REMOVE_HANDLE_TYPE, 'assets/img/delete.svg')
+  .set(Constants.PROPERTIES_HANDLE_TYPE, 'assets/img/cog.svg');
+
+const HANDLE_ICON_SIZE = new Map<string, dia.Size>()
+  .set(Constants.REMOVE_HANDLE_TYPE, {width: 10, height: 10})
+  .set(Constants.PROPERTIES_HANDLE_TYPE, {width: 11, height: 11});
+
+const DECORATION_ICON_MAP = new Map<string, string>()
+  .set(Constants.ERROR_DECORATION_KIND, 'assets/img/error.svg');
+
+const SHAPE_TYPE_COMPONENT_TYPE = new Map<string, Type<ShapeComponent>>()
+  .set(joint.shapes.flo.NODE_TYPE, NodeComponent)
+  .set(joint.shapes.flo.DECORATION_TYPE, DecorationComponent)
+  .set(joint.shapes.flo.HANDLE_TYPE, HandleComponent);
+
+@Injectable()
+export class RenderService implements Flo.Renderer {
+
+  constructor(
+    private componentFactoryResolver?: ComponentFactoryResolver,
+    private injector?: Injector,
+    private applicationRef?: ApplicationRef
+  ) {}
+
+  createHandle(kind: string, parent: dia.Cell) {
+    console.log('createHandle', kind);
+    return new joint.shapes.flo.ErrorDecoration({
+      size: HANDLE_ICON_SIZE.get(kind),
+      attrs: {
+        'image': {
+          'xlink:href': HANDLE_ICON_MAP.get(kind)
+        }
+      }
+    });
+  }
+
+  createDecoration(kind: string, parent: dia.Cell) {
+    console.log('createDecoration', kind);
+    return new joint.shapes.flo.ErrorDecoration({
+      size: {width: 16, height: 16},
+      attrs: {
+        'image': {
+          'xlink:href': DECORATION_ICON_MAP.get(kind)
+        }
+      }
+    });
+  }
+
+  createNode(metadata: Flo.ElementMetadata): dia.Element {
+    console.log('createNode', metadata.group, metadata.name);
+    if (metadata.group === 'task') {
+      return new TaskAppShape(
+        defaultsDeep({
+          attrs: {
+            '.label': {
+              'text': metadata.name
+            }
+          }
+        }, TaskAppShape.prototype.defaults)
+      );
+    } else if (metadata.name === 'START') {
+      return new BatchStartShape(
+        defaultsDeep({
+          attrs: {
+            '.label': {
+              'text': metadata.name
+            }
+          }
+        }, BatchStartShape.prototype.defaults)
+      );
+    } else if (metadata.name === 'END') {
+      return new BatchEndShape(
+        defaultsDeep({
+          attrs: {
+            '.label': {
+              'text': metadata.name
+            }
+          }
+        }, BatchEndShape.prototype.defaults)
+      );
+    } else if (metadata.name === 'sync') {
+      return new BatchSyncShape(
+        defaultsDeep({
+          attrs: {
+            '.label': {
+              'text': metadata.name
+            }
+          }
+        }, BatchSyncShape.prototype.defaults)
+      );
+    }
+  }
+
+  createLink() {
+    return new BatchLink();
+  }
+
+  layout(paper) {
+    return Promise.resolve(layout(paper));
+  }
+
+  getNodeView(): dia.ElementView {
+    console.log('getNodeView');
+    const self = this;
+
+    return joint.dia.ElementView.extend({
+      options: defaultsDeep({}, joint.dia.ElementView.prototype.options),
+
+      renderMarkup: function () {
+        // Not called often. It's fine to destro old component and create the new one, because old DOM
+        // may have been aletered by JointJS updates
+        if (self.componentFactoryResolver && SHAPE_TYPE_COMPONENT_TYPE.has(this.model.get('type'))) {
+          if (this._angularComponentRef) {
+            this._angularComponentRef.destroy();
+          }
+          const nodeComponentFactory = self.componentFactoryResolver
+            .resolveComponentFactory(SHAPE_TYPE_COMPONENT_TYPE.get(this.model.get('type')));
+
+          const componentRef: ComponentRef<ShapeComponent> = nodeComponentFactory.create(self.injector);
+          self.applicationRef.attachView(componentRef.hostView);
+          componentRef.instance.view = this;
+          this._angularComponentRef = componentRef;
+          const nodes = [];
+          for (let i = 0; i < this._angularComponentRef.location.nativeElement.children.length; i++) {
+            nodes.push(this._angularComponentRef.location.nativeElement.children.item(i));
+          }
+
+          const vNodes = nodes.map(childNode => new joint.V(childNode));
+          this.vel.append(vNodes);
+
+          this._angularComponentRef.changeDetectorRef.markForCheck();
+          this._angularComponentRef.changeDetectorRef.detectChanges();
+        } else {
+          joint.dia.ElementView.prototype.renderMarkup.apply(this, arguments);
+        }
+      },
+
+      onRemove: function() {
+        if (this._angularComponentRef) {
+          this._angularComponentRef.destroy();
+        }
+        joint.dia.ElementView.prototype.onRemove.apply(this, arguments);
+      },
+
+    });
+
+  }
+}

--- a/ui/src/app/tasks/flo/support/shapes.ts
+++ b/ui/src/app/tasks/flo/support/shapes.ts
@@ -1,0 +1,292 @@
+import { defaultsDeep } from 'lodash';
+import * as _joint from 'jointjs';
+
+const joint: any = _joint;
+
+export const IMAGE_W = 120;
+export const IMAGE_H = 40;
+export const CONTROLNODES_GROUP_TYPE = 'control nodes';
+
+const CONTROL_NODE_SIZE = {
+  width: 40,
+  height: 40
+};
+
+const START_END_NODE_CENTRE_TRANSFORM =
+  'translate(' + CONTROL_NODE_SIZE.width / 2 + ' ' + CONTROL_NODE_SIZE.height / 2 + ')';
+
+export const TaskAppShape = joint.shapes.basic.Generic.extend({
+  markup:
+  '<g class="composed-task">' +
+    '<g class="shape">' +
+      '<rect class="border"/>' +
+      '<text class="label"/>' +
+    '</g>' +
+    '<circle class="input-port" />' +
+    '<circle class="output-port" />' +
+  '</g>',
+
+  defaults: defaultsDeep({
+    type: joint.shapes.flo.NODE_TYPE,
+    position: {x: 0, y: 0},
+    size: { width: IMAGE_W, height: IMAGE_H },
+    attrs: {
+      '.': { magnet: false },
+      '.border': {
+        width: IMAGE_W,
+        height: IMAGE_H,
+        rx: 5,
+        ry: 5,
+        'stroke-width' : 1,
+        'stroke': '#34302D',
+        fill: '#6db33f'
+      },
+      '.input-port': {
+        r: 7,
+        type: 'input',
+        magnet: true,
+        fill: '#5fa134',
+        'ref-x': 0.5,
+        'ref-y': 0,
+        ref: '.border',
+        stroke: '#34302D'
+      },
+      '.output-port': {
+        r: 7,
+        type: 'output',
+        magnet: true,
+        fill: '#5fa134',
+        'ref-x': 0.5,
+        'ref-y': 0.99999999,
+        ref: '.border',
+        stroke: '#34302D',
+      },
+      '.label': {
+        'ref-x': 0.5,
+        'ref-y': 0.5,
+        'y-alignment': 'middle',
+        'x-alignment': 'middle',
+        ref: '.border',
+        fill: 'white',
+        'font-family': 'Monospace',
+      },
+      '.shape': {
+      }
+    },
+  }, joint.shapes.basic.Generic.prototype.defaults)
+});
+
+export const BatchStartShape = joint.shapes.basic.Generic.extend({
+  markup:
+  '<g class="composed-task">' +
+    '<g class="shape">' +
+      '<circle class="border"/>' +
+      '<text class="label"/>' +
+    '</g>' +
+    '<circle class="output-port"/>' +
+  '</g>',
+
+  defaults: defaultsDeep({
+    size: CONTROL_NODE_SIZE,
+    attrs: {
+      '.output-port': {
+        r: 7,
+        type: 'output',
+        magnet: true,
+        fill: '#5fa134',
+        'ref-x': 0.5,
+        'ref-y': 0.99999999,
+        ref: '.border',
+        stroke: '#34302D',
+      },
+      '.border': {
+        r: CONTROL_NODE_SIZE.width / 2,
+        'stroke-width': 1,
+        fill: '#6db33f',
+        stroke: '#34302D',
+        transform: START_END_NODE_CENTRE_TRANSFORM
+      },
+      '.label': {
+        'text-anchor': 'middle',
+        transform: 'translate(' + CONTROL_NODE_SIZE.width / 2 + ' -12)',
+        fill: 'black',
+        'font-family': 'Monospace',
+        'font-size': 20,
+        text: 'START'
+      },
+      '.shape': {
+      }
+    }
+  }, joint.shapes.basic.Generic.prototype.defaults)
+});
+
+export const BatchEndShape = joint.shapes.basic.Generic.extend({
+  markup:
+  '<g class="composed-task">' +
+    '<g class="shape">' +
+      '<circle class="inner"/>' +
+      '<circle class="outer"/>' +
+      '<text class="label"/>' +
+    '</g>' +
+    '<g>' +
+      '<circle class="input-port"/>' +
+    '</g>' +
+  '</g>',
+
+  defaults: defaultsDeep({
+    size: CONTROL_NODE_SIZE,
+    attrs: {
+      '.inner': {
+        fill: '#6db33f',
+        stroke: '#34302D',
+        transform: START_END_NODE_CENTRE_TRANSFORM,
+        r: CONTROL_NODE_SIZE.width / 2 - 10
+      },
+      '.outer': {
+        fill: 'transparent',
+        stroke: '#34302D',
+        'stroke-width': 1,
+        transform: START_END_NODE_CENTRE_TRANSFORM,
+        r: CONTROL_NODE_SIZE.width / 2
+      },
+      '.input-port': {
+        r: 7,
+        type: 'input',
+        magnet: true,
+        fill: '#5fa134',
+        'ref-x': 0.5,
+        'ref-y': 0,
+        ref: '.outer',
+        stroke: '#34302D'
+      },
+      '.label': {
+        'ref-x': 0.5,
+        'ref-y': 0.52,
+        'x-alignment': 'middle',
+        'y-alignment': 'middle',
+        ref: '.outer',
+        fill: 'white',
+        'font-family': 'Monospace',
+        'font-size': 10,
+        text: 'END'
+      },
+      '.shape': {
+      }
+    }
+  }, joint.shapes.basic.Generic.prototype.defaults)
+});
+
+export const BatchSyncShape = joint.shapes.basic.Generic.extend({
+  markup:
+    '<g class="composed-task">' +
+      '<g class="shape">' +
+        '<circle class="border"/>' +
+        '<text class="label"/>' +
+      '</g>' +
+      '<circle class="input-port"/>' +
+      '<circle class="output-port" />' +
+    '</g>',
+
+  defaults: defaultsDeep({
+    type: joint.shapes.flo.NODE_TYPE,
+    size: CONTROL_NODE_SIZE,
+    attrs: {
+      '.input-port': {
+        r: 7,
+        type: 'input',
+        magnet: true,
+        fill: '#5fa134',
+        'ref-x': 0.5,
+        'ref-y': 0,
+        ref: '.border',
+        stroke: '#34302D'
+      },
+      '.output-port': {
+        r: 7,
+        type: 'output',
+        magnet: true,
+        fill: '#5fa134',
+        'ref-x': 0.5,
+        'ref-y': 0.99999999,
+        ref: '.border',
+        stroke: '#34302D',
+      },
+      '.border': {
+        r: CONTROL_NODE_SIZE.width / 2,
+        'stroke-width': 1,
+        fill: '#6db33f',
+        stroke: '#34302D',
+        transform: START_END_NODE_CENTRE_TRANSFORM
+      },
+      '.label': {
+        'ref-x': 0.5,
+        'ref-y': 0.52,
+        'y-alignment': 'middle',
+        'x-alignment': 'middle',
+        ref: '.border',
+        fill: 'white',
+        'font-family': 'Monospace',
+        text: 'SYNC'
+      },
+      '.shape': {
+      }
+    }
+  }, joint.shapes.basic.Generic.prototype.defaults)
+});
+
+export const BatchLink = joint.dia.Link.extend({
+  toolMarkup: [
+    '<g class="link-tool composed-task">',
+      '<g class="tool-remove" event="remove">',
+        '<rect class="link-tools-container" width="47" height="22" transform="translate(-11 -11)"/>',
+        '<circle r="11" />',
+        '<path transform="scale(.8) translate(-16, -16)" d="M24.778,21.419 19.276,15.917 24.777,10.415 21.949,7.585 ' +
+          '16.447,13.087 10.945,7.585 8.117,10.415 13.618,15.917 8.116,21.419 10.946,24.248 16.447,18.746 21.948,24.248z"/>',
+        '<title>Remove link.</title>',
+      '</g>',
+      '<g class="tool-options" event="link:options">',
+        '<circle r="11" transform="translate(25)"/>',
+        '<path fill="white" transform="scale(.7) translate(20, -16)" d="M31.229,17.736c0.064-0.571,0.104-1.148,0.104-' +
+          '1.736s-0.04-1.166-0.104-1.737l-4.377-1.557c-0.218-0.716-0.504-1.401-0.851-2.05l1.993-4.192c-0.725-0.91-' +
+          '1.549-1.734-2.458-2.459l-4.193,1.994c-0.647-0.347-1.334-0.632-2.049-0.849l-1.558-4.378C17.165,0.708,16.588,' +
+          '0.667,16,0.667s-1.166,0.041-1.737,0.105L12.707,5.15c-0.716,0.217-1.401,0.502-2.05,0.849L6.464,4.005C5.554,' +
+          '4.73,4.73,5.554,4.005,6.464l1.994,4.192c-0.347,0.648-0.632,1.334-0.849,2.05l-4.378,1.557C0.708,14.834,0.667,' +
+          '15.412,0.667,16s0.041,1.165,0.105,1.736l4.378,1.558c0.217,0.715,0.502,1.401,0.849,2.049l-1.994,4.193c0.725,' +
+          '0.909,1.549,1.733,2.459,2.458l4.192-1.993c0.648,0.347,1.334,0.633,2.05,0.851l1.557,4.377c0.571,0.064,1.148,' +
+          '0.104,1.737,0.104c0.588,0,1.165-0.04,1.736-0.104l1.558-4.377c0.715-0.218,1.399-0.504,2.049-0.851l4.193,' +
+          '1.993c0.909-0.725,1.733-1.549,2.458-2.458l-1.993-4.193c0.347-0.647,0.633-1.334,0.851-2.049L31.229,17.736zM16,' +
+          '20.871c-2.69,0-4.872-2.182-4.872-4.871c0-2.69,2.182-4.872,4.872-4.872c2.689,0,4.871,2.182,4.871,4.872C20.871,' +
+          '18.689,18.689,20.871,16,20.871z"/>',
+        '<title>Properties</title>',
+      '</g>',
+    '</g>'
+  ].join(''),
+
+  arrowheadMarkup: [
+    '<g class="marker-arrowhead-group marker-arrowhead-group-<%= end %>">',
+      '<path class="marker-arrowhead" end="<%= end %>" d="M 16 0 L 0 8 L 16 16 z" />',
+    '</g>'
+  ].join(''),
+
+  vertexMarkup: [
+    '<g class="marker-vertex-group" transform="translate(<%= x %>, <%= y %>)">',
+      '<circle class="marker-vertex" idx="<%= idx %>" r="8" />',
+      '<path class="marker-vertex-remove-area" idx="<%= idx %>" d="M16,5.333c-7.732,0-14,4.701-14,10.5c0,1.982,0.741,' +
+        '3.833,2.016,5.414L2,25.667l5.613-1.441c2.339,1.317,5.237,2.107,8.387,2.107c7.732,0,14-4.701,14-10.5C30,10.034,' +
+        '23.732,5.333,16,5.333z" transform="translate(5, -33)"/>',
+      '<path class="marker-vertex-remove" idx="<%= idx %>" transform="scale(.8) translate(8.5, -37)" d="M24.778,21.419 ' +
+        '19.276,15.917 24.777,10.415 21.949,7.585 16.447,13.087 10.945,7.585 8.117,10.415 13.618,15.917 8.116,21.419 ' +
+        '10.946,24.248 16.447,18.746 21.948,24.248z">',
+        '<title>Remove vertex.</title>',
+      '</path>',
+    '</g>'
+  ].join(''),
+
+  defaults: defaultsDeep({
+    attrs: {
+      '.connection': { 'stroke-linecap': 'round'},
+      '.marker-target': { d: 'M 5 0 L 0.67, 2.5 L 5 5 z', 'stroke-width' : 3},
+      'props': {}
+    }
+  }, joint.dia.Link.prototype.defaults)
+});

--- a/ui/src/app/tasks/flo/task-graph-view/task-graph-view.component.html
+++ b/ui/src/app/tasks/flo/task-graph-view/task-graph-view.component.html
@@ -1,0 +1,5 @@
+<div id="task-graph-view-container">
+  <flo-editor (floApi)="setEditorContext($event)" [metamodel]="metamodelService" [renderer]="renderService"
+              [dsl]="dsl" [paperPadding]="paperPadding" >
+  </flo-editor>
+</div>

--- a/ui/src/app/tasks/flo/task-graph-view/task-graph-view.component.spec.ts
+++ b/ui/src/app/tasks/flo/task-graph-view/task-graph-view.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaskGraphViewComponent } from './task-graph-view.component';
+
+xdescribe('TaskGraphViewComponent', () => {
+  let component: TaskGraphViewComponent;
+  let fixture: ComponentFixture<TaskGraphViewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TaskGraphViewComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TaskGraphViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/src/app/tasks/flo/task-graph-view/task-graph-view.component.ts
+++ b/ui/src/app/tasks/flo/task-graph-view/task-graph-view.component.ts
@@ -1,0 +1,39 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Flo } from 'spring-flo';
+import { MetamodelService } from '../metamodel.service';
+import { RenderService } from '../render.service';
+
+@Component({
+  selector: 'app-task-graph-view',
+  templateUrl: './task-graph-view.component.html',
+  styleUrls: ['./task-graph-view.component.scss']
+})
+export class TaskGraphViewComponent implements OnInit {
+
+  @Input()
+  dsl: string;
+
+  @Input()
+  paperPadding = 5;
+
+  private editorContext: Flo.EditorContext;
+
+  constructor(
+    public metamodelService: MetamodelService,
+    public renderService: RenderService
+  ) {}
+
+  ngOnInit() {
+  }
+
+  setEditorContext(editorContext: Flo.EditorContext) {
+    this.editorContext = editorContext;
+    this.editorContext.noPalette = true;
+    this.editorContext.readOnlyCanvas = true;
+  }
+
+  get flo(): Flo.EditorContext {
+    return this.editorContext;
+  }
+
+}

--- a/ui/src/app/tasks/task-create-composed-task/task-create-composed-task.component.html
+++ b/ui/src/app/tasks/task-create-composed-task/task-create-composed-task.component.html
@@ -1,3 +1,15 @@
-<p>
-  This is in under development. We would love to hear feedback on the other available tabs/views.
-</p>
+<div id="flo-container" class="stream-editor">
+  <flo-editor (floApi)="editorContext = $event" [metamodel]="metamodelService" [renderer]="renderService"
+              [editor]="editorService" [paletteSize]="paletteSize" [paperPadding]="20" [(dsl)]="dsl">
+    <button (click)="createTaskDefs()" class="btn btn-default" type="button">Create</button>
+    <button (click)="editorContext.clearGraph()" class="btn btn-default" type="button">Clear</button>
+    <button (click)="arrangeAll()" class="btn btn-default" type="button">Layout</button>
+    <button class="btn" (click)="gridOn = !gridOn"
+            [ngClass]="{'btn-default-alt': !gridOn, 'btn-default': gridOn}">Grid</button>
+    <div class="flow-definition-container">
+      <dsl-editor [(dsl)]="dsl" line-numbers="true" line-wrapping="true" (blur)="editorContext.graphToTextSync=true"
+                  (focus)="editorContext.graphToTextSync=false" placeholder="Enter Composed Task definition here..."
+      ></dsl-editor>
+    </div>
+  </flo-editor>
+</div>

--- a/ui/src/app/tasks/task-create-composed-task/task-create-composed-task.component.ts
+++ b/ui/src/app/tasks/task-create-composed-task/task-create-composed-task.component.ts
@@ -1,14 +1,33 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { MetamodelService } from '../flo/metamodel.service';
+import { RenderService } from '../flo/render.service';
+import { EditorService } from '../flo/editor.service';
+import { Flo } from 'spring-flo';
 
 @Component({
   selector: 'app-task-create-composed-task',
   templateUrl: './task-create-composed-task.component.html',
+  styleUrls: [ '../../streams/flo/flo.scss' ],
+  encapsulation: ViewEncapsulation.None
 })
 export class TaskCreateComposedTaskComponent implements OnInit {
 
-  constructor() { }
+  dsl: string;
+  paletteSize = 170;
+  gridOn = false;
+  editorContext: Flo.EditorContext;
+
+  constructor(public metamodelService: MetamodelService,
+              public renderService: RenderService,
+              public editorService: EditorService) { }
 
   ngOnInit() {
   }
 
+  arrangeAll() {
+    this.editorContext.performLayout().then(() => this.editorContext.fitToPage());
+  }
+
+  createTaskDefs() {
+  }
 }

--- a/ui/src/app/tasks/tasks.module.ts
+++ b/ui/src/app/tasks/tasks.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { SharedModule } from '../shared/shared.module';
 import { NgxPaginationModule } from 'ngx-pagination';
 
+import { FloModule } from 'spring-flo';
 import { TasksComponent } from './tasks.component';
 import { TaskAppsComponent } from './task-apps/task-apps.component';
 import { TaskDefinitionsComponent } from './task-definitions/task-definitions.component';
@@ -15,8 +16,13 @@ import { TaskLaunchComponent } from './task-launch/task-launch.component';
 import { TasksService } from './tasks.service';
 import { TasksRoutingModule } from './tasks-routing.module';
 import { ReactiveFormsModule } from '@angular/forms';
-import { ModalModule, PopoverModule } from 'ngx-bootstrap';
+import { ModalModule, PopoverModule, TooltipModule } from 'ngx-bootstrap';
 import { AuthModule } from '../auth/auth.module';
+import { TaskGraphViewComponent } from './flo/task-graph-view/task-graph-view.component';
+import { MetamodelService } from './flo/metamodel.service';
+import { RenderService } from './flo/render.service';
+import { EditorService } from './flo/editor.service';
+import { NodeComponent } from './flo/node/node.component';
 
 @NgModule({
   imports: [
@@ -26,7 +32,9 @@ import { AuthModule } from '../auth/auth.module';
     ReactiveFormsModule,
     ModalModule.forRoot(),
     PopoverModule.forRoot(),
-    AuthModule
+    AuthModule,
+    FloModule,
+    TooltipModule.forRoot()
   ],
   declarations: [
     TasksComponent,
@@ -38,10 +46,18 @@ import { AuthModule } from '../auth/auth.module';
     TaskAppDetailsComponent,
     TaskCreateComponent,
     TaskBulkDefineComponent,
-    TaskLaunchComponent
+    TaskLaunchComponent,
+    TaskGraphViewComponent,
+    NodeComponent,
+  ],
+  entryComponents: [
+    NodeComponent
   ],
   providers: [
-    TasksService
+    TasksService,
+    MetamodelService,
+    RenderService,
+    EditorService
   ]
 })
 export class TasksModule { }


### PR DESCRIPTION
- Focus for this is to copy and implement tasks
  editors without touching any flo code in streams.
  Essentially this is to get dsl and flo editor to
  work on some level. Some error are still expected
  which will get fixed in other PR's.
- When tasks flo is closer to its full implementation,
  then it's easier to see what is the actual shared
  feature set in tasks and streams and extract that
  to shared classes. For this specific reason I'm
  referensing some stream flo classes from tasks.
- I'm starting to add tests in PR's after this.
- There has been some attempt to not use stuff under
  `joint.shapes.flo` directly as it will create situation
  where typescript compiles but may result runtime
  errors if some specific imports are missing.
- Fixes #484