### PR TITLE
Cleanup temp nodes. Switch to spring-flo from master.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "web-animations-js": "2.3.1",
     "stompjs": "2.3.3",
     "jshint": "2.9.5",
-    "spring-flo": "git://github.com/spring-projects/spring-flo.git#angular5",
+    "spring-flo": "git://github.com/spring-projects/spring-flo.git#c39d28dba288095fc56350ac11f46c89878f1215",
     "ng-busy": "1.4.4"
   },
   "devDependencies": {

--- a/ui/src/app/streams/flo/support/view-helper.ts
+++ b/ui/src/app/streams/flo/support/view-helper.ts
@@ -280,16 +280,20 @@ export class ViewHelper {
 
         document.body.appendChild(svgDocument);
 
-        width = textSpan.getComputedTextLength();
-        for (let i = 1; i < width && width > threshold; i++) {
-          textNode.data = label.substr(0, label.length - i) + '\u2026';
+        try {
           width = textSpan.getComputedTextLength();
-        }
+          for (let i = 1; i < width && width > threshold; i++) {
+            textNode.data = label.substr(0, label.length - i) + '\u2026';
+            width = textSpan.getComputedTextLength();
+          }
 
-        if (offset) {
-          (<any>node).attr('.label1/ref-x', Math.max((offset + HORIZONTAL_PADDING + width / 2) / IMAGE_W, 0.5), {silent: true});
+          if (offset) {
+            (<any>node).attr('.label1/ref-x', Math.max((offset + HORIZONTAL_PADDING + width / 2) / IMAGE_W, 0.5), {silent: true});
+          }
+          (<any>node).attr(labelPath, textNode.data);
+        } finally {
+          document.body.removeChild(svgDocument);
         }
-        (<any>node).attr(labelPath, textNode.data);
       } else {
         (<any>node).attr('.label1/ref-x', Math.max((offset + HORIZONTAL_PADDING + width / 2) / IMAGE_W, 0.5));
       }


### PR DESCRIPTION
Fixes #615 
Label size calculations uses temporary SVG node added to the body. The temporary node needs to be removed after calculations are completed.