### PR TITLE
Change the no task definition message on jobs

### DIFF
--- a/ui/src/app/jobs/components/definition-status.component.ts
+++ b/ui/src/app/jobs/components/definition-status.component.ts
@@ -38,8 +38,8 @@ export class DefinitionStatusComponent implements AfterContentInit, DoCheck {
     if (this.jobExecution) {
 
       if (!this.jobExecution.defined) {
-        this.labelClass = 'danger';
-        this.label = 'Deleted';
+        this.labelClass = 'info';
+        this.label = 'No Task Definition';
       }
     }
   }


### PR DESCRIPTION
Change class from Danger to Info
Updated message from `Deleted` to `No Task Definition`.

resolves #579