### PR TITLE
Turn off blur action for dsl text field and update flo

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,7 @@
     "ngx-pagination": "3.0.1",
     "rxjs": "5.5.2",
     "sockjs-client": "1.1.4",
-    "spring-flo": "git://github.com/spring-projects/spring-flo.git#16d0d3daa74cd19be1b82e17f97ef60c5e792101",
+    "spring-flo": "git://github.com/spring-projects/spring-flo.git#fdf3b6ffbc9bbf80eb3ad9a125d0f6241cbeb0fc",
     "stompjs": "2.3.3",
     "tixif-ngx-busy": "0.0.5",
     "zone.js": "0.8.18"

--- a/ui/src/app/streams/stream-create/stream-create.component.html
+++ b/ui/src/app/streams/stream-create/stream-create.component.html
@@ -10,7 +10,7 @@
     <button class="btn" (click)="gridOn = !gridOn"
             [ngClass]="{'btn-default-alt': !gridOn, 'btn-default': gridOn}">Grid</button>
     <div class="flow-definition-container">
-      <dsl-editor [(dsl)]="dsl" line-numbers="true" line-wrapping="true" (blur)="editorContext.graphToTextSync=true"
+      <dsl-editor [(dsl)]="dsl" line-numbers="true" line-wrapping="true"
                   (focus)="editorContext.graphToTextSync=false" placeholder="Enter stream definition..."
                   [hintOptions]="hintOptions" [lintOptions]="lintOptions"></dsl-editor>
     </div>


### PR DESCRIPTION
Just turning off the blur action would be bad but the update
to flo ensures we pickup a flo change where graph-to-text
syncing is turned on once you start interacting with the graph.

In this way if you simply switch to a different browser tab and
back, the DSL text field will still retain focus and you won't
lose some text you have in progress that isn't yet complete.

Fixes #423