### PR TITLE
Support flo property validation against long or short names

### DIFF
--- a/ui/src/app/streams/flo/editor.service.spec.ts
+++ b/ui/src/app/streams/flo/editor.service.spec.ts
@@ -225,6 +225,19 @@ describe('editor.service', () => {
         });
     });
 
+    it('property validation - long names', (done) => {
+        const formatPropertySpec = toPropertyMetadata('formatid', 'format', 'Format of the time', 'HHMM', 'string');
+        const timeMetadata = toMetadataWithCustomProperties('time', 'source', new Map([['foobar.format', formatPropertySpec]]));
+        const timeSource = createNodeFromMetadata(timeMetadata);
+        createLink(timeSource, createSink('log'));
+        // Both forms valid (short form 'format' and long form 'foobar.format')
+        setProperties(timeSource, new Map([['format', 'anyoldvalue'], ['foobar.format', 'anyoldvalue2']]));
+        editorService.validate(graph, null, null).then((markers) => {
+            expectMarkerCount(markers, 0);
+            done();
+        });
+    });
+
     function expectMarker(marker: Flo.Marker, severity: number, message: string) {
         if (!marker) {
             fail('missing marker');

--- a/ui/src/app/streams/flo/editor.service.ts
+++ b/ui/src/app/streams/flo/editor.service.ts
@@ -523,13 +523,19 @@ export class EditorService implements Flo.Editor {
             const specifiedProperties = element.attr('props');
             if (specifiedProperties) {
                 const propertiesRanges = element.attr('propertiesranges');
-                const appSchema = element.attr('metadata');
+                const appSchema: Flo.ElementMetadata = element.attr('metadata');
                 appSchema.properties().then(appSchemaProperties => {
                     if (!appSchemaProperties) {
                         appSchemaProperties = new Map<string, Flo.PropertyMetadata>();
                     }
                     Object.keys(specifiedProperties).forEach(propertyName => {
-                        if (!appSchemaProperties.has(propertyName)) {
+                        let validPropertyName = false;
+                        appSchemaProperties.forEach((value: Flo.PropertyMetadata, key) => {
+                            if (key === propertyName || value.name === propertyName) {
+                                validPropertyName = true;
+                            }
+                        });
+                        if (!validPropertyName) {
                             const range = propertiesRanges ? propertiesRanges[propertyName] : null;
                             markers.push({
                                 severity: Flo.Severity.Error,


### PR DESCRIPTION
Previously validation was only against long names (like
'trigger.time-unit' on the time module). With this change
validation also allows the short-form name 'time-unit' too.
Tests added.

Fixes #477