### PR TITLE
Use ApplicationType in SharedAppService#getApps() rather than `any` type

### DIFF
--- a/ui/src/app/shared/services/shared-apps.service.ts
+++ b/ui/src/app/shared/services/shared-apps.service.ts
@@ -23,13 +23,13 @@ export class SharedAppsService {
   /**
    * Returns a paged list of {@link AppRegistrations}s.
    */
-  getApps(pageRequest: PageRequest, type?: any, search?: string,
+  getApps(pageRequest: PageRequest, type?: ApplicationType, search?: string,
           sort?: Array<{ sort: string, order: string }>): Observable<Page<AppRegistration>> {
     const params = HttpUtils.getPaginationParams(pageRequest.page, pageRequest.size);
     const requestOptionsArgs: RequestOptionsArgs = HttpUtils.getDefaultRequestOptions();
 
     if (type) {
-      params.append('type', type);
+      params.append('type', ApplicationType[type]);
     }
     if (search) {
       params.append('search', search);

--- a/ui/src/app/tasks/flo/render.service.ts
+++ b/ui/src/app/tasks/flo/render.service.ts
@@ -192,13 +192,16 @@ export class RenderService implements Flo.Renderer {
 
         document.body.appendChild(svgDocument);
 
-        width = textSpan.getComputedTextLength();
-        for (let i = 1; i < width && width > threshold; i++) {
-          textNode.data = label.substr(0, label.length - i) + '\u2026';
+        try {
           width = textSpan.getComputedTextLength();
+          for (let i = 1; i < width && width > threshold; i++) {
+            textNode.data = label.substr(0, label.length - i) + '\u2026';
+            width = textSpan.getComputedTextLength();
+          }
+          (<any>node).attr(labelPath, textNode.data);
+        } finally {
+          document.body.removeChild(svgDocument);
         }
-
-        (<any>node).attr(labelPath, textNode.data);
       }
     }
   }

--- a/ui/src/app/tasks/tasks.service.ts
+++ b/ui/src/app/tasks/tasks.service.ts
@@ -111,9 +111,8 @@ export class TasksService {
   }
 
   getTaskAppRegistrations(): Observable<Page<AppRegistration>> {
-    const type = ApplicationType[ApplicationType.task.toString()];
     return this.sharedAppsService.getApps(
-      new PageRequest(this.appRegistrations.pageNumber, this.appRegistrations.pageSize), type).map(
+      new PageRequest(this.appRegistrations.pageNumber, this.appRegistrations.pageSize), ApplicationType.task).map(
         appRegistrations => {
           this.appRegistrations = appRegistrations;
           return appRegistrations;

--- a/ui/src/app/tests/mocks/shared-app.ts
+++ b/ui/src/app/tests/mocks/shared-app.ts
@@ -110,7 +110,7 @@ export class MockSharedAppService extends SharedAppsService {
     super(null, null);
   }
 
-  getApps(pageRequest: PageRequest, type?: any, search?: string,
+  getApps(pageRequest: PageRequest, type?: ApplicationType, search?: string,
           sort?: Array<{ sort: string, order: string }>): Observable<Page<AppRegistration>> {
 
     const page = new Page<AppRegistration>();


### PR DESCRIPTION
Fixes #638 
Adjust API to use `ApplicationType` enum type rather than `any` type to match signature of `#getAppInfo(...)`
Add fix for #615 to Tasks rendering
