### PR TITLE
Move `unresolved` in ExtraMetadata object from ElementMetadata

### DIFF
--- a/ui/src/app/shared/flo/support/utils.ts
+++ b/ui/src/app/shared/flo/support/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import { Flo } from 'spring-flo';
+import { dia } from 'jointjs';
 
 /**
  * Utilities for Flo based graph editors.
@@ -47,6 +48,10 @@ export class Utils {
         && (propertyLowerCase === 'code' || propertyLowerCase === 'rxjava-processor.code'))
       || (metadata.name === Utils.SCRIPTABLE_TRANSFORM_NAME
         && (propertyLowerCase === 'script' || propertyLowerCase === 'scriptable-transformer.script'));
+  }
+
+  static isUnresolved(element: dia.Cell): boolean {
+    return element.attr('metadata/metadata/unresolved');
   }
 
 }

--- a/ui/src/app/streams/components/flo/editor.service.spec.ts
+++ b/ui/src/app/streams/components/flo/editor.service.spec.ts
@@ -4,18 +4,14 @@ import { MetamodelService } from './metamodel.service';
 import { RenderService } from './render.service';
 
 import { dia } from 'jointjs';
-import * as _ from 'lodash';
 import { Flo, Constants } from 'spring-flo';
-import { convertGraphToText } from './graph-to-text';
 import { Shapes } from 'spring-flo';
-import * as _joint from 'jointjs';
-const joint: any = _joint;
 
 import { EditorService } from './editor.service';
 import {MockSharedAppService} from '../../../tests/mocks/shared-app';
 import { LoggerService } from '../../../shared/services/logger.service';
 
-describe('editor.service', () => {
+describe('Streams Editor Service', () => {
     const editorService = new EditorService(null);
 
     let graph: dia.Graph;
@@ -352,11 +348,11 @@ describe('editor.service', () => {
                 },
                 properties(): Promise<Map<string, Flo.PropertyMetadata>> {
                     return Promise.resolve(new Map());
+                },
+                metadata: {
+                  unresolved: !group ? true : false
                 }
             };
-        }
-        if (!group) {
-          params.metadata.unresolved = true;
         }
         const newNode: dia.Element = Shapes.Factory.createNode(params);
         graph.addCell(newNode);

--- a/ui/src/app/streams/components/flo/editor.service.ts
+++ b/ui/src/app/streams/components/flo/editor.service.ts
@@ -21,6 +21,7 @@ import { Flo, Constants } from 'spring-flo';
 import { dia, g } from 'jointjs';
 import { StreamPropertiesDialogComponent } from './properties/stream-properties-dialog.component';
 import { Utils } from './support/utils';
+import { Utils as SharedUtils } from '../../../shared/flo/support/utils';
 import * as _joint from 'jointjs';
 import {StreamGraphPropertiesSource, StreamHead} from './properties/stream-properties-source';
 const joint: any = _joint;
@@ -66,7 +67,7 @@ export class EditorService implements Flo.Editor {
             createHandle(owner, Constants.REMOVE_HANDLE_TYPE, flo.deleteSelectedNode, pt);
 
             // Properties handle
-            if (!element.attr('metadata/unresolved')) {
+            if (!SharedUtils.isUnresolved(element)) {
                 pt = bbox.origin().offset(-14, bbox.height + 3);
                 createHandle(owner, Constants.PROPERTIES_HANDLE_TYPE, () => {
                     const modalRef = this.bsModalService.show(StreamPropertiesDialogComponent);
@@ -574,7 +575,7 @@ export class EditorService implements Flo.Editor {
 
     private validateMetadata(element: dia.Cell, errors: Array<Flo.Marker>) {
         // Unresolved elements validation
-        if (!element.attr('metadata') || element.attr('metadata/unresolved')) {
+        if (!element.attr('metadata') || SharedUtils.isUnresolved(element)) {
             let msg = 'Unknown element \'' + element.attr('metadata/name') + '\'';
             if (element.attr('metadata/group')) {
                 msg += ' from group \'' + element.attr('metadata/group') + '\'.';

--- a/ui/src/app/streams/components/flo/text-to-graph.ts
+++ b/ui/src/app/streams/components/flo/text-to-graph.ts
@@ -356,15 +356,17 @@ class TextToGraphConverter {
             if (!groupMetadata) {
                 // Create fake metadata so some sort of graph can be built
                 md = {
-                    'group': group,
-                    'name': name,
-                    unresolved: true,
-                    get(property: String): Promise<Flo.PropertyMetadata> {
-                        return Promise.resolve(null);
-                    },
-                    properties(): Promise<Map<string, Flo.PropertyMetadata>> {
-                        return Promise.resolve(new Map());
-                    }
+                      'group': group,
+                      'name': name,
+                      get(property: String): Promise<Flo.PropertyMetadata> {
+                          return Promise.resolve(null);
+                      },
+                      properties(): Promise<Map<string, Flo.PropertyMetadata>> {
+                          return Promise.resolve(new Map());
+                      },
+                      metadata: {
+                        unresolved: true
+                      }
                     };
             } else {
                 md = group ? this.metamodel.get(group).get(name) : null;

--- a/ui/src/app/tasks/components/flo/editor.service.ts
+++ b/ui/src/app/tasks/components/flo/editor.service.ts
@@ -6,6 +6,7 @@ import { dia, g } from 'jointjs';
 import * as _joint from 'jointjs';
 import { TaskPropertiesDialogComponent } from './properties/task-properties-dialog-component';
 import { TaskGraphPropertiesSource } from './properties/task-properties-source';
+import { Utils} from '../../../shared/flo/support/utils';
 
 const joint: any = _joint;
 
@@ -24,6 +25,8 @@ export class EditorService implements Flo.Editor {
   }
 
   allowLinkVertexEdit = true;
+
+
 
   /**
    * Creates cell handles.
@@ -49,7 +52,7 @@ export class EditorService implements Flo.Editor {
       }
 
       // Properties handle
-      if (!element.attr('metadata/unresolved') && !element.attr('metadata/metadata/noEditableProps')) {
+      if (!Utils.isUnresolved(element) && !element.attr('metadata/metadata/noEditableProps')) {
         pt = bbox.origin().offset(-14, bbox.height + 3);
         createHandle(owner, Constants.PROPERTIES_HANDLE_TYPE, () => {
           const modalRef = this.bsModalService.show(TaskPropertiesDialogComponent);
@@ -125,7 +128,7 @@ export class EditorService implements Flo.Editor {
   }
 
   private validateConnectedLinks(graph: dia.Graph, element: dia.Element, markers: Array<Flo.Marker>) {
-    if (element.attr('metadata') && !element.attr('metadata/unresolved')) {
+    if (element.attr('metadata') && !Utils.isUnresolved(element)) {
       const type = element.attr('metadata/name');
       const incoming = graph.getConnectedLinks(element, { inbound: true });
       const outgoing = graph.getConnectedLinks(element, { outbound: true });
@@ -264,7 +267,7 @@ export class EditorService implements Flo.Editor {
 
   private validateMetadata(element: dia.Cell, errors: Array<Flo.Marker>) {
     // Unresolved elements validation
-    if (!element.attr('metadata') || element.attr('metadata/unresolved')) {
+    if (!element.attr('metadata') || Utils.isUnresolved(element)) {
       let msg = `Unknown element '${element.attr('metadata/name')}'`;
       if (element.attr('metadata/group')) {
         msg += ` from group '${element.attr('metadata/group')}'.`;

--- a/ui/src/app/tasks/components/flo/metamodel.service.ts
+++ b/ui/src/app/tasks/components/flo/metamodel.service.ts
@@ -259,12 +259,10 @@ export class MetamodelService implements Flo.Metamodel {
         group = TASK_GROUP_TYPE;
       }
 
-      let metadata = metamodel.get(group).get(name);
+      let metadata = metamodel.get(group) ? metamodel.get(group).get(name) : undefined;
       if (!metadata) {
         // Unknown element
-        metadata = this.createMetadata(name, group, '', new Map<string, Flo.PropertyMetadata>());
-        // Mark it "unresolved"
-        metadata.unresolved = true;
+        metadata = this.createMetadata(name, group, '', new Map<string, Flo.PropertyMetadata>(), { unresolved: true });
       }
 
       const properties = new Map<string, any>();


### PR DESCRIPTION
The `unresolved` property was set on the ElementMetadata object. It's moved inside ExtraMetadata object which is contained by ElementMetadata to ensure TS `readonly` is not violated.
New TS compiler with Angular 6 seem to catch these violations...