### PR TITLE
Create Stream button enablement based on validation

### DIFF
--- a/ui/src/app/streams/flo/properties/properties-dialog.component.ts
+++ b/ui/src/app/streams/flo/properties/properties-dialog.component.ts
@@ -100,14 +100,29 @@ class PropertiesGroupModel extends Properties.PropertiesGroupModel {
     });
   }
 
+  private determineAttributeName(metadata: Flo.PropertyMetadata): string {
+    const nameAttr = `props/${metadata.name}`;
+    const idAttr = `props/${metadata.id}`;
+    if (this.cell.attr('metadata/group') === 'other') {
+      // For something in the other group (like tap) use the id not the name of the property
+      return idAttr;
+    }
+    const valueFromName = this.cell.attr(nameAttr);
+    const valueFromId = this.cell.attr(idAttr);
+    if (valueFromName === undefined || valueFromName === null && !(valueFromId === undefined || valueFromId === null)) {
+      return idAttr;
+    } else {
+      return nameAttr;
+    }
+  }
+
   protected createProperty(metadata: Flo.PropertyMetadata): Properties.Property {
     return {
       id: metadata.id,
       name: metadata.name,
       defaultValue: metadata.defaultValue,
-      // For something in the other group (like tap) use the id not the name of the property
-      attr: `props/${this.cell.attr('metadata/group') === 'other' ? metadata.id : metadata.name}`,
-      value: this.cell.attr(`props/${metadata.name}`) || this.cell.attr(`props/${metadata.id}`),
+      attr: this.determineAttributeName(metadata),
+      value: this.cell.attr(this.determineAttributeName(metadata)),
       description: metadata.description,
       metadata: metadata
     };

--- a/ui/src/app/streams/stream-create/stream-create.component.html
+++ b/ui/src/app/streams/stream-create/stream-create.component.html
@@ -1,7 +1,7 @@
 <div id="flo-container" class="stream-editor">
   <flo-editor (floApi)="editorContext = $event" [metamodel]="metamodelService" [renderer]="renderService"
               [editor]="editorService" [paletteSize]="paletteSize" [(dsl)]="dsl" [paperPadding]="20" (validationMarkers)="validationMarkers = $event">
-    <button (click)="createStreamDefs()" class="btn btn-default" type="button" [disabled]="!dsl">Create Stream</button>
+    <button (click)="createStreamDefs()" class="btn btn-default" type="button" [disabled]="isCreateStreamsDisabled">Create Stream</button>
     <button (click)="editorContext.clearGraph()" class="btn btn-default" type="button">Clear</button>
     <button (click)="arrangeAll()" class="btn btn-default" type="button">Layout</button>
     <button class="btn" (click)="editorContext.autolink = !editorContext.autolink"


### PR DESCRIPTION
* `Create Stream` button enablement based on presence validation error markers and parse errors
* Fixed an issue with property stream having a long name property but properties dialog setting the short name property in this case. Should just update the long name property if it's being changed

Fixes #450 