### PR TITLE
Upgrade Flo to 0.8.6 and get the fix for overlapping links

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "web-animations-js": "2.3.1",
     "stompjs": "2.3.3",
     "jshint": "2.9.5",
-    "spring-flo": "0.8.5",
+    "spring-flo": "0.8.6",
     "ng-busy": "1.4.4",
     "rxjs-compat": "6.2.1",
     "uuid": "3.3.2"


### PR DESCRIPTION
Fixes #996 
Also upgrade Flo to angular 7.1.1 and JointJS 2.2.1