### PR TITLE
Stream deploy: Fix property issues

### DIFF
--- a/ui/src/app/streams/stream-deploy/builder/builder.component.ts
+++ b/ui/src/app/streams/stream-deploy/builder/builder.component.ts
@@ -521,7 +521,10 @@ export class StreamDeployBuilderComponent implements OnInit, OnDestroy {
     const options = builder.builderAppsProperties[app.name] ? builder.builderAppsProperties[app.name] : app.options;
     const modal = this.bsModalService.show(StreamDeployAppPropertiesComponent);
 
-    modal.content.title = `Properties for ${app.name} (${version})`;
+    modal.content.title = `Properties for ${app.name}`;
+    if (version) {
+      modal.content.title += ` (${version})`;
+    }
     const appPropertiesSource = new AppPropertiesSource(Object.assign([], options
       .map((property) => Object.assign({}, property))));
 

--- a/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
@@ -181,11 +181,16 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
     this.update(value);
     const propertiesMap = {};
     value.forEach((val) => {
-      const arr = val.split('=');
-      if (arr.length !== 2) {
+      const arr = val.split(/=(.*)/);
+      if (arr.length !== 3) {
         console.error('Split line property', val);
       } else {
-        propertiesMap[arr[0]] = arr[1];
+        // Workaround sensitive property: ignored property
+        if (arr[1] === `'******'`) {
+          console.log(`Sensitive property ${arr[0]} is ignored`);
+        } else {
+          propertiesMap[arr[0]] = arr[1];
+        }
       }
     });
 


### PR DESCRIPTION
- Ignore sensitive property value on deploy stream
- Fix parsing line: app.foo=#jsonPath(payload,'$.lang')=='en' is now correctly parse
- Title dialog app property: remove version if skipper is not enable

Resolves spring-cloud/spring-cloud-dataflow-ui#780