### PR TITLE
Fix analytics polling stop

### DIFF
--- a/ui/src/app/analytics/analytics.service.spec.ts
+++ b/ui/src/app/analytics/analytics.service.spec.ts
@@ -1,0 +1,36 @@
+import { MockToastyService } from '../tests/mocks/toasty';
+import { ErrorHandler } from '../shared/model/error-handler';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+
+  const errorHandler = new ErrorHandler();
+  const toastyService = new MockToastyService();
+
+  beforeEach(() => {
+    this.mockHttp = jasmine.createSpyObj('mockHttp', ['get']);
+    this.jsonData = { };
+    this.analyticsService = new AnalyticsService(this.mockHttp, errorHandler, toastyService);
+  });
+
+  describe('counterInterval', () => {
+    it('default interval is set', () => {
+      expect(this.analyticsService._counterInterval).toBe(2);
+    });
+
+    it('interval change is correctly set', () => {
+      this.analyticsService.counterInterval = 1;
+      expect(this.analyticsService._counterInterval).toBe(1);
+    });
+
+    it('zero interval stops polling', () => {
+      const spy = spyOn(this.analyticsService, 'stopPollingForCounters');
+
+      this.analyticsService.counterInterval = 0;
+      // interval is not set below 1 but spy that polling stops
+      expect(this.analyticsService._counterInterval).toBe(2);
+      expect(spy.calls.count()).toBe(1);
+    });
+  });
+
+});

--- a/ui/src/app/analytics/analytics.service.ts
+++ b/ui/src/app/analytics/analytics.service.ts
@@ -1,18 +1,14 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Http, Response, RequestOptionsArgs, URLSearchParams } from '@angular/http';
-
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
-
 import { ErrorHandler, Page } from '../shared/model';
-
-import { AggregateCounter, AggregateCounterResolutionType, BaseCounter,
-         Counter, DashboardItem, FieldValueCounter, MetricType } from './model';
-
+import { AggregateCounter, BaseCounter, Counter, DashboardItem, FieldValueCounter, MetricType } from './model';
 import { HttpUtils } from '../shared/support/http.utils';
 import { ToastyService } from 'ng2-toasty';
+
 /**
  * @author Gunnar Hillert
  */
@@ -50,7 +46,7 @@ export class AnalyticsService {
   }
 
   public set counterInterval(rate: number) {
-    if (rate && !isNaN(rate)) {
+    if (rate !== undefined && !isNaN(rate)) {
       if (rate < 0.01) {
           rate = 0;
           this.stopPollingForCounters();


### PR DESCRIPTION
- In AnalyticsService check if given rate is undefined
  istead of simple `if(rate) as that will be false if
  zero is given.
- Add spec for AnalyticsService and test intervals.
- Imports polish for AnalyticsService
- Fixes #418