### PR TITLE
gh-499 Provide better messaging if no Apps are registered

### DIFF
--- a/ui/src/app/apps/apps.component.html
+++ b/ui/src/app/apps/apps.component.html
@@ -30,7 +30,6 @@
         class="btn btn-default"
 ><span class="glyphicon glyphicon-refresh"></span></button>
 
-<div *ngIf="!appRegistrations || appRegistrations.items.length === 0">No apps available.</div>
 <table *ngIf="appRegistrations?.items && appRegistrations.items.length > 0" class="table table-hover">
   <thead>
     <tr>
@@ -64,6 +63,21 @@
 </table>
 <pagination-controls *ngIf="appRegistrations?.items && appRegistrations.items.length > 0" (pageChange)="getPage($event)"></pagination-controls>
 
+<div class="row" *ngIf="!appRegistrations || appRegistrations.items.length === 0" style="margin-top: 1em;">
+  <div class="text-center col-md-14 col-md-offset-5">
+    <p><strong>No registered apps.</strong></p>
+    <div [appRoles]="['ROLE_CREATE']">
+      <p>You can register apps by clicking:</p>
+      <button type="button" (click)="registerApps()"
+              class="btn btn-default" style="margin-bottom: 1em;"
+      ><span class="glyphicon glyphicon-plus"></span>
+          Register Application(s)
+      </button>
+      <p>Alternatively, using the <i>Data Flow Shell</i> application,
+      you can register new apps with the <strong>app register</strong> and <strong>app import</strong> commands.</p>
+    </div>
+  </div>
+</div>
 <div bsModal #unregisterSingleAppModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-sm">
     <div class="modal-content">

--- a/ui/src/app/auth/directives/roles.directive.ts
+++ b/ui/src/app/auth/directives/roles.directive.ts
@@ -24,9 +24,7 @@ export class RolesDirective implements AfterViewInit, DoCheck {
   private checkRoles() {
     const found = this.authService.securityInfo.canAccess(this.appRoles);
 
-    if (found) {
-      this.renderer.setStyle(this.elem.nativeElement, 'display', 'inherit');
-    } else {
+    if (!found) {
       this.renderer.setStyle(this.elem.nativeElement, 'display', 'none');
     }
   }


### PR DESCRIPTION
* Render a message similar to the old UI.
* Make the message role aware
  - `Register Application(s)` button is only shown if user has the `CREATE` role

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/499

See also screenshots added under https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/499