### PR TITLE
Re-enable Stream deploy options for Skipper mode

### DIFF
--- a/ui/src/app/streams/stream-create-dialog/stream-create-dialog.component.html
+++ b/ui/src/app/streams/stream-create-dialog/stream-create-dialog.component.html
@@ -40,7 +40,7 @@
       </td>
     </tr>
   </tbody>
-  <label class="dialog-control" *ngIf="(featureInfo | async) && !(featureInfo | async)?.skipperEnabled">
+  <label class="dialog-control">
     <input [disabled]="isStreamCreationInProgress()" type="checkbox" [(ngModel)]="deploy"
                                        [ngModelOptions]="{standalone: true}"/>Deploy stream(s)
   </label>

--- a/ui/src/app/streams/stream-definitions/stream-definitions.component.html
+++ b/ui/src/app/streams/stream-definitions/stream-definitions.component.html
@@ -99,12 +99,8 @@
             <span class="glyphicon glyphicon-stop"></span>
           </button>
 
-          <button *ngIf="!(featureInfo | async)?.skipperEnabled" type="button" [appRoles]="['ROLE_CREATE']" [disabled]="(item.status==='deployed' || item.status==='deploying')" (click)="deploy(item)"
+          <button type="button" [appRoles]="['ROLE_CREATE']" [disabled]="(item.status==='deployed' || item.status==='deploying')" (click)="deploy(item)"
                   class="btn btn-default" style="margin-left: 0;" title="Deploy">
-            <span class="glyphicon glyphicon-play"></span>
-          </button>
-          <button *ngIf="(featureInfo | async)?.skipperEnabled" type="button" [appRoles]="['ROLE_CREATE']" class="btn btn-default" style="margin-left: 0;"
-                  popover="Switch to the Shell to deploy a stream using Skipper. The Dashboard support for it is under development" popoverTitle="Unsupported" placement="bottom" triggers="focus">
             <span class="glyphicon glyphicon-play"></span>
           </button>
 


### PR DESCRIPTION
Resolve #594

 - (re)enable the deploy checkbox in stream-create dialog
 - remove the skipper not-supported tooltip button