### PR TITLE
gh-223 Add bulk-operations support for stream-list view

### DIFF
--- a/ui/src/app/shared/components/tri-state-button.component.ts
+++ b/ui/src/app/shared/components/tri-state-button.component.ts
@@ -18,7 +18,7 @@ import { Selectable } from '../../shared/model/selectable';
   selector: 'app-tri-state-button',
   template:
   `<button #theButton name="topLevel" type="button" (click)="onClick()"
-         class="btn btn-default"><span class="glyphicon glyphicon-trash"></span>
+         class="btn btn-default"><span class="glyphicon glyphicon-{{icon}}"></span>
     <span class="hidden-xs">{{label}}</span>
   </button>`
 })
@@ -66,6 +66,21 @@ export class TriStateButtonComponent implements AfterViewInit, DoCheck {
   allSelectedLabel: string;
 
   /**
+   * The icon displayed inside the button
+   * Trash by default
+   * @type {string}
+   */
+  @Input()
+  icon: string = 'trash';
+
+  /**
+   * Optional Function to filter items, should return a Boolean.
+   * @type {Function}
+   */
+  @Input()
+  filter: Function;
+
+  /**
    * The button label.
    * @type {string}
    */
@@ -101,7 +116,9 @@ export class TriStateButtonComponent implements AfterViewInit, DoCheck {
     }
     let count = 0;
     for (let i = 0; i < this._items.length; i++) {
-      count += this._items[i].isSelected ? 1 : 0;
+      if (this._items[i].isSelected) {
+        count += this.filter ? this.filter(this._items[i]) : 1;
+      }
     }
 
     if (count > 0 && count < this._items.length) {

--- a/ui/src/app/shared/components/tri-state-button.component.ts
+++ b/ui/src/app/shared/components/tri-state-button.component.ts
@@ -13,6 +13,7 @@ import { Selectable } from '../../shared/model/selectable';
  * @author Gunnar Hillert
  * @author Janne Valkealahti
  * @author Glenn Renfro
+ * @author Damien Vitrac
  */
 @Component({
   selector: 'app-tri-state-button',

--- a/ui/src/app/streams/model/stream-definition.spec.ts
+++ b/ui/src/app/streams/model/stream-definition.spec.ts
@@ -4,6 +4,7 @@ import {StreamDefinition} from './stream-definition';
  * Test {@link StreamDefinition} model.
  *
  * @author Glenn Renfro
+ * @author Damien Vitrac
  */
 describe('StreamsDefinition', () => {
 
@@ -13,9 +14,13 @@ describe('StreamsDefinition', () => {
       expect(streamDefinition.name).toBe('foo');
       expect(streamDefinition.dslText).toBe('bar');
       expect(streamDefinition.status).toBe('baz');
+      expect(streamDefinition.force).toBe(false);
       expect(streamDefinition.isExpanded).toBe(false);
       streamDefinition.toggleIsExpanded();
       expect(streamDefinition.isExpanded).toBe(true);
+      streamDefinition.isSelected = true
+      expect(streamDefinition.force).toBe(true);
+      expect(Object.keys(streamDefinition.deploymentProperties).length).toBe(0);
     });
   });
 });

--- a/ui/src/app/streams/model/stream-definition.ts
+++ b/ui/src/app/streams/model/stream-definition.ts
@@ -5,6 +5,7 @@ import { Expandable } from './../../shared/model/expandable';
  *
  * @author Janne Valkealahti
  * @author Gunnar Hillert
+ * @author Damien Vitrac
  */
 export class StreamDefinition implements Expandable {
 
@@ -12,7 +13,9 @@ export class StreamDefinition implements Expandable {
   public dslText: String;
   public status: String;
   public isExpanded = false;
-  public force: boolean;
+  public force: boolean = false;
+
+  public deploymentProperties: any = {};
 
   constructor(
       name: String,

--- a/ui/src/app/streams/model/stream-definition.ts
+++ b/ui/src/app/streams/model/stream-definition.ts
@@ -12,6 +12,7 @@ export class StreamDefinition implements Expandable {
   public dslText: String;
   public status: String;
   public isExpanded = false;
+  public force: boolean;
 
   constructor(
       name: String,
@@ -20,6 +21,13 @@ export class StreamDefinition implements Expandable {
     this.name = name;
     this.dslText = dslText;
     this.status = status;
+  }
+
+  get isSelected(): boolean {
+    return this.force;
+  }
+  set isSelected(isSelected: boolean) {
+    this.force = isSelected;
   }
 
   /**

--- a/ui/src/app/streams/stream-definitions/deployment-properties/deployment-properties.component.html
+++ b/ui/src/app/streams/stream-definitions/deployment-properties/deployment-properties.component.html
@@ -1,0 +1,47 @@
+<div class="modal-header">
+  <h4 class="modal-title pull-left">Add deployment properties for <strong>{{stream.name}}</strong></h4>
+  <button type="button" class="close pull-right" aria-label="Close" (click)="cancelDeployment()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+<form novalidate [formGroup]="form" (ngSubmit)="deployDefinition()">
+  <div class="modal-body">
+
+    <p class="index-page--subtitle">
+      Please specify any <strong>optional</strong> deployment properties.
+      You can either enter deployment properties directly into the text-area
+      field below or alternatively, you can point to an external properties file,
+      which will be used to populate the text-area field.<br><br>
+      For more information please see the
+      <a href="http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/htmlsingle/#_passing_application_properties_when_deploying_stream"
+         target="_blank">Technical Documentation</a>.
+    </p>
+
+      <div class="form-group" [ngClass]="form.controls.deploymentProperties.errors ? 'has-warning has-feedback' : ''">
+        <label for="deploymentProperties" class="control-label">Deployment Properties</label>
+        <div>
+          <textarea class="form-control" id="deploymentProperties" name="deploymentProperties"
+                    formControlName="deploymentProperties" autofocus rows="5"
+                    placeholder="Enter optional deployment properties.
+    1 line per property e.g.:
+    property1=Spring
+    property2=Data Flow"></textarea>
+          <span class="glyphicon glyphicon-warning-sign form-control-feedback" *ngIf="form.controls.deploymentProperties.errors"></span>
+          <p class="help-block" *ngIf="form.controls.deploymentProperties.errors">The format of your deployment properties is invalid. {{form.controls.deploymentProperties.errors.validateDeploymentProperties.reason}}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label">Select Properties File</label>
+        <div>
+          <input type="file" (change)="displayFileContents($event)"/>
+          <p class="help-block">Please provide a text file containing deployment properties. This will be used to populate the text area above.</p>
+        </div>
+      </div>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default" (click)="cancelDeployment()">Back</button>
+    <button type="submit" class="btn btn-primary">Add</button>
+  </div>
+</form>

--- a/ui/src/app/streams/stream-definitions/deployment-properties/deployment-properties.component.spec.ts
+++ b/ui/src/app/streams/stream-definitions/deployment-properties/deployment-properties.component.spec.ts
@@ -1,0 +1,79 @@
+import {TestBed, async, ComponentFixture} from "@angular/core/testing";
+import {DeploymentPropertiesComponent} from "./deployment-properties.component";
+import {ReactiveFormsModule, FormsModule} from "@angular/forms";
+import {StreamDefinition} from "../../model/stream-definition";
+
+/**
+ * Test {@link DeploymentPropertiesComponent}.
+ *
+ * @author Damien Vitrac
+ */
+describe('DeploymentPropertiesComponent', () => {
+
+  let component: DeploymentPropertiesComponent;
+  let fixture: ComponentFixture<DeploymentPropertiesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        DeploymentPropertiesComponent
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+      ],
+      providers: []
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeploymentPropertiesComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should be created', () => {
+    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should populate properties input', () => {
+    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream.deploymentProperties = {a: 'a', b: 'b'};
+    fixture.detectChanges();
+    expect(component.deploymentProperties.value).toBe('a=a\nb=b');
+  });
+
+  it('should not populate properties input (empty)', () => {
+    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    fixture.detectChanges();
+    expect(component.deploymentProperties.value).toBe('');
+  });
+
+  it('should not populate properties input (invalid data)', () => {
+    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream.deploymentProperties = 'aa';
+    fixture.detectChanges();
+    expect(component.deploymentProperties.value).toBe('');
+  });
+
+  it('should emit cancel event on cancel action', () => {
+    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    fixture.detectChanges();
+    const cancelEvent = spyOn(component.cancel, 'emit');
+    component.cancelDeployment();
+    expect(cancelEvent).toHaveBeenCalled();
+  });
+
+  it('should update the stream definition to deploy and emit event Submit on submit', () => {
+    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    fixture.detectChanges();
+    const submitEvent = spyOn(component.submit, 'emit');
+    component.deploymentProperties.setValue('a=a');
+    component.deployDefinition();
+    expect(component.stream.deploymentProperties.a).toBe('a');
+    expect(submitEvent).toHaveBeenCalled();
+  });
+
+});

--- a/ui/src/app/streams/stream-definitions/deployment-properties/deployment-properties.component.ts
+++ b/ui/src/app/streams/stream-definitions/deployment-properties/deployment-properties.component.ts
@@ -1,0 +1,88 @@
+import {Component, OnInit, Output, EventEmitter, Input} from '@angular/core';
+import { FormGroup, FormControl, FormBuilder } from '@angular/forms';
+import {validateDeploymentProperties} from "../../stream-deploy/stream-deploy-validators";
+import {StreamDefinition} from "../../model/stream-definition";
+
+@Component({
+  selector: 'app-stream-deployment-properties',
+  templateUrl: './deployment-properties.component.html',
+})
+
+/**
+ * Component used to deploy stream definitions.
+ *
+ * @author Damien Vitrac
+ */
+export class DeploymentPropertiesComponent implements OnInit {
+
+  id: String;
+  form: FormGroup;
+  deploymentProperties = new FormControl('', validateDeploymentProperties);
+
+  @Output()
+  public cancel = new EventEmitter();
+
+  @Output()
+  public submit = new EventEmitter();
+
+  @Input()
+  public stream:StreamDefinition;
+
+  /**
+   * Adds deployment properties to the FormBuilder
+   * @param fb used establish the deployment properties as a part of the form.
+   */
+  constructor(
+    fb: FormBuilder
+  ) {
+     this.form = fb.group({
+       'deploymentProperties': this.deploymentProperties
+     });
+  }
+
+  ngOnInit() {
+    if (this.stream.deploymentProperties instanceof Object) {
+      this.deploymentProperties.setValue(Object.keys(this.stream.deploymentProperties)
+        .map(a => {
+          return a + '=' + this.stream.deploymentProperties[a]
+        }).join('\n'));
+    }
+  }
+
+  /**
+   * Deploy the definition and submit the event
+   */
+  deployDefinition() {
+    const propertiesAsMap = {};
+    if (this.deploymentProperties.value) {
+      for (const prop of this.deploymentProperties.value.split('\n')) {
+        if (prop && prop.length > 0 && !prop.startsWith('#')) {
+          const keyValue = prop.split('=');
+          if (keyValue.length === 2) {
+            propertiesAsMap[keyValue[0]] = keyValue[1];
+          }
+        }
+      }
+    }
+    this.stream.deploymentProperties = propertiesAsMap;
+    this.submit.emit();
+  }
+
+  cancelDeployment() {
+    this.cancel.emit();
+  }
+
+  /**
+   * Used to read the deployment properties of a stream from a flat file
+   * @param event The event from the file selection dialog.
+   */
+  displayFileContents(event: any) {
+    const file: File = event.target.files[0];
+    const reader: FileReader = new FileReader();
+    const _form = this.form;
+    reader.onloadend = function(e){
+      _form.patchValue({deploymentProperties: reader.result});
+    };
+    reader.readAsText(file);
+  }
+}

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.html
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.html
@@ -25,7 +25,7 @@
           </td>
         </tr>
         <tr>
-          <td colspan="2" class="col-xs-12" height="45px">
+          <td colspan="2" class="col-xs-12 col-actions" height="45px">
             <app-tri-state-button *ngIf="streamDefinitions?.items" class="toggle-all" [appRoles]="['ROLE_CREATE']"
                                   [items]="streamDefinitions.getItemsAsObservable()"
                                   (eventHandler)="deployMultipleStreamDefinitions(streamDefinitions.items)"
@@ -76,7 +76,7 @@
       <th style="width: 32px"></th>
       <th style="width: 70px"><a (click)="toggleDefinitionNameSort()"><span style="margin-right: 5px">Name</span></a><i class="fa" [ngClass]="{'fa-sort': definitionNameSort === undefined, 'fa-sort-asc': definitionNameSort === false, 'fa-sort-desc': definitionNameSort === true }" aria-hidden="true"></i></th>
       <th><a (click)="toggleDefinitionSort()"><span style="margin-right: 5px">Definitions</span></a><i class="fa" [ngClass]="{'fa-sort': definitionSort === undefined, 'fa-sort-asc': definitionSort === false, 'fa-sort-desc': definitionSort === true }" aria-hidden="true"></i></th>
-      <th style="width: 50px">Status
+      <th style="width: 50px" nowrap="">Status
         <a #childPopover="bs-popover"
         [popover]="popTemplate"
         placement="bottom"
@@ -163,7 +163,7 @@
   </div>
 </ng-template>
 
-<div bsModal #destroyMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+<div id="destroyMultipleStreamDefinitionsModal" bsModal #destroyMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -201,9 +201,10 @@
   </div>
 </div>
 
-<div bsModal #deployMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+<div id="deployMultipleStreamDefinitionsModal" bsModal #deployMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
   <div class="modal-dialog">
-    <div class="modal-content">
+
+    <div class="modal-content" *ngIf="!selectStreamDefinition">
       <div class="modal-header">
         <h4 class="modal-title pull-left">Confirm Deploy Stream Definitions</h4>
         <button type="button" class="close pull-right" aria-label="Close" (click)="cancelDeployMultipleStreamDefinitions()">
@@ -213,7 +214,9 @@
       <div class="modal-body" *ngIf="streamDefinitionsToDeploy">
         <p>
           This action will deploy the {{streamDefinitionsToDeploy.length}}
-          stream definition{{streamDefinitionsToDeploy.length > 1 ? 's' : ''}} listed below. Are you sure?
+          stream definition{{streamDefinitionsToDeploy.length > 1 ? 's' : ''}} listed below.<br />
+          Are you sure?<br />
+          You can add deployment properties for each stream definition.
         </p>
         <br/>
         <table class="table table-striped">
@@ -221,12 +224,28 @@
           <tr>
             <th>Name</th>
             <th>Definition</th>
+            <th>Deployment properties</th>
           </tr>
           </thead>
           <tbody>
           <tr *ngFor="let item of streamDefinitionsToDeploy">
             <td>{{item.name}}</td>
             <td>{{item.dslText}}</td>
+            <td width="10" nowrap="">
+              <div *ngIf="(item.deploymentProperties | keyvalues).length > 0">
+                <p style="padding-bottom: 6px"><strong>{{(item.deploymentProperties | keyvalues).length}} propert{{(item.deploymentProperties | keyvalues).length > 1 ? 'ies' : 'y'}}</strong></p>
+                <a class="btn btn-sm btn-default" (click)="deployAddDeploymentProperties(item)">
+                  <span class="glyphicon glyphicon-edit"></span>
+                  Edit deployment properties
+                </a>
+              </div>
+              <div *ngIf="(item.deploymentProperties | keyvalues).length == 0">
+                <a class="btn btn-sm btn-default" (click)="deployAddDeploymentProperties(item)">
+                  <span class="glyphicon glyphicon-plus"></span>
+                  Add deployment properties
+                </a>
+              </div>
+            </td>
           </tr>
           </tbody>
         </table>
@@ -236,10 +255,17 @@
         <button type="button" class="btn btn-primary" (click)="proceedToDeployMultipleStreamDefinitions(streamDefinitionsToDeploy)">Yes</button>
       </div>
     </div>
+
+    <div class="modal-content" *ngIf="selectStreamDefinition">
+        <app-stream-deployment-properties [stream]="selectStreamDefinition"
+          (submit)="backDeployMultipleStreamDefinitions()" (cancel)="backDeployMultipleStreamDefinitions()">
+        </app-stream-deployment-properties>
+    </div>
+
   </div>
 </div>
 
-<div bsModal #undeployMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+<div id="undeployMultipleStreamDefinitionsModal" bsModal #undeployMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.html
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.html
@@ -24,6 +24,43 @@
               <span class="glyphicon glyphicon-refresh"></span></button>
           </td>
         </tr>
+        <tr>
+          <td colspan="2" class="col-xs-12" height="45px">
+            <app-tri-state-button *ngIf="streamDefinitions?.items" class="toggle-all" [appRoles]="['ROLE_CREATE']"
+                                  [items]="streamDefinitions.getItemsAsObservable()"
+                                  (eventHandler)="deployMultipleStreamDefinitions(streamDefinitions.items)"
+                                  noneSelectedLabel="No stream selected to deploy"
+                                  oneSelectedLabel="Deploy {selectedCount} selected stream"
+                                  manySelectedLabel="Deploy {selectedCount} selected streams"
+                                  allSelectedLabel="Deploy all {selectedCount} selected streams"
+                                  icon="play"
+                                  [filter]="filterDeployable"
+            ></app-tri-state-button>
+
+            <app-tri-state-button *ngIf="streamDefinitions?.items" class="toggle-all" [appRoles]="['ROLE_CREATE']"
+                                  [items]="streamDefinitions.getItemsAsObservable()"
+                                  (eventHandler)="undeployMultipleStreamDefinitions(streamDefinitions.items)"
+                                  noneSelectedLabel="No stream selected to undeploy"
+                                  oneSelectedLabel="Undeploy {selectedCount} selected stream"
+                                  manySelectedLabel="Undeploy {selectedCount} selected streams"
+                                  allSelectedLabel="Undeploy all {selectedCount} selected streams"
+                                  icon="stop"
+                                  [filter]="filterUndeployable"
+            ></app-tri-state-button>
+
+            <app-tri-state-button *ngIf="streamDefinitions?.items" class="toggle-all" [appRoles]="['ROLE_CREATE']"
+                                  [items]="streamDefinitions.getItemsAsObservable()"
+                                  (eventHandler)="destroyMultipleStreams(streamDefinitions.items)"
+                                  noneSelectedLabel="No stream selected to destroy"
+                                  oneSelectedLabel="Destroy {selectedCount} selected stream"
+                                  manySelectedLabel="Destroy {selectedCount} selected streams"
+                                  allSelectedLabel="Destroy all {selectedCount} selected streams"
+                                  icon="remove"
+            ></app-tri-state-button>
+
+          </td>
+
+        </tr>
       </table>
     </div>
   </div>
@@ -32,6 +69,10 @@
 <table *ngIf="streamDefinitions?.items" class="table table-hover" id="streamDefinitionsTable">
   <thead>
     <tr>
+      <th style="width: 30px">
+        <app-tri-state-checkbox *ngIf="streamDefinitions?.items" [appRoles]="['ROLE_CREATE']" class="toggle-all" [items]="streamDefinitions.getItemsAsObservable()"></app-tri-state-checkbox>
+      </th>
+
       <th style="width: 32px"></th>
       <th style="width: 70px"><a (click)="toggleDefinitionNameSort()"><span style="margin-right: 5px">Name</span></a><i class="fa" [ngClass]="{'fa-sort': definitionNameSort === undefined, 'fa-sort-asc': definitionNameSort === false, 'fa-sort-desc': definitionNameSort === true }" aria-hidden="true"></i></th>
       <th><a (click)="toggleDefinitionSort()"><span style="margin-right: 5px">Definitions</span></a><i class="fa" [ngClass]="{'fa-sort': definitionSort === undefined, 'fa-sort-asc': definitionSort === false, 'fa-sort-desc': definitionSort === true }" aria-hidden="true"></i></th>
@@ -48,6 +89,7 @@
   <tbody>
     <ng-template ngFor let-item [ngForOf]="streamDefinitions.items | paginate: streamDefinitions.getPaginationInstance()">
       <tr>
+        <td><input type="checkbox" [(ngModel)]="item.isSelected"/></td>
         <td>
           <button class="glyphicon glyphicon-expand"
                   (click)="item.toggleIsExpanded()"
@@ -76,7 +118,7 @@
         </td>
       </tr>
       <tr *ngIf="item.isExpanded">
-        <td colspan="5">
+        <td colspan="6">
           <app-stream-graph-definition [stream]="item" [metrics]="metricsForStream(item.name)"></app-stream-graph-definition>
         </td>
       </tr>
@@ -120,3 +162,117 @@
     </table>
   </div>
 </ng-template>
+
+<div bsModal #destroyMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Confirm Destroy Stream Definitions</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="cancelDestroyMultipleStreamDefinitions()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body" *ngIf="streamDefinitionsToDestroy">
+        <p>
+          This action will destroy the {{streamDefinitionsToDestroy.length}}
+          stream definition{{streamDefinitionsToDestroy.length > 1 ? 's' : ''}} listed below. Are you sure?
+        </p>
+        <br/>
+        <table class="table table-striped">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr *ngFor="let item of streamDefinitionsToDestroy">
+            <td>{{item.name}}</td>
+            <td>{{item.dslText}}</td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" (click)="cancelDestroyMultipleStreamDefinitions()">No</button>
+        <button type="button" class="btn btn-primary" (click)="proceedToDestroyMultipleStreamDefinitions(streamDefinitionsToDestroy)">Yes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div bsModal #deployMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Confirm Deploy Stream Definitions</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="cancelDeployMultipleStreamDefinitions()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body" *ngIf="streamDefinitionsToDeploy">
+        <p>
+          This action will deploy the {{streamDefinitionsToDeploy.length}}
+          stream definition{{streamDefinitionsToDeploy.length > 1 ? 's' : ''}} listed below. Are you sure?
+        </p>
+        <br/>
+        <table class="table table-striped">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr *ngFor="let item of streamDefinitionsToDeploy">
+            <td>{{item.name}}</td>
+            <td>{{item.dslText}}</td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" (click)="cancelDeployMultipleStreamDefinitions()">No</button>
+        <button type="button" class="btn btn-primary" (click)="proceedToDeployMultipleStreamDefinitions(streamDefinitionsToDeploy)">Yes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div bsModal #undeployMultipleStreamDefinitionsModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Confirm Undeploy Stream Definitions</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="cancelUndeployMultipleStreamDefinitions()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body" *ngIf="streamDefinitionsToUndeploy">
+        <p>
+          This action will undeploy the {{streamDefinitionsToUndeploy.length}}
+          stream definition{{streamDefinitionsToUndeploy.length > 1 ? 's' : ''}} listed below. Are you sure?
+        </p>
+        <br/>
+        <table class="table table-striped">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr *ngFor="let item of streamDefinitionsToUndeploy">
+            <td>{{item.name}}</td>
+            <td>{{item.dslText}}</td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" (click)="cancelUndeployMultipleStreamDefinitions()">No</button>
+        <button type="button" class="btn btn-primary" (click)="proceedToUndeployMultipleStreamDefinitions(streamDefinitionsToUndeploy)">Yes</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.spec.ts
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.spec.ts
@@ -22,6 +22,8 @@ import { AuthService } from '../../auth/auth.service';
 import { StreamGraphViewComponent } from '../stream-graph-view/stream-graph-view.component';
 import { FloModule } from 'spring-flo';
 import { StreamGraphDefinitionComponent } from '../stream-graph-definition/stream-graph-definition.component';
+import {TriStateButtonComponent} from '../../shared/components/tri-state-button.component';
+import {TriStateCheckboxComponent} from '../../shared/components/tri-state-checkbox.component';
 
 /**
  * Test {@link StreamDefinitionsComponent}.
@@ -46,6 +48,8 @@ describe('StreamDefinitionsComponent', () => {
         StreamGraphViewComponent,
         StreamGraphDefinitionComponent,
         StreamDefinitionsComponent,
+        TriStateButtonComponent,
+        TriStateCheckboxComponent
       ],
       imports: [
         BusyModule,
@@ -82,10 +86,10 @@ describe('StreamDefinitionsComponent', () => {
     streamsService.streamDefinitions = STREAM_DEFINITIONS;
     fixture.detectChanges();
     const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table[id=streamDefinitionsTable] td'));
-    expect(des.length).toBe(5);
-    expect(des[1].nativeElement.textContent).toContain('foo2');
-    expect(des[2].nativeElement.textContent).toContain('time |log');
-    expect(des[3].nativeElement.textContent).toContain('undeployed');
+    expect(des.length).toBe(6);
+    expect(des[2].nativeElement.textContent).toContain('foo2');
+    expect(des[3].nativeElement.textContent).toContain('time |log');
+    expect(des[4].nativeElement.textContent).toContain('undeployed');
   });
 
   it('Should navigate to the details page.', () => {

--- a/ui/src/app/streams/streams.module.ts
+++ b/ui/src/app/streams/streams.module.ts
@@ -27,6 +27,7 @@ import { StreamGraphViewComponent } from './stream-graph-view/stream-graph-view.
 import { StreamGraphDefinitionComponent } from './stream-graph-definition/stream-graph-definition.component';
 import { InstanceDotComponent } from './flo/instance-dot/instance-dot.component';
 import { MessageRateComponent } from './flo/message-rate/message-rate.component';
+import {DeploymentPropertiesComponent} from "./stream-definitions/deployment-properties/deployment-properties.component";
 
 @NgModule({
   imports: [
@@ -56,7 +57,8 @@ import { MessageRateComponent } from './flo/message-rate/message-rate.component'
     StreamGraphViewComponent,
     StreamGraphDefinitionComponent,
     InstanceDotComponent,
-    MessageRateComponent
+    MessageRateComponent,
+    DeploymentPropertiesComponent
   ],
   entryComponents: [
     StreamCreateDialogComponent,

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -11,6 +11,7 @@ import {STREAM_DEFINITIONS} from '../tests/mocks/mock-data';
  * Test Streams Services.
  *
  * @author Glenn Renfro
+ * @author Damien Vitrac
  */
 describe('StreamsService', () => {
 
@@ -212,12 +213,11 @@ describe('StreamsService', () => {
         const options = HttpUtils.getDefaultRequestOptions();
         this.mockHttp.post.and.returnValue(Observable.of(this.jsonData));
         expect(this.streamsService.streamDefinitions).toBeDefined();
-        const streamDefinitions = [
-          new StreamDefinition('stream1', 'file|filter|ftp', 'undeployed'),
-          new StreamDefinition('stream2', 'ftp|filter|file', 'undeployed')
-        ];
-        this.streamsService.deployMultipleStreamDefinitions(streamDefinitions, {});
-        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/stream1', {}, options);
+        const stream1 = new StreamDefinition('stream1', 'file|filter|ftp', 'undeployed');
+        const stream2 = new StreamDefinition('stream2', 'file|filter|ftp', 'undeployed');
+        stream1.deploymentProperties = {a: 'a'};
+        this.streamsService.deployMultipleStreamDefinitions([stream1, stream2]);
+        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/stream1', {a: 'a'}, options);
         expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/stream2', {}, options);
         expect(this.mockHttp.post).toHaveBeenCalledTimes(2);
       });

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -3,7 +3,7 @@ import {StreamsService} from './streams.service';
 import {Observable} from 'rxjs/Observable';
 import {HttpUtils, URL_QUERY_ENCODER} from '../shared/support/http.utils';
 import {StreamDefinition} from './model/stream-definition';
-import {Headers, RequestOptions, URLSearchParams} from '@angular/http';
+import {URLSearchParams} from '@angular/http';
 import {MockResponse} from '../tests/mocks/response';
 import {STREAM_DEFINITIONS} from '../tests/mocks/mock-data';
 
@@ -190,5 +190,54 @@ describe('StreamsService', () => {
       });
 
     });
+
+    describe('destroyMultipleStreamDefinitions', () => {
+      it('should call the stream definition service with the right url to destroy multiple stream definitions', () => {
+        const options = HttpUtils.getDefaultRequestOptions();
+        this.mockHttp.delete.and.returnValue(Observable.of(this.jsonData));
+        expect(this.streamsService.streamDefinitions).toBeDefined();
+        const streamDefinitions = [
+          new StreamDefinition('stream1', 'file|filter|ftp', 'deployed'),
+          new StreamDefinition('stream2', 'ftp|filter|file', 'deployed')
+        ];
+        this.streamsService.destroyMultipleStreamDefinitions(streamDefinitions);
+        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/definitions/stream1', options);
+        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/definitions/stream2', options);
+        expect(this.mockHttp.delete).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('deployMultipleStreamDefinitions', () => {
+      it('should call the stream definition service with the right url to deploy multiple stream definitions', () => {
+        const options = HttpUtils.getDefaultRequestOptions();
+        this.mockHttp.post.and.returnValue(Observable.of(this.jsonData));
+        expect(this.streamsService.streamDefinitions).toBeDefined();
+        const streamDefinitions = [
+          new StreamDefinition('stream1', 'file|filter|ftp', 'undeployed'),
+          new StreamDefinition('stream2', 'ftp|filter|file', 'undeployed')
+        ];
+        this.streamsService.deployMultipleStreamDefinitions(streamDefinitions, {});
+        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/stream1', {}, options);
+        expect(this.mockHttp.post).toHaveBeenCalledWith('/streams/deployments/stream2', {}, options);
+        expect(this.mockHttp.post).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('undeployMultipleStreamDefinitions', () => {
+      it('should call the stream definition service with the right url to undeploy multiple stream definitions', () => {
+        const options = HttpUtils.getDefaultRequestOptions();
+        this.mockHttp.delete.and.returnValue(Observable.of(this.jsonData));
+        expect(this.streamsService.streamDefinitions).toBeDefined();
+        const streamDefinitions = [
+          new StreamDefinition('stream1', 'file|filter|ftp', 'deployed'),
+          new StreamDefinition('stream2', 'ftp|filter|file', 'deployed')
+        ];
+        this.streamsService.undeployMultipleStreamDefinitions(streamDefinitions);
+        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/deployments/stream1', options);
+        expect(this.mockHttp.delete).toHaveBeenCalledWith('/streams/deployments/stream2', options);
+        expect(this.mockHttp.delete).toHaveBeenCalledTimes(2);
+      });
+    });
+
   });
 });

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -116,6 +116,14 @@ export class StreamsService {
       .catch(this.errorHandler.handleError);
   }
 
+  destroyMultipleStreamDefinitions(streamDefinitions: StreamDefinition[]): Observable<Response[]> {
+    const observables: Observable<Response>[] = [];
+    for (const streamDefinition of streamDefinitions) {
+      observables.push(this.destroyDefinition(streamDefinition));
+    }
+    return Observable.forkJoin(observables);
+  }
+
   /**
    * Calls the Spring Cloud Data Flow server to undeploy the {@link StreamDefinition}.
    * @param streamDefinition
@@ -128,6 +136,15 @@ export class StreamsService {
       .catch(this.errorHandler.handleError);
   }
 
+  undeployMultipleStreamDefinitions(streamDefinitions: StreamDefinition[]): Observable<Response[]> {
+    const observables: Observable<Response>[] = [];
+    for (const streamDefinition of streamDefinitions) {
+      observables.push(this.undeployDefinition(streamDefinition));
+    }
+    return Observable.forkJoin(observables);
+  }
+
+
   /**
    * Posts a request to the data flow server to deploy the stream associated with the streamDefinitionName.
    * @param streamDefinitionName the name of the stream to deploy.
@@ -139,6 +156,14 @@ export class StreamsService {
     const options = HttpUtils.getDefaultRequestOptions();
     return this.http.post('/streams/deployments/' + streamDefinitionName, propertiesAsMap, options)
       .catch(this.errorHandler.handleError);
+  }
+
+  deployMultipleStreamDefinitions(streamDefinitions: StreamDefinition[], propertiesAsMap: any): Observable<Response[]> {
+    const observables: Observable<Response>[] = [];
+    for (const streamDefinition of streamDefinitions) {
+      observables.push(this.deployDefinition(streamDefinition.name, propertiesAsMap));
+    }
+    return Observable.forkJoin(observables);
   }
 
   getRelatedDefinitions(streamName: string, nested?: boolean): Observable<StreamDefinition[]> {

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -17,6 +17,7 @@ import { HttpUtils, URL_QUERY_ENCODER } from '../shared/support/http.utils';
  * @author Janne Valkealahti
  * @author Gunnar Hillert
  * @author Glenn Renfro
+ * @author Damien Vitrac
  *
  */
 @Injectable()
@@ -158,10 +159,10 @@ export class StreamsService {
       .catch(this.errorHandler.handleError);
   }
 
-  deployMultipleStreamDefinitions(streamDefinitions: StreamDefinition[], propertiesAsMap: any): Observable<Response[]> {
+  deployMultipleStreamDefinitions(streamDefinitions: StreamDefinition[]): Observable<Response[]> {
     const observables: Observable<Response>[] = [];
     for (const streamDefinition of streamDefinitions) {
-      observables.push(this.deployDefinition(streamDefinition.name, propertiesAsMap));
+      observables.push(this.deployDefinition(streamDefinition.name, streamDefinition.deploymentProperties));
     }
     return Observable.forkJoin(observables);
   }

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -877,9 +877,22 @@ export const STREAM_DEFINITIONS = {
         dslText: 'time |log ',
         status: 'undeployed',
         statusDescription: 'The app or group is known to the system, but is not currently deployed',
+        force: false,
         _links: {
           self: {
             href: 'http://localhost:9393/streams/definitions/foo2'
+          }
+        }
+      },
+      {
+        name: 'foo3',
+        dslText: 'time |log ',
+        status: 'undeployed',
+        statusDescription: 'The app or group is known to the system, but is currently deployed',
+        force: false,
+        _links: {
+          self: {
+            href: 'http://localhost:9393/streams/definitions/foo3'
           }
         }
       }

--- a/ui/src/app/tests/mocks/streams.ts
+++ b/ui/src/app/tests/mocks/streams.ts
@@ -18,6 +18,7 @@ import {StreamDefinition} from '../../streams/model/stream-definition';
  * runtimeAppsService._testRuntimeApps = STREAM_DEFINITIONS;//Stream Definitions json
  *
  * @author Glenn Renfro
+ * @author Damien Vitrac
  */
 export class MockStreamsService {
 
@@ -54,12 +55,24 @@ export class MockStreamsService {
     return Observable.of({});
   }
 
+  undeployMultipleStreamDefinitions(streamDefinitions: StreamDefinition[]): Observable<any>[] {
+    return [Observable.of({})];
+  }
+
   destroyDefinition(streamDefinition: StreamDefinition): Observable<Response>|Observable<any> {
     return Observable.of({});
   }
 
+  destroyMultipleStreamDefinitions(streamDefinitions: StreamDefinition[]): Observable<any>[] {
+    return [Observable.of({})];
+  }
+
   deployDefinition(streamDefinitionName: String, propertiesAsMap: any): Observable<Response>|Observable<any> {
     return Observable.of({});
+  }
+
+  deployMultipleStreamDefinitions(streamDefinitions: StreamDefinition[]): Observable<any>[] {
+    return [Observable.of({})];
   }
 
   getRelatedDefinitions(streamDefinitionName: String, nested?: boolean): Observable<StreamDefinition[]> {


### PR DESCRIPTION
resolves #223 

Question: How do you want to handle this case when multiple stream definitions are selected to be deployed?

<img width="1150" alt="screen shot 2017-10-05 at 8 04 14 pm" src="https://user-images.githubusercontent.com/487067/31242781-68059ef8-aa08-11e7-8e6c-9fbf54a3a604.png">

Right now there is nothing to add deployment's properties.
