### PR TITLE
Add tools service

### DIFF
--- a/ui/src/app/tasks/flo/editor.service.ts
+++ b/ui/src/app/tasks/flo/editor.service.ts
@@ -8,6 +8,11 @@ import { PropertiesDialogComponent } from '../../streams/flo/properties/properti
 
 const joint: any = _joint;
 
+/**
+ * Flo service class for its Editor used for composed tasks.
+ *
+ * @author Janne Valkealahti
+ */
 @Injectable()
 export class EditorService implements Flo.Editor {
 
@@ -15,6 +20,13 @@ export class EditorService implements Flo.Editor {
     private bsModalService: BsModalService
   ) {}
 
+  /**
+   * Creates cell handles.
+   *
+   * @param {Flo.EditorContext} flo the flo editor context
+   * @param {(owner: dia.CellView, kind: string, action: () => void, location: dia.Point) => void} createHandle the create function
+   * @param {dia.CellView} owner the owner cell
+   */
   createHandles(flo: Flo.EditorContext, createHandle: (owner: dia.CellView, kind: string,
                                                        action: () => void, location: dia.Point) => void, owner: dia.CellView): void {
     if (owner.model instanceof joint.dia.Link) {
@@ -39,6 +51,13 @@ export class EditorService implements Flo.Editor {
     }
   }
 
+  /**
+   * Creates a default content for flo editor. These are outside of what
+   * is in dsl and i.e. composed tasks always need to create start and end nodes.
+   *
+   * @param {Flo.EditorContext} editorContext the flo editor context
+   * @param {Map<string, Map<string, Flo.ElementMetadata>>} elementMetadata the element metadata
+   */
   setDefaultContent(editorContext: Flo.EditorContext,
                     elementMetadata: Map<string, Map<string, Flo.ElementMetadata>>): void {
     editorContext.createNode(this.createMetadata('START',

--- a/ui/src/app/tasks/flo/model/models.ts
+++ b/ui/src/app/tasks/flo/model/models.ts
@@ -1,0 +1,69 @@
+/**
+ * Generic response type returned from both tools conversions.
+ */
+export class TaskConversion {
+
+  public graph: Graph;
+  public dsl: string;
+  public errors: Array<Map<string, any>> = new Array();
+
+  constructor(dsl: string, errors?: Array<Map<string, any>>, graph?: Graph) {
+    this.dsl = dsl;
+    if (errors) {
+      this.errors = errors;
+    }
+    this.graph = graph;
+  }
+}
+
+/**
+ * Represents a graph in a TaskConversion response.
+ */
+export class Graph {
+
+  public nodes: Array<Node>;
+  public links: Array<Link>;
+
+  constructor(nodes: Array<Node>, links: Array<Link>) {
+    this.nodes = nodes;
+    this.links = links;
+  }
+
+  toJson(): string {
+    return JSON.stringify(this);
+  }
+}
+
+/**
+ * Represents node in a Graph.
+ */
+export class Node {
+
+  public id: string;
+  public name: string;
+  public properties: Map<string, string>;
+  public metadata: Map<string, string>;
+
+  constructor(id: string, name: string, properties?: Map<string, string>, metadata?: Map<string, string>) {
+    this.id = id;
+    this.name = name;
+    this.properties = properties;
+    this.metadata = metadata;
+  }
+}
+
+/**
+ * Represents link in a Graph.
+ */
+export class Link {
+
+  public from: string;
+  public to: string;
+  public properties: Map<string, string>;
+
+  constructor(from: string, to: string, properties?: Map<string, string>) {
+    this.from = from;
+    this.to = to;
+    this.properties = properties;
+  }
+}

--- a/ui/src/app/tasks/flo/render.service.ts
+++ b/ui/src/app/tasks/flo/render.service.ts
@@ -2,6 +2,7 @@ import { ApplicationRef, ComponentFactoryResolver, ComponentRef, Injectable, Inj
 import { Constants, Flo } from 'spring-flo';
 import { dia } from 'jointjs';
 import { defaultsDeep } from 'lodash';
+import { BsModalService } from 'ngx-bootstrap';
 import { TaskAppShape, BatchSyncShape, BatchLink, BatchStartShape, BatchEndShape } from './support/shapes';
 import { layout } from '../../streams/flo/support/layout';
 import { ShapeComponent } from '../../streams/flo/support/shape-component';
@@ -9,6 +10,7 @@ import { NodeComponent } from './node/node.component';
 import { DecorationComponent } from '../../streams/flo/decoration/decoration.component';
 import { HandleComponent } from '../../streams/flo/handle/handle.component';
 import * as _joint from 'jointjs';
+import { PropertiesDialogComponent } from '../../streams/flo/properties/properties-dialog.component';
 const joint: any = _joint;
 
 const HANDLE_ICON_MAP = new Map<string, string>()
@@ -27,15 +29,27 @@ const SHAPE_TYPE_COMPONENT_TYPE = new Map<string, Type<ShapeComponent>>()
   .set(joint.shapes.flo.DECORATION_TYPE, DecorationComponent)
   .set(joint.shapes.flo.HANDLE_TYPE, HandleComponent);
 
+/**
+ * Flo service class for its Renderer used for composed tasks.
+ *
+ * @author Janne Valkealahti
+ */
 @Injectable()
 export class RenderService implements Flo.Renderer {
 
   constructor(
+    private bsModalService: BsModalService,
     private componentFactoryResolver?: ComponentFactoryResolver,
     private injector?: Injector,
     private applicationRef?: ApplicationRef
   ) {}
 
+  /**
+   * Creates handle in flo cells.
+   *
+   * @param {string} kind the cell type
+   * @param {dia.Cell} parent the owner
+   */
   createHandle(kind: string, parent: dia.Cell) {
     console.log('createHandle', kind);
     return new joint.shapes.flo.ErrorDecoration({
@@ -48,6 +62,12 @@ export class RenderService implements Flo.Renderer {
     });
   }
 
+  /**
+   * Creates decuration in flo cells.
+   *
+   * @param {string} kind the cell type
+   * @param {dia.Cell} parent the owner
+   */
   createDecoration(kind: string, parent: dia.Cell) {
     console.log('createDecoration', kind);
     return new joint.shapes.flo.ErrorDecoration({
@@ -60,6 +80,13 @@ export class RenderService implements Flo.Renderer {
     });
   }
 
+  /**
+   * Creates a node with a supported types. Called with
+   * types shown in flo editor.
+   *
+   * @param {Flo.ElementMetadata} metadata the element metadata
+   * @returns {dia.Element} the created element
+   */
   createNode(metadata: Flo.ElementMetadata): dia.Element {
     console.log('createNode', metadata.group, metadata.name);
     if (metadata.group === 'task') {
@@ -105,14 +132,48 @@ export class RenderService implements Flo.Renderer {
     }
   }
 
+  /**
+   * Creates a link used to link nodes. For now we
+   * only have one node link type.
+   */
   createLink() {
     return new BatchLink();
   }
 
+  /**
+   * Handles events from link. These will happen for various
+   * events like connects and disconnects. Also delete and options
+   * are sent as events.
+   *
+   * @param {Flo.EditorContext} context the editor context
+   * @param {string} event the event type
+   * @param {dia.Link} link the link
+   */
+  handleLinkEvent(context: Flo.EditorContext, event: string, link: dia.Link): void {
+    if (event === 'options') {
+      // TODO, doesn't really work, maybe flo issue
+      const modalRef = this.bsModalService.show(PropertiesDialogComponent);
+      modalRef.content.title = `Properties for LINK`;
+      modalRef.content.setData(link, context.getGraph());
+    }
+  }
+
+  /**
+   * Layout whole flo. For now just delegates to resolve.
+   *
+   * @param paper the flo paper
+   * @returns {Promise<any>} a promise when layout has happened
+   */
   layout(paper) {
     return Promise.resolve(layout(paper));
   }
 
+  /**
+   * Gets a node view for an element which is used to dynamically handle
+   * some angular component instantiation.
+   *
+   * @returns {dia.ElementView} a element view
+   */
   getNodeView(): dia.ElementView {
     console.log('getNodeView');
     const self = this;

--- a/ui/src/app/tasks/flo/tools.service.spec.ts
+++ b/ui/src/app/tasks/flo/tools.service.spec.ts
@@ -1,0 +1,107 @@
+import { Observable } from 'rxjs/Observable';
+import { ToolsService } from './tools.service';
+import { Graph, Link, Node } from './model/models';
+import { ErrorHandler } from '../../shared/model/error-handler';
+import { HttpUtils } from '../../shared/support/http.utils';
+import { MockResponse } from '../../tests/mocks/response';
+
+/**
+ * Tests tools service.
+ *
+ * @author Janne Valkealahti
+ */
+describe('ToolsService', () => {
+
+  const CONVERSION_RESPONSE_1 = {
+    graph: null,
+    dsl: 'timestamp',
+    errors: []
+  };
+
+  const CONVERSION_RESPONSE_2 = {
+    graph: {
+      nodes: [
+        {
+          id: '0',
+          name: 'START'
+        },
+        {
+          id: '1',
+          name: 'timestamp'
+        },
+        {
+          id: '2',
+          name: 'END'
+        }
+      ],
+      links: [
+        {
+          from: '0',
+          to: '1'
+        },
+        {
+          from: '1',
+          to: '2'
+        }
+      ]
+    },
+    dsl: null,
+    errors: []
+  };
+
+  beforeEach(() => {
+    this.mockHttp = jasmine.createSpyObj('mockHttp', ['post']);
+    this.jsonData = {};
+    const errorHandler = new ErrorHandler();
+    this.toolsService = new ToolsService(this.mockHttp, errorHandler);
+  });
+
+  describe('parseTaskTextToGraph', () => {
+    it('should call the tools service to parse dsl to graph', () => {
+      this.mockHttp.post.and.returnValue(Observable.of(this.jsonData));
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      this.toolsService.parseTaskTextToGraph('fakedsl');
+      expect(this.mockHttp.post).toHaveBeenCalledWith('/tools/parseTaskTextToGraph',
+        '{"dsl":"fakedsl","name":"unknown"}', requestOptionsArgs);
+    });
+  });
+
+  describe('convertTaskGraphToText', () => {
+    it('should call the tools service to parse graph to dsl', () => {
+      this.mockHttp.post.and.returnValue(Observable.of(this.jsonData));
+      const requestOptionsArgs = HttpUtils.getDefaultRequestOptions();
+      const graph = new Graph(new Array(), new Array());
+      this.toolsService.convertTaskGraphToText(graph);
+      expect(this.mockHttp.post).toHaveBeenCalledWith('/tools/convertTaskGraphToText',
+        '{"nodes":[],"links":[]}', requestOptionsArgs);
+    });
+  });
+
+  describe('extractConversionData', () => {
+    it('should do correct conversion', () => {
+      const response = new MockResponse();
+      response.body = CONVERSION_RESPONSE_1;
+      let taskConversion = this.toolsService.extractConversionData(response);
+      expect(taskConversion.dsl).toBe('timestamp');
+
+      response.body = CONVERSION_RESPONSE_2;
+      taskConversion = this.toolsService.extractConversionData(response);
+      expect(taskConversion.graph).toBeTruthy();
+      expect(taskConversion.graph.nodes.length).toBe(3);
+      expect(taskConversion.graph.links.length).toBe(2);
+    });
+  });
+
+  describe('model', () => {
+    it('graph to json', () => {
+      const nodes: Array<Node> = new Array();
+      nodes.push(new Node('id1', 'name1'));
+      const links: Array<Link> = new Array();
+      links.push(new Link('from1', 'to1'));
+      const graph = new Graph(nodes, links);
+      expect(graph.toJson())
+        .toBe('{"nodes":[{"id":"id1","name":"name1"}],"links":[{"from":"from1","to":"to1"}]}');
+    });
+  });
+
+});

--- a/ui/src/app/tasks/flo/tools.service.ts
+++ b/ui/src/app/tasks/flo/tools.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@angular/core';
+import { Http, Response } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { HttpUtils } from '../../shared/support/http.utils';
+import { ErrorHandler } from '../../shared/model/error-handler';
+import { Graph, Link, Node, TaskConversion } from './model/models';
+
+/**
+ * Provides tools service having conversion between
+ * dsl and flo json in composed tasks.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Injectable()
+export class ToolsService {
+
+  private parseTaskTextToGraphUrl = '/tools/parseTaskTextToGraph';
+  private convertTaskGraphToTextUrl = '/tools/convertTaskGraphToText';
+
+  constructor(
+    private http: Http,
+    private errorHandler: ErrorHandler
+  ) { }
+
+  /**
+   * Parses dsl and returns TaskConversion as an observable.
+   *
+   * @param {string} dsl the dsl
+   * @param {string} name the optional name, defaults to 'unknown'
+   * @returns {Observable<TaskConversion>}
+   */
+  parseTaskTextToGraph(dsl: string, name: string = 'unknown'): Observable<TaskConversion> {
+    const options = HttpUtils.getDefaultRequestOptions();
+    const body = '{"dsl":"' + dsl + '","name":"' + name + '"}';
+
+    return this.http.post(this.parseTaskTextToGraphUrl, body, options)
+      .map(this.extractConversionData.bind(this))
+      .catch(this.errorHandler.handleError);
+  }
+
+  /**
+   * Parses graph and returns TaskConversion as an observable.
+   *
+   * @param {string} graph the graph
+   * @returns {Observable<TaskConversion>}
+   */
+  convertTaskGraphToText(graph: Graph): Observable<TaskConversion> {
+    const options = HttpUtils.getDefaultRequestOptions();
+    const body = graph.toJson();
+
+    return this.http.post(this.convertTaskGraphToTextUrl, body, options)
+      .map(this.extractConversionData.bind(this))
+      .catch(this.errorHandler.handleError);
+  }
+
+  /**
+   * Extract TaskConversion from a response.
+   *
+   * @param {Response} res the response
+   * @returns {TaskConversion}
+   */
+  extractConversionData(res: Response): TaskConversion {
+    const body = res.json();
+
+    let graph: Graph;
+    if (body.graph) {
+      const nodes: Array<Node> = new Array();
+      const links: Array<Link> = new Array();
+      if (body.graph.nodes) {
+        body.graph.nodes.map(item => {
+          nodes.push(new Node(item.id, item.name, item.properties, item.metadata));
+        });
+      }
+      if (body.graph.links) {
+        body.graph.links.map(item => {
+          links.push(new Link(item.from, item.to, item.properties));
+        });
+      }
+      graph = new Graph(nodes, links);
+    }
+
+    return new TaskConversion(body.dsl, null, graph);
+  }
+
+}

--- a/ui/src/app/tasks/tasks.module.ts
+++ b/ui/src/app/tasks/tasks.module.ts
@@ -23,6 +23,7 @@ import { MetamodelService } from './flo/metamodel.service';
 import { RenderService } from './flo/render.service';
 import { EditorService } from './flo/editor.service';
 import { NodeComponent } from './flo/node/node.component';
+import { ToolsService } from './flo/tools.service';
 
 @NgModule({
   imports: [
@@ -57,7 +58,8 @@ import { NodeComponent } from './flo/node/node.component';
     TasksService,
     MetamodelService,
     RenderService,
-    EditorService
+    EditorService,
+    ToolsService
   ]
 })
 export class TasksModule { }


### PR DESCRIPTION
- Create new ToolsService class and domain classes
  accessing /tools to handle dsl-flo conversion logic.
  This is in favour of doing raw http calls in flo service
  classes.
- In flo metamodel/editor/render classes use this new
  service class.
- Refactor all the code around where data flows and we're
  now using those new domain classes instead of passing
  js objects around.
- Remove all dead and broken code around global properties
  in a flo. Essentially flo uses `timeout` property in start
  node together with rest of global properties. None of these
  exist in tasks nor in a service under `/tools`.
- Hard code group name matching as in old code it was done in
  matchGroup function which don't work anymore. Concept of that
  function made sense in streams space where you have more groups
  but here we have only one together with `control nodes`.
- Also all dead code which were brought over from streams to tasks
  (even in old code) are removed. Essentially this code we used in
  streams and had no meaning in tasks.
- Added broken popup for link properties. There is now a popup but
  its content view is broken as most of the features around
  node/cell properties are not yet implemented.
- Fixes #485