### PR TITLE
Ensure recognize tap streams when computing text from graph

### DIFF
--- a/ui/src/app/streams/flo/graph-to-text.spec.ts
+++ b/ui/src/app/streams/flo/graph-to-text.spec.ts
@@ -398,6 +398,16 @@ describe('graph-to-text', () => {
         expect(dsl).toEqual('aaa=time | logA\n:aaa.time > logB');
     });
 
+    it('tapped simple stream 2', () => {
+        const timeSource = createSource('time');
+        timeSource.attr('stream-name', 'aaa');
+        // Now the tap is the first one, not the second one
+        createTap(timeSource, createSink('logA'));
+        createLink(timeSource, createSink('logB'));
+        dsl = convertGraphToText(graph);
+        expect(dsl).toEqual(':aaa.time > logA\naaa=time | logB');
+    });
+
     it('tap into processor', () => {
         const timeSource = createSource('time');
         timeSource.attr('stream-name', 'aaa');

--- a/ui/src/app/streams/flo/graph-to-text.ts
+++ b/ui/src/app/streams/flo/graph-to-text.ts
@@ -186,7 +186,7 @@ class GraphToTextConverter {
 
             for (let i = 0; i < stream.length; i++) {
                 const node = stream[i];
-                const isTapStream = tapStreams.find(ts => ts === s);
+                const isTapStream = typeof tapStreams.find(ts => ts === s) !== 'undefined';
                 if (i === 0) { // If first node, special handling...
                     // For a tap the name is on the 2nd element
                     const nameIndex = (isTapStream || this.isChannel(node)) ? 1 : 0;


### PR DESCRIPTION
Without this change if the first stream in a graph is a tap stream
the graph to text algorithm will make a mistake and not treat it
as a tap stream because Array.find returns 0 in this case (because
it is stream 0 that is a tap stream). 0 is treated as false. It
is better to check the Array.find call returned a result (i.e.
result is not undefined)

Fixes #603