### PR TITLE
Ensure ranges set for properties and they are used correctly

### DIFF
--- a/ui/src/app/streams/flo/editor.service.ts
+++ b/ui/src/app/streams/flo/editor.service.ts
@@ -530,7 +530,7 @@ export class EditorService implements Flo.Editor {
                     }
                     Object.keys(specifiedProperties).forEach(propertyName => {
                         if (!appSchemaProperties.has(propertyName)) {
-                            const range = propertiesRanges ? propertiesRanges[propertyName] : null;
+                            const range = propertiesRanges ? propertiesRanges.get(propertyName) : null;
                             markers.push({
                                 severity: Flo.Severity.Error,
                                 message: 'unrecognized option \'' + propertyName + '\' for app \'' +

--- a/ui/src/app/streams/stream-create/stream-create.component.ts
+++ b/ui/src/app/streams/stream-create/stream-create.component.ts
@@ -108,7 +108,7 @@ export class StreamCreateComponent implements OnInit {
     Array.from(this.validationMarkers.values())
       .filter(markers => Array.isArray(markers))
       .forEach(markers => markers
-        .filter(m => m.range && m.severity)
+        .filter(m => m.range && m.hasOwnProperty('severity'))
         .forEach(m => annotations.push({
           message: m.message,
           from: m.range.start,


### PR DESCRIPTION
With this change the validation of properties now works
properly in the DSL view when creating streams. There are a
few changes included:
- use map access to get ranges rather than property access.
- use hasOwnProperty to verify severity specified otherwise
  markers with severity 0 are filtered out.
- when building the text from the graph, update the graph
  propertiesranges to indicate where the properties have
  been put in the DSL text.

Fixes #482