### PR TITLE
Task / Scheduler: enforce rules for deployment properties

### DIFF
--- a/ui/src/app/tasks/task-launch/task-launch.component.html
+++ b/ui/src/app/tasks/task-launch/task-launch.component.html
@@ -31,8 +31,8 @@
                   <td>
                     <div [class.has-error]="form.get('args.' + i).invalid">
                       <input formControlName="key" type="text" class="form-control"/>
-                      <div *ngIf="form.get('args.' + i + '.key').invalid"
-                           class="help-block">Invalid key
+                      <div *ngIf="form.get('args.' + i + '.key').invalid" class="help-block">
+                        Invalid key
                       </div>
                       <div *ngIf="form.get('args.' + i).invalid" class="help-block">
                         Invalid key
@@ -79,10 +79,10 @@
                   <td>
                     <div [class.has-error]="form.get('params.' + i).invalid">
                       <input formControlName="key" type="text" class="form-control"/>
-                      <div *ngIf="form.get('params.' + i + '.key').invalid"
-                           class="help-block">Invalid key
+                      <div *ngIf="form.get('params.' + i + '.key').invalid" class="help-block">
+                        The key should start with `app.` or `deployer.` or `scheduler.`.
                       </div>
-                      <div *ngIf="form.get('params.' + i).invalid" class="help-block">
+                      <div *ngIf="form.get('params.' + i).invalid && !form.get('params.' + i + '.key').invalid" class="help-block">
                         Invalid key
                       </div>
                     </div>

--- a/ui/src/app/tasks/task-launch/task-launch.component.ts
+++ b/ui/src/app/tasks/task-launch/task-launch.component.ts
@@ -80,23 +80,23 @@ export class TaskLaunchComponent implements OnInit, OnDestroy {
       'args': new FormArray([])
     });
     const isEmpty = (dictionary): boolean => Object.entries(dictionary).every((a) => a[1] === '');
-    const clean = (array: FormArray, addFunc) => {
+    const clean = (array: FormArray, addFunc, keyValidator: boolean) => {
       if (!isEmpty(array.controls[array.controls.length - 1].value)) {
-        return addFunc(array);
+        return addFunc(array, keyValidator);
       }
     };
-    const add = (arr: FormArray) => {
+    const add = (arr: FormArray, keyValidator: boolean) => {
       const group = new FormGroup({
-        'key': new FormControl(''),
+        'key': new FormControl('', keyValidator ? TaskLaunchValidator.key : null),
         'val': new FormControl('')
       }, { validators: TaskLaunchValidator.keyRequired });
       group.valueChanges.subscribe(() => {
-        clean(arr, add);
+        clean(arr, add, keyValidator);
       });
       arr.push(group);
     };
-    add(this.form.get('params') as FormArray);
-    add(this.form.get('args') as FormArray);
+    add(this.form.get('params') as FormArray, true);
+    add(this.form.get('args') as FormArray, false);
   }
 
   /**

--- a/ui/src/app/tasks/task-launch/task-launch.validator.spec.ts
+++ b/ui/src/app/tasks/task-launch/task-launch.validator.spec.ts
@@ -1,4 +1,4 @@
-import {FormControl, FormGroup} from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { TaskLaunchValidator } from './task-launch.validator';
 
 /**
@@ -31,6 +31,29 @@ describe('TaskLaunchValidator', () => {
           'val': new FormControl(mock[1])
         });
         expect(TaskLaunchValidator.keyRequired(group)).toBeNull();
+      });
+    });
+  });
+
+  describe('key', () => {
+    it('invalid', () => {
+      [
+        'foo',
+        'foo.bar',
+        'apps.aaa'
+      ].forEach((mock) => {
+        const control: FormControl = new FormControl(mock);
+        expect(TaskLaunchValidator.key(control).invalid).toBeTruthy();
+      });
+    });
+    it('valid', () => {
+      [
+        'app.foo',
+        'deployer.foo',
+        'scheduler.foo',
+      ].forEach((mock) => {
+        const control: FormControl = new FormControl(mock);
+        expect(TaskLaunchValidator.key(control)).toBeNull();
       });
     });
   });

--- a/ui/src/app/tasks/task-launch/task-launch.validator.ts
+++ b/ui/src/app/tasks/task-launch/task-launch.validator.ts
@@ -24,4 +24,18 @@ export class TaskLaunchValidator {
     return { invalid: true };
   }
 
+  /**
+   * Key should start with app. or deployer. or scheduler if not empty
+   *
+   * @param {FormControl} control
+   * @returns {any}
+   */
+  static key(control: FormControl) {
+    const value = control.value;
+    if (value && !value.startsWith('app.') && !value.startsWith('deployer.') && !value.startsWith('scheduler.')) {
+      return { invalid: true };
+    }
+    return null;
+  }
+
 }

--- a/ui/src/app/tasks/task-schedule-create/task-schedule-create.component.html
+++ b/ui/src/app/tasks/task-schedule-create/task-schedule-create.component.html
@@ -163,10 +163,13 @@
                     <td>
                       <div [class.has-error]="submitted && form.get('params.' + i).invalid">
                         <input formControlName="key" type="text" class="form-control input-sm"/>
-                        <div *ngIf="submitted && form.get('params.' + i + '.key').invalid" class="help-block">Invalid
-                          key
+                        <div *ngIf="submitted && form.get('params.' + i + '.key').invalid" class="help-block">
+                          The key should start with `app.` or `deployer.` or `scheduler.`.
                         </div>
-                        <div *ngIf="submitted && form.get('params.' + i).invalid" class="help-block">Invalid key</div>
+                        <div class="help-block"
+                             *ngIf="submitted && form.get('params.' + i).invalid && !form.get('params.' + i + '.key').invalid">
+                          Invalid key
+                        </div>
                       </div>
                     </td>
                     <td>

--- a/ui/src/app/tasks/task-schedule-create/task-schedule-create.component.ts
+++ b/ui/src/app/tasks/task-schedule-create/task-schedule-create.component.ts
@@ -139,23 +139,23 @@ export class TaskScheduleCreateComponent implements OnInit {
       'args': new FormArray([])
     });
     const isEmpty = (dictionary): boolean => Object.entries(dictionary).every((a) => a[1] === '');
-    const clean = (array: FormArray, addFunc) => {
+    const clean = (array: FormArray, addFunc, keyValidator: boolean) => {
       if (!isEmpty(array.controls[array.controls.length - 1].value)) {
-        return addFunc(array);
+        return addFunc(array, keyValidator);
       }
     };
-    const add = (arr: FormArray) => {
+    const add = (arr: FormArray, keyValidator: boolean) => {
       const group = new FormGroup({
-        'key': new FormControl(''),
+        'key': new FormControl('', keyValidator ? TaskLaunchValidator.key : null),
         'val': new FormControl('')
       }, { validators: TaskLaunchValidator.keyRequired });
       group.valueChanges.subscribe(() => {
-        clean(arr, add);
+        clean(arr, add, keyValidator);
       });
       arr.push(group);
     };
-    add(this.form.get('params') as FormArray);
-    add(this.form.get('args') as FormArray);
+    add(this.form.get('params') as FormArray, true);
+    add(this.form.get('args') as FormArray, false);
   }
 
   /**


### PR DESCRIPTION
Resolves #937
Deployment properties: the key should start with ‘app.’ or ‘deployer.’ or ‘scheduler.’