### PR TITLE
Override link options to prevent link tools resizing

### DIFF
--- a/ui/src/app/streams/flo/support/view-helper.ts
+++ b/ui/src/app/streams/flo/support/view-helper.ts
@@ -61,7 +61,14 @@ export class ViewHelper {
     const V = joint.V;
 
     return joint.shapes.flo.LinkView.extend({
-
+      options: {
+        shortLinkLength: 0,
+        doubleLinkTools: false,
+        longLinkLength: 160,
+        linkToolsOffset: 30,
+        doubleLinkToolsOffset: 60,
+        sampleInterval: 50
+      },
       renderLabels: function () {
 
         if (!this._V.labels) {
@@ -173,7 +180,6 @@ export class ViewHelper {
           }));
 
         }, this);
-
         return this;
       }
     });


### PR DESCRIPTION
All options are the same as default except shortLinkLength which has been reduced to 0. Normally if link length is < shortLinkLength then the size of the tools is halved.

resolves #393 