### PR TITLE
[DO NOT MERGE] Stream definitions: add constraints on deployment properties

### DIFF
--- a/ui/src/app/streams/stream-deploy/stream-deploy-validators.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy-validators.ts
@@ -6,6 +6,9 @@ import { FormControl } from '@angular/forms';
  * @returns {any} null if successful or reason of the failure.
  */
 export function validateDeploymentProperties(formControl: FormControl) {
+
+  const uriRegex = /^(app.|deployer.)([a-zA-Z0-9-]+)$/;
+
   const properties = formControl.value.split('\n');
 
   if (properties) {
@@ -16,6 +19,15 @@ export function validateDeploymentProperties(formControl: FormControl) {
           return {
             validateDeploymentProperties: {
               reason: `Invalid deployment property "${prop}" must contain a single "=".`
+            }
+          };
+        }
+        if (!uriRegex.test(keyValue[0])) {
+          const message = `Invalid deployment property "${keyValue[0]}" must start with "app." or "deployer." and  `
+            + ` contain only alphanumeric characters.`;
+          return {
+            validateDeploymentProperties: {
+              reason: message
             }
           };
         }


### PR DESCRIPTION
Resolve #515
The key must start with `app.` or `deployer.`.
The key must contain only alphanumeric characters.