### PR TITLE
Stream Deploy adjustments

### DIFF
--- a/ui/src/app/streams/stream-deploy/builder/builder.component.ts
+++ b/ui/src/app/streams/stream-deploy/builder/builder.component.ts
@@ -503,10 +503,21 @@ export class StreamDeployBuilderComponent implements OnInit, OnDestroy {
       return [];
     }
     return appProperties.map((property: Properties.Property) => {
-      return (property.value !== undefined && property.value.toString() !== '' && property.value !== property.defaultValue) ? ({
-        key: `${property.id}`,
-        value: property.value
-      }) : null;
+      if (property.value && property.value !== undefined && property.value.toString() !== ''
+        && property.value !== property.defaultValue) {
+        if (property.id.startsWith(`${appId}.`)) {
+          return {
+            key: `${property.name}`,
+            value: property.value
+          };
+        } else {
+          return {
+            key: `${property.id}`,
+            value: property.value
+          };
+        }
+      }
+      return null;
     }).filter((app) => app !== null);
   }
 

--- a/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
@@ -61,7 +61,7 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
   /**
    * Original properties Array
    */
-  originalProperties: Array<string> = [];
+  ignoreProperties: Array<string> = [];
 
   /**
    * Constructor
@@ -101,7 +101,7 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
         val => this.streamsService.getDeploymentInfo(val.id),
         (config: any, deploymentInfo: StreamDefinition) => {
           const properties = [];
-          const originalProperties = [];
+          const ignoreProperties = [];
 
           // Deployer properties
           Object.keys(deploymentInfo.deploymentProperties).map(app => {
@@ -134,12 +134,14 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
                   keyShort = key.substring(`${appType}.`.length, key.length);
                 }
                 properties.push(`app.${app}.${keyShort}=${value}`);
-                originalProperties.push(`app.${app}.${keyShort}=${value}`);
+                ignoreProperties.push(`app.${app}.${keyShort}=${value}`);
               });
             }
           });
           this.properties = properties;
-          this.originalProperties = originalProperties;
+          if (!config.skipper) {
+            this.ignoreProperties = ignoreProperties;
+          }
           config.streamDefinition = deploymentInfo;
           return config;
         }
@@ -188,7 +190,7 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
     this.update(value);
     const propertiesMap = {};
     value.forEach((val) => {
-      if (this.originalProperties.indexOf(val) === -1) {
+      if (this.ignoreProperties.indexOf(val) === -1) {
         const arr = val.split(/=(.*)/);
         if (arr.length !== 3) {
           console.error('Split line property', val);
@@ -204,21 +206,39 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
     });
 
     let obs = Observable.of({});
-    if (['deployed', 'deploying'].indexOf(this.refConfig.streamDefinition.status) > -1) {
-      obs = this.streamsService.undeployDefinition(this.refConfig.streamDefinition);
-    }
-    const busy = obs.pipe(mergeMap(
+    const isDeployed = (['deployed', 'deploying'].indexOf(this.refConfig.streamDefinition.status) > -1);
+    const update = this.refConfig.skipper && isDeployed;
+
+    if (update) {
+      obs = obs.pipe(mergeMap(
+        val => this.streamsService.updateDefinition(this.refConfig.id, propertiesMap),
+        (val1, val2) => val2
+      ));
+    } else {
+      if (isDeployed) {
+        obs = obs.pipe(mergeMap(
+          val => this.streamsService.undeployDefinition(this.refConfig.streamDefinition),
+          (val1, val2) => val2
+        ));
+      }
+      obs = obs.pipe(mergeMap(
         val => this.streamsService.deployDefinition(this.refConfig.id, propertiesMap),
         (val1, val2) => val2
-      ))
-      .pipe(takeUntil(this.ngUnsubscribe$))
-      .subscribe(
-        data => {
-          this.toastyService.success(`Successfully deployed stream definition "${this.refConfig.id}"`);
+      ));
+    }
+
+    const busy = obs.pipe(takeUntil(this.ngUnsubscribe$))
+      .subscribe(data => {
+          if (update) {
+            this.toastyService.success(`Successfully update stream definition "${this.refConfig.id}"`);
+          } else {
+            this.toastyService.success(`Successfully deployed stream definition "${this.refConfig.id}"`);
+          }
           this.router.navigate(['streams']);
         },
         error => {
-          this.toastyService.error(`${error.message ? error.message : error.toString()}`);
+          const err = error.message ? error.message : error.toString();
+          this.toastyService.error(err ? err : 'An error occurred during the stream deployment update.');
         }
       );
 

--- a/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
@@ -59,6 +59,11 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
   properties: Array<string> = [];
 
   /**
+   * Original properties Array
+   */
+  originalProperties: Array<string> = [];
+
+  /**
    * Constructor
    *
    * @param {ActivatedRoute} route
@@ -96,6 +101,7 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
         val => this.streamsService.getDeploymentInfo(val.id),
         (config: any, deploymentInfo: StreamDefinition) => {
           const properties = [];
+          const originalProperties = [];
 
           // Deployer properties
           Object.keys(deploymentInfo.deploymentProperties).map(app => {
@@ -128,11 +134,12 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
                   keyShort = key.substring(`${appType}.`.length, key.length);
                 }
                 properties.push(`app.${app}.${keyShort}=${value}`);
+                originalProperties.push(`app.${app}.${keyShort}=${value}`);
               });
             }
           });
-
           this.properties = properties;
+          this.originalProperties = originalProperties;
           config.streamDefinition = deploymentInfo;
           return config;
         }
@@ -181,15 +188,17 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
     this.update(value);
     const propertiesMap = {};
     value.forEach((val) => {
-      const arr = val.split(/=(.*)/);
-      if (arr.length !== 3) {
-        console.error('Split line property', val);
-      } else {
-        // Workaround sensitive property: ignored property
-        if (arr[1] === `'******'`) {
-          console.log(`Sensitive property ${arr[0]} is ignored`);
+      if (this.originalProperties.indexOf(val) === -1) {
+        const arr = val.split(/=(.*)/);
+        if (arr.length !== 3) {
+          console.error('Split line property', val);
         } else {
-          propertiesMap[arr[0]] = arr[1];
+          // Workaround sensitive property: ignored property
+          if (arr[1] === `'******'`) {
+            console.log(`Sensitive property ${arr[0]} is ignored`);
+          } else {
+            propertiesMap[arr[0]] = arr[1];
+          }
         }
       }
     });

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -168,6 +168,17 @@ export class StreamsService {
     return Observable.forkJoin(observables);
   }
 
+  updateDefinition(streamDefinitionName: String, propertiesAsMap: any = {}): Observable<Response> {
+    console.log('Updating...', streamDefinitionName, propertiesAsMap);
+    const options = HttpUtils.getDefaultRequestOptions();
+    return this.http.post(`/streams/deployments/update/${streamDefinitionName}`, {
+      releaseName: streamDefinitionName,
+      packageIdentifier: { packageName: streamDefinitionName, packageVersion: null },
+      updateProperties: propertiesAsMap
+    }, options)
+      .catch(this.errorHandler.handleError);
+  }
+
   getDeploymentInfo(streamDefinitionName: string): Observable<StreamDefinition> {
     const options = HttpUtils.getDefaultRequestOptions();
     return this.http.get(`/streams/deployments/${streamDefinitionName}`, options).map(res => {


### PR DESCRIPTION
Resolves #786 :  avoid resubmitting apps form values
Resolves #788 : on stream deploy, if skipper is enabled and the stream is deployed, an update of the stream is performed instead of an undeploy/deploy.