### PR TITLE
Hide task-launch button for VIEW-only users

### DIFF
--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -37,7 +37,7 @@
                 class="btn btn-default" style="margin-left: 0;" title="Details" [disabled]="!item.dslText || !item.composed">
           <span class="glyphicon glyphicon-info-sign"></span>
         </button>
-        <button type="button" (click)="launchTask(item)"
+        <button type="button" [appRoles]="['ROLE_CREATE']" (click)="launchTask(item)"
                 class="btn btn-default" style="margin-left: 0;" title="Launch">
           <span class="glyphicon glyphicon-play"></span>
         </button>


### PR DESCRIPTION
See the [comment](https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/588#issuecomment-356436316) for background and the proposed solution. 

This was verified with a user having a VIEW-only role. Likewise, when the role is switched to CREATE, all the buttons will show.

Resolves spring-cloud/spring-cloud-dataflow-ui#588.