### PR TITLE
Switch spring-flo to 0.7.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,7 @@
     "ngx-pagination": "3.0.1",
     "rxjs": "5.5.2",
     "sockjs-client": "1.1.4",
-    "spring-flo": "git://github.com/spring-projects/spring-flo#0ee041142d50044512b091b504e9ab9df3ffcd48",
+    "spring-flo": "0.7.0",
     "stompjs": "2.3.3",
     "tixif-ngx-busy": "0.0.5",
     "zone.js": "0.8.18",


### PR DESCRIPTION
Flo 0.7.0 is out. Same really as the latest commit that SCDF UI was pointing too). Point to the new NPM published release. No implications.