### PR TITLE
Task defs list up to date after task create

### DIFF
--- a/ui/src/app/tasks/task-create/task-create.component.ts
+++ b/ui/src/app/tasks/task-create/task-create.component.ts
@@ -74,12 +74,14 @@ export class TaskCreateComponent implements OnInit, OnDestroy {
     this.tasksService.createDefinition(def, this.definitionName.value).subscribe(
       data => {
         this.toastyService.success('Task definition create requested');
+        this.router.navigate(['tasks/definitions']);
       },
       error => {
         this.toastyService.error(error);
+        this.router.navigate(['tasks/definitions']);
       }
     );
-    this.router.navigate(['tasks/definitions']);
+
   }
 
   private calculateDefinition() {


### PR DESCRIPTION
resolves #476

This was a sporadic issue that only occured when using the H2 DB.
And could not be reproduced using the server provided by angular.
The source problem was that the redirect only navigate was outside
the Observable and it would fire before the observable was complete.

To reproduce the problem.
. Build UI using `mvn clean install`
. Update SCDF pom to use BUILD-SNAPSHOT of UI
. Build SCDF
. Start SCDF using the default H2 database
. Add task definitions.