### PR TITLE
Unbound stream applications

### DIFF
--- a/ui/src/app/apps/apps.service.spec.ts
+++ b/ui/src/app/apps/apps.service.spec.ts
@@ -93,7 +93,7 @@ describe('AppsService', () => {
 
       const httpUri = this.mockHttp.delete.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.delete.calls.mostRecent().args[1].headers;
-      expect(httpUri).toEqual('/apps/0/blubba');
+      expect(httpUri).toEqual('/apps/1/blubba');
       expect(headerArgs.get('Content-Type')).toEqual('application/json');
       expect(headerArgs.get('Accept')).toEqual('application/json');
 

--- a/ui/src/app/apps/components/app-list-bar/app-list-bar.component.html
+++ b/ui/src/app/apps/components/app-list-bar/app-list-bar.component.html
@@ -34,6 +34,7 @@
         </a>
         <ul class="dropdown-menu dropdown-menu-right" *dropdownMenu="">
           <li [class.active]="form.type == '' || form.type == null"><a (click)="form.type = ''">All types</a></li>
+          <li [class.active]="form.type == 'app'"><a (click)="form.type = 'app'">App</a></li>
           <li [class.active]="form.type == 'source'"><a (click)="form.type = 'source'">Source</a></li>
           <li [class.active]="form.type == 'processor'"><a (click)="form.type = 'processor'">Processor</a></li>
           <li [class.active]="form.type == 'sink'"><a (click)="form.type = 'sink'">Sink</a></li>

--- a/ui/src/app/apps/components/app-type/app-type.component.ts
+++ b/ui/src/app/apps/components/app-type/app-type.component.ts
@@ -52,6 +52,9 @@ export class AppTypeComponent implements AfterContentInit, DoCheck {
       this.label = this.application.type.toString().toUpperCase();
 
       switch (this.label) {
+        case 'APP':
+          this.labelClass = 'error';
+          break;
         case 'TASK':
           this.labelClass = 'danger';
           break;

--- a/ui/src/app/apps/components/app-type/app-type.component.ts
+++ b/ui/src/app/apps/components/app-type/app-type.component.ts
@@ -53,7 +53,7 @@ export class AppTypeComponent implements AfterContentInit, DoCheck {
 
       switch (this.label) {
         case 'APP':
-          this.labelClass = 'error';
+          this.labelClass = 'app';
           break;
         case 'TASK':
           this.labelClass = 'danger';

--- a/ui/src/app/shared/model/application-type.ts
+++ b/ui/src/app/shared/model/application-type.ts
@@ -6,6 +6,11 @@
  */
 export enum ApplicationType {
   /**
+   * An applicatioin type that can have a number of input and output channels
+   */
+  app,
+
+  /**
    * An application type that appears in a stream, at first position.
    */
   source,

--- a/ui/src/app/shared/services/tokenizer.spec.ts
+++ b/ui/src/app/shared/services/tokenizer.spec.ts
@@ -93,13 +93,41 @@ describe('tokenizer:', () => {
 
   it('error: unexpected char', () => {
     try {
-      tokens = tokenize(' *');
+      tokens = tokenize(' (');
       fail();
     } catch (error) {
       expect(error.msg).toEqual('TokenizationError: Unexpected character');
       expect(error.start).toEqual(1);
       expect(error.end).toEqual(2);
     }
+  });
+
+  it('channel tokenization', () => {
+    tokens = tokenize(':foo');
+    expect(tokens.length).toEqual(2);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    tokens = tokenize(':foo*');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    expectToken(tokens[2], TokenKind.STAR, 4, 5);
+    tokens = tokenize(':foo/');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    expectToken(tokens[2], TokenKind.SLASH, 4, 5);
+    tokens = tokenize(':foo#');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    expectToken(tokens[2], TokenKind.HASH, 4, 5);
+    tokens = tokenize(':*/#');
+    expect(tokens.length).toEqual(4);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.STAR, 1, 2);
+    expectToken(tokens[2], TokenKind.SLASH, 2, 3);
+    expectToken(tokens[3], TokenKind.HASH, 3, 4);
   });
 
   it('option tokenization', () => {
@@ -118,8 +146,6 @@ describe('tokenizer:', () => {
     expect(token.end).toEqual(end);
     if (data) {
       expect(token.data).toEqual(data);
-    } else {
-      expect(token.data).toBeUndefined();
     }
   }
 });

--- a/ui/src/app/shared/services/tokenizer.ts
+++ b/ui/src/app/shared/services/tokenizer.ts
@@ -26,8 +26,12 @@ export enum TokenKind {
     SEMICOLON = ';',
     // REFERENCE = '@',
     DOT = '.',
+    SLASH = '/',
+    STAR = '*',
+    HASH = '#',
     LITERAL_STRING = '<LITERAL_STRING>',
-    EOF = '<EOF>'
+    EOF = '<EOF>',
+    COMMA = ','
 }
 
 export interface Token {
@@ -94,7 +98,7 @@ class Tokenizer {
 
     private isArgValueIdentifierTerminator(ch: string, quoteOpen: boolean): boolean {
         return (ch === '|' && !quoteOpen) || (ch === ';' && !quoteOpen) || ch === '\0' || (ch === ' ' && !quoteOpen) ||
-            (ch === '\t' && !quoteOpen) || (ch === '>' && !quoteOpen) ||
+            (ch === '\t' && !quoteOpen) || (ch === '>' && !quoteOpen) || (ch === ',' && !quoteOpen) ||
             ch === '\r' || ch === '\n';
     }
 
@@ -130,7 +134,7 @@ class Tokenizer {
     }
 
     private pushCharToken(tokenkind: TokenKind) {
-        this.tokens.push({'kind': tokenkind, 'start': this.pos, 'end': this.pos + 1});
+        this.tokens.push({'kind': tokenkind,  'data': tokenkind, 'start': this.pos, 'end': this.pos + 1});
         this.pos++;
     }
 
@@ -293,8 +297,20 @@ class Tokenizer {
                 case '>':
                     this.pushCharToken(TokenKind.GT);
                     break;
+                case ',':
+                    this.pushCharToken(TokenKind.COMMA);
+                    break;
                 case ':':
                     this.pushCharToken(TokenKind.COLON);
+                    break;
+                case '/':
+                    this.pushCharToken(TokenKind.SLASH);
+                    break;
+                case '*':
+                    this.pushCharToken(TokenKind.STAR);
+                    break;
+                case '#':
+                    this.pushCharToken(TokenKind.HASH);
                     break;
                 case ';':
                     this.pushCharToken(TokenKind.SEMICOLON);

--- a/ui/src/app/streams/components/flo/editor.service.ts
+++ b/ui/src/app/streams/components/flo/editor.service.ts
@@ -129,17 +129,24 @@ export class EditorService implements Flo.Editor {
         }
 
         if (cellViewS.model.attr('metadata') && cellViewT.model.attr('metadata')) {
+            const targetGroup = cellViewT.model.attr('metadata/group');
+
             // Target is a SOURCE node? Disallow link!
-            if (cellViewT.model.attr('metadata/group') === ApplicationType[ApplicationType.source]) {
+            // Target is APP type node? Disallow link!
+            if (targetGroup === ApplicationType[ApplicationType.source]
+                || targetGroup === ApplicationType[ApplicationType.app]) {
                 return false;
             }
             // Target is an explicit tap? Disallow link!
             if (cellViewT.model.attr('metadata/name') === 'tap') {
                 return false;
             }
-            // Sinks and Tasks cannot have outgoing links
-            if (cellViewS.model.attr('metadata/group') === ApplicationType[ApplicationType.sink] ||
-                cellViewS.model.attr('metadata/group') === ApplicationType[ApplicationType.task]) {
+
+            const sourceGroup = cellViewS.model.attr('metadata/group');
+            // SINK, TASK, APP cannot have outgoing links
+            if (sourceGroup === ApplicationType[ApplicationType.sink]
+              || sourceGroup === ApplicationType[ApplicationType.task]
+              || sourceGroup === ApplicationType[ApplicationType.app]) {
                 return false;
             }
 

--- a/ui/src/app/streams/components/flo/metamodel.service.ts
+++ b/ui/src/app/streams/components/flo/metamodel.service.ts
@@ -69,7 +69,7 @@ export class MetamodelService implements Flo.Metamodel {
     }
 
     groups(): Array<string> {
-        return ['source', 'processor', 'sink', 'other'];
+        return ['app', 'source', 'processor', 'sink', 'other'];
     }
 
     load(): Promise<Map<string, Map<string, Flo.ElementMetadata>>> {
@@ -83,7 +83,8 @@ export class MetamodelService implements Flo.Metamodel {
             this.appsService.getApps({page: 0, size: 1000}).subscribe(
                 data => {
                     data.items.filter(item => {
-                        return item.type.toString() === ApplicationType[ApplicationType.source]
+                        return item.type.toString() === ApplicationType[ApplicationType.app]
+                        || item.type.toString() === ApplicationType[ApplicationType.source]
                         || item.type.toString() === ApplicationType[ApplicationType.processor]
                         || item.type.toString() === ApplicationType[ApplicationType.sink];
                     }).forEach(item => {

--- a/ui/src/app/streams/components/flo/support/node-helper.ts
+++ b/ui/src/app/streams/components/flo/support/node-helper.ts
@@ -36,6 +36,7 @@ const DECORATION_ICON_MAP = new Map<string, string>()
 
 // Default icons (unicode chars) for each group member, unless they override
 const GROUP_ICONS = new Map<string, string>()
+  .set('app', '⌸') // U+2338 (Quad equal symbol)
   .set('source', '⤇')// 2907
   .set('processor', 'λ') // 3bb  //flux capacitor? 1D21B
   .set('sink', '⤇') // 2907
@@ -54,6 +55,31 @@ export class NodeHelper {
 
   static createNode(metadata: Flo.ElementMetadata): dia.Element {
     switch (metadata.group) {
+
+      case ApplicationType[ApplicationType.app]:
+        return new joint.shapes.flo.DataFlowApp(
+          joint.util.deepSupplement({
+            attrs: {
+              '.box': {
+                'fill': '#eef4ee',
+              },
+              '.input-port': {
+                display: 'none',
+                magnet: false
+              },
+              '.output-port': {
+                display: 'none',
+                magnet: false
+              },
+              '.label1': {
+                'text': metadata.name
+              },
+              '.label2': {
+                'text': GROUP_ICONS.get(metadata.group)
+              }
+            }
+          }, joint.shapes.flo.DataFlowApp.prototype.defaults)
+        );
 
       case ApplicationType[ApplicationType.source]:
         return new joint.shapes.flo.DataFlowApp(

--- a/ui/src/app/streams/components/flo/support/utils.spec.ts
+++ b/ui/src/app/streams/components/flo/support/utils.spec.ts
@@ -23,6 +23,72 @@ describe('utils', () => {
     METAMODEL_SERVICE.load().then(data => metamodel = data);
   }));
 
+  it('app can be head of stream', () => {
+    const node = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('http-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    expect(Utils.canBeHeadOfStream(graph, node)).toEqual(true);
+  });
+
+  it('both app can be head of stream', () => {
+    const node1 = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('http-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    const node2 = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('file-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    expect(Utils.canBeHeadOfStream(graph, node1)).toEqual(true);
+    expect(Utils.canBeHeadOfStream(graph, node2)).toEqual(true);
+  });
+
+  it('if one app has "stream-name" set others cannot be head of stream', () => {
+    const node = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('time-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    node.attr('stream-name', 'STREAM-1');
+    const node1 = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('http-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    const node2 = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('file-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    expect(Utils.canBeHeadOfStream(graph, node)).toEqual(true);
+    expect(Utils.canBeHeadOfStream(graph, node1)).toEqual(false);
+    expect(Utils.canBeHeadOfStream(graph, node2)).toEqual(false);
+  });
+
+  it('if non-app node has "stream-name" set other app nodes can be head of streams', () => {
+    const node = Shapes.Factory.createNode({
+      metadata: metamodel.get('source').get('http'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    const node1 = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('http-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    const node2 = Shapes.Factory.createNode({
+      metadata: metamodel.get('app').get('file-app'),
+      renderer: RENDER_SERVICE,
+      graph: graph
+    });
+    expect(Utils.canBeHeadOfStream(graph, node1)).toEqual(true);
+    expect(Utils.canBeHeadOfStream(graph, node2)).toEqual(true);
+  });
+
   it('source can be head of stream', () => {
     const node = Shapes.Factory.createNode({
       metadata: metamodel.get('source').get('http'),

--- a/ui/src/app/streams/components/flo/text-to-graph.spec.ts
+++ b/ui/src/app/streams/components/flo/text-to-graph.spec.ts
@@ -63,6 +63,17 @@ describe('text-to-graph', () => {
         expect(graph.links[1].to).toEqual(1);
     });
 
+    it('jsongraph: two separate apps should be unconnected', () => {
+        graph = getGraph('aaa, bbb');
+        expect(graph.streamdefs.length).toEqual(1);
+        expect(graph.streamdefs[0].def).toEqual('aaa, bbb');
+        expect(graph.nodes[0].name).toEqual('aaa');
+        expect(graph.nodes[0].group).toEqual('app');
+        expect(graph.nodes[1].name).toEqual('bbb');
+        expect(graph.nodes[1].group).toEqual('app');
+        expect(graph.links.length).toEqual(0);
+    });
+
     it('jsongraph: tapping a stream', () => {
         graph = getGraph('aaaa= time | log\n:aaaa.time>log');
         expect(graph.streamdefs[0].def).toEqual('time | log');

--- a/ui/src/app/tests/mocks/shared-app.ts
+++ b/ui/src/app/tests/mocks/shared-app.ts
@@ -7,102 +7,129 @@ import {Page} from '../../shared/model/page';
 import {AppRegistration} from '../../shared/model/app-registration.model';
 import {DetailedAppRegistration} from '../../shared/model/detailed-app-registration.model';
 import {Flo} from 'spring-flo';
-import { EMPTY } from 'rxjs/index';
+import {EMPTY} from 'rxjs/index';
 
-const METAMODEL_DATA: Array<RawMetadata> = [{
-  name: 'http', type: 'source', description: 'Receive HTTP input',
-  options: [
-    {id: 'port', name: 'port', defaultValue: '80', description: 'Port on which to listen', type: 'number'}
-  ],
-}, {
-  name: 'rabbit', type: 'source', description: 'Receives messages from RabbitMQ',
-  options: [
-    {id: 'queue', name: 'queue', description: 'the queue(s) from which messages will be received'},
-    {id: 'time-unit', name: 'time-unit', description: 'Time unit for heart beat messages', type: 'enum',
-      options: ['HOURS', 'MINUTES', 'SECONDS', 'MILIOSECONDS'], defaultValue: 'SECONDS'},
-    {id: 'heart-beat', name: 'heart-beat', description: 'Heart beat on/off', type: 'boolean', defaultValue: false},
-    {id: 'interval', name: 'interval', description: 'Time period being consecutive heart beat messages', type: 'number', defaultValue: 20},
-    {id: 'url', name: 'url', description: 'Service URL', type: 'url'},
-    {id: 'password', name: 'password', description: 'Password to login to service', type: 'password'},
-    {id: 'messages', name: 'messages', description: 'List of messages', type: 'list'},
-    {id: 'counts', name: 'counts', description: 'List of counts', type: 'list[number]'},
-    {id: 'successes', name: 'successes', description: 'List of successes', type: 'list[boolean]'},
-  ],
-}, {
-  name: 'filewatch', type: 'source', description: 'Produce messages from the content of files created in a directory',
-  options: [
-    {id: 'dir', name: 'dir', description: 'the absolute path to monitor for files'}
-  ],
-}, {
-  name: 'transform', type: 'processor', description: 'Apply an expression to modify incoming messages',
-  options: [
-    {id: 'expression', name: 'expression', defaultValue: 'payload', description: 'SpEL expression to apply'}
-  ],
-}, {
-  name: 'filter', type: 'processor', description: 'Only allow messages through that pass the filter expression',
-  options: [
-    {id: 'expression', name: 'expression', defaultValue: 'true', description: 'SpEL expression to use for filtering'}
-  ],
-}, {
-  name: 'filesave', type: 'sink', description: 'Writes messages to a file',
-  options: [
-    {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
-    {id: 'name', name: 'name', description: 'The name of the file to create'}
-  ],
-}, {
-  name: 'end', type: 'sink', description: 'Writes messages to a file',
-  options: [
-    {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
-    {id: 'name', name: 'name', description: 'The name of the file to create'}
-  ],
-}, {
-  name: 'null', type: 'sink', description: 'Writes messages to a file',
-  options: [
-    {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
-    {id: 'name', name: 'name', description: 'The name of the file to create'}
-  ],
-}, {
-  name: 'console', type: 'sink', description: 'Writes messages to a file',
-  options: [
-    {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
-    {id: 'name', name: 'name', description: 'The name of the file to create'}
-  ],
-}, {
-  name: 'hdfs', type: 'sink', description: 'Writes messages to a file',
-  options: [
-    {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
-    {id: 'name', name: 'name', description: 'The name of the file to create'}
-  ],
-}, {
-  name: 'jdbc', type: 'sink', description: 'Writes messages to a file',
-  options: [
-    {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
-    {id: 'name', name: 'name', description: 'The name of the file to create'}
-  ],
-}, {
-  name: 'ftp', type: 'sink', description: 'Send messages over FTP',
-  options: [
-    {id: 'host', name: 'host', description: 'the host name for the FTP server'},
-    {id: 'port', name: 'port', description: 'The port for the FTP server', type: 'number'},
-    {id: 'remoteDir', name: 'remoteDir', description: 'The remote directory on the server'},
-  ],
-}, {
-  name: 'a', type: 'task', description: 'Task a', options: []
-}, {
-  name: 'b', type: 'task', description: 'Task b', options: []
-}, {
-  name: 'c', type: 'task', description: 'Task c', options: []
-}, {
-  name: 'd', type: 'task', description: 'Task d', options: []
-}, {
-  name: 'super-very-long-task-name', type: 'task', description: 'Task d', options: []
-}];
+const METAMODEL_DATA: Array<RawMetadata> = [
+  {
+    name: 'file-app', type: 'app', description: 'File App',
+    options: [
+      {id: 'port', name: 'port', defaultValue: '80', description: 'Port on which to listen', type: 'number'}
+    ],
+  },
+  {
+    name: 'time-app', type: 'app', description: 'Time App',
+    options: [
+      {id: 'port', name: 'port', defaultValue: '80', description: 'Port on which to listen', type: 'number'}
+    ],
+  },
+  {
+    name: 'http-app', type: 'app', description: 'HTTP app',
+    options: [
+      {id: 'port', name: 'port', defaultValue: '80', description: 'Port on which to listen', type: 'number'}
+    ],
+  },
+  {
+    name: 'http', type: 'source', description: 'Receive HTTP input',
+    options: [
+      {id: 'port', name: 'port', defaultValue: '80', description: 'Port on which to listen', type: 'number'}
+    ],
+  }, {
+    name: 'rabbit', type: 'source', description: 'Receives messages from RabbitMQ',
+    options: [
+      {id: 'queue', name: 'queue', description: 'the queue(s) from which messages will be received'},
+      {
+        id: 'time-unit', name: 'time-unit', description: 'Time unit for heart beat messages', type: 'enum',
+        options: ['HOURS', 'MINUTES', 'SECONDS', 'MILIOSECONDS'], defaultValue: 'SECONDS'
+      },
+      {id: 'heart-beat', name: 'heart-beat', description: 'Heart beat on/off', type: 'boolean', defaultValue: false},
+      {
+        id: 'interval',
+        name: 'interval',
+        description: 'Time period being consecutive heart beat messages',
+        type: 'number',
+        defaultValue: 20
+      },
+      {id: 'url', name: 'url', description: 'Service URL', type: 'url'},
+      {id: 'password', name: 'password', description: 'Password to login to service', type: 'password'},
+      {id: 'messages', name: 'messages', description: 'List of messages', type: 'list'},
+      {id: 'counts', name: 'counts', description: 'List of counts', type: 'list[number]'},
+      {id: 'successes', name: 'successes', description: 'List of successes', type: 'list[boolean]'},
+    ],
+  }, {
+    name: 'filewatch', type: 'source', description: 'Produce messages from the content of files created in a directory',
+    options: [
+      {id: 'dir', name: 'dir', description: 'the absolute path to monitor for files'}
+    ],
+  }, {
+    name: 'transform', type: 'processor', description: 'Apply an expression to modify incoming messages',
+    options: [
+      {id: 'expression', name: 'expression', defaultValue: 'payload', description: 'SpEL expression to apply'}
+    ],
+  }, {
+    name: 'filter', type: 'processor', description: 'Only allow messages through that pass the filter expression',
+    options: [
+      {id: 'expression', name: 'expression', defaultValue: 'true', description: 'SpEL expression to use for filtering'}
+    ],
+  }, {
+    name: 'filesave', type: 'sink', description: 'Writes messages to a file',
+    options: [
+      {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
+      {id: 'name', name: 'name', description: 'The name of the file to create'}
+    ],
+  }, {
+    name: 'end', type: 'sink', description: 'Writes messages to a file',
+    options: [
+      {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
+      {id: 'name', name: 'name', description: 'The name of the file to create'}
+    ],
+  }, {
+    name: 'null', type: 'sink', description: 'Writes messages to a file',
+    options: [
+      {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
+      {id: 'name', name: 'name', description: 'The name of the file to create'}
+    ],
+  }, {
+    name: 'console', type: 'sink', description: 'Writes messages to a file',
+    options: [
+      {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
+      {id: 'name', name: 'name', description: 'The name of the file to create'}
+    ],
+  }, {
+    name: 'hdfs', type: 'sink', description: 'Writes messages to a file',
+    options: [
+      {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
+      {id: 'name', name: 'name', description: 'The name of the file to create'}
+    ],
+  }, {
+    name: 'jdbc', type: 'sink', description: 'Writes messages to a file',
+    options: [
+      {id: 'dir', name: 'dir', description: 'Absolute path to directory'},
+      {id: 'name', name: 'name', description: 'The name of the file to create'}
+    ],
+  }, {
+    name: 'ftp', type: 'sink', description: 'Send messages over FTP',
+    options: [
+      {id: 'host', name: 'host', description: 'the host name for the FTP server'},
+      {id: 'port', name: 'port', description: 'The port for the FTP server', type: 'number'},
+      {id: 'remoteDir', name: 'remoteDir', description: 'The remote directory on the server'},
+    ],
+  }, {
+    name: 'a', type: 'task', description: 'Task a', options: []
+  }, {
+    name: 'b', type: 'task', description: 'Task b', options: []
+  }, {
+    name: 'c', type: 'task', description: 'Task c', options: []
+  }, {
+    name: 'd', type: 'task', description: 'Task d', options: []
+  }, {
+    name: 'super-very-long-task-name', type: 'task', description: 'Task d', options: []
+  }];
 
 interface RawMetadata {
   name: string;
   type: string;
   description: string;
-  options: Array < Flo.PropertyMetadata >;
+  options: Array<Flo.PropertyMetadata>;
 }
 
 export class MockSharedAppService extends SharedAppsService {

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -436,6 +436,11 @@ em.required {
   color: rgba(255, 255, 255, .9);
 }
 
+.label-error {
+  background-color: #FF0000;
+  color: rgba(255, 255, 255, .9);
+}
+
 .label-apptype, .label-stream-status, .label-task-status, .label-job-status {
   padding: .25em 0.8em .3em;
   &.label-default {

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -446,6 +446,10 @@ em.required {
   &.label-default {
     background-color: #87939f;
   }
+  &.label-app {
+    background: #ff00de;
+    color: rgba(255, 255, 255, .9);
+  }
 }
 
 .input-file {


### PR DESCRIPTION
Fixes #889
Fixes #926 

- Unbound stream apps correspond to "App" type in the UI
- DSL client side parser supports comma separated app list.
- Client side tokenization/parsing extended to allow extra wildcards in
  destination names.
- Tests added for new features and adjusted existing tests.