### PR TITLE
Better graph validation and auto link adding on transition editing

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -48,7 +48,7 @@
     "web-animations-js": "2.3.1",
     "stompjs": "2.3.3",
     "jshint": "2.9.5",
-    "spring-flo": "0.7.5",
+    "spring-flo": "git://github.com/spring-projects/spring-flo#483faf1a1b6ed595580a2af86d901d3f33013353",
     "ng-busy": "1.4.4"
   },
   "devDependencies": {

--- a/ui/src/app/tasks/components/flo/editor.service.ts
+++ b/ui/src/app/tasks/components/flo/editor.service.ts
@@ -216,6 +216,15 @@ export class EditorService implements Flo.Editor {
             message: 'Must have an outgoing link',
             range: element.attr('range')
           });
+        } else {
+            link = outgoing.find(l => !l.attr('props/ExitStatus'));
+            if (!link) {
+                markers.push({
+                    severity: Flo.Severity.Error,
+                    message: 'Must have at least one outgoing link with no Exit Status condition specified',
+                    range: element.attr('range')
+                });
+            }
         }
       }
     }


### PR DESCRIPTION
This PR does three things:

1) Upgrade Flo - this pulls in a version that will continue to drive validation even if the graph-to-text conversion fails. This is helpful because often the validation errors will tell the user what they need to fix to make the graph-to-text conversion work!
How to test: Paste this into the DSL textbox: `<a:timestamp || b:timestamp>`. Now delete the link from `b` to `$END`. Without this PR there is no indication on node `b` that there is a problem. With this change you will get the validation error `Must have an outgoing link` on `b`.

2) Auto create a missing default link when feasible - if you adjust the exit status code for a link from a node such that there is no longer a default (non-exit status code) link from that node then we will try to add a default link automatically. We will only do this if we can come up with a suitable end target for that link. It doesn't mean just creating a link to `$END` because you could be working anywhere in the graph, what we will do right now is if the target node for the link you are adjusting has a default link from it, we will treat that as the new target for a default link we create from the original node that no longer has a default link.
How to test: Paste this into the DSL textbox: `<extractDB: timestamp || extractFiles: timestamp> && merge: timestamp && cleanse: timestamp && <writetohdfs: timestamp || transform: timestamp && writetos3: timestamp 1->foo:timestamp && bar: timestamp>` now edit the properties of the link from `writetos3` to `bar`, change exit status condition to `2`.  You will see the link you edited becomes dotted and a new default link is created from `writetos3` to `$END` (because the target of `bar` was `$END`).  Without this change you will be missing that default link and you will have no idea you need to add it... and so onto (3)

3) An extra validation message - this will put an error on a node if there is no 'default' link from that node. A default link is one with no exit status condition specified (so a solid black link).
How to test: Paste this into the DSL textbox: `<extractDB: timestamp || extractFiles: timestamp> && merge: timestamp && cleanse: timestamp && <writetohdfs: timestamp || transform: timestamp && writetos3: timestamp 1->foo:timestamp && bar: timestamp>`.  Now delete the link from `bar` to `$END`. Now edit the link between `writetos3` and `bar` and specify an exit status. When you close that properties view for the link we can't come up with a good target to create a default link for you, so we don't and you will see the validation message on `writetos3` that says `Must have at least one outgoing link with no Exit Status condition specified`.

Resolves spring-cloud/spring-cloud-dataflow-ui#804