### PR TITLE
Fix sort names for stream/task definitions

### DIFF
--- a/ui/src/app/apps/apps-add/apps-add.validator.ts
+++ b/ui/src/app/apps/apps-add/apps-add.validator.ts
@@ -51,9 +51,9 @@ export class AppsAddValidator {
           if (tmp.length !== 2) {
             throw new Error();
           }
-          const val:string = tmp[1];
+          const val: string = tmp[1];
           const startWidth = ['http://', 'https://', 'docker:', 'maven://'];
-          if (startWidth.filter((a) => val.startsWith(a)).length === 0) {
+          if (startWidth.filter((b) => val.startsWith(b)).length === 0) {
             throw new Error();
           }
         });

--- a/ui/src/app/layout/navigation/search/search.component.ts
+++ b/ui/src/app/layout/navigation/search/search.component.ts
@@ -131,7 +131,7 @@ export class NavigationSearchComponent implements OnInit {
             q: value + '',
             page: 0,
             size: 5,
-            sort: 'DEFINITION_NAME',
+            sort: 'name',
             order: 'ASC'
           }).subscribe((page: Page<StreamDefinition>) => {
             this.resultSearch.stream = page;
@@ -141,7 +141,7 @@ export class NavigationSearchComponent implements OnInit {
             q: value + '',
             page: 0,
             size: 5,
-            sort: 'DEFINITION_NAME',
+            sort: 'taskName',
             order: 'ASC'
           }).subscribe((page: Page<TaskDefinition>) => {
             this.resultSearch.task = page;
@@ -250,7 +250,7 @@ export class NavigationSearchComponent implements OnInit {
           q: this.q.value,
           page: 0,
           size: 30,
-          sort: 'DEFINITION_NAME',
+          sort: 'name',
           order: OrderParams.ASC,
           itemsSelected: [],
           itemsExpanded: []
@@ -263,7 +263,7 @@ export class NavigationSearchComponent implements OnInit {
           q: this.q.value,
           page: 0,
           size: 30,
-          sort: 'DEFINITION_NAME',
+          sort: 'name',
           order: OrderParams.ASC,
           itemsSelected: []
         };

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -74,7 +74,7 @@ describe('StreamsService', () => {
 
     it('should call the definitions service with the right url [asc sort]', () => {
       this.mockHttp.get.and.returnValue(of(this.jsonData));
-      this.streamsService.getDefinitions({ q: '', page: 0, size: 10, sort: 'DEFINITION', order: 'ASC' });
+      this.streamsService.getDefinitions({ q: '', page: 0, size: 10, sort: 'dslText', order: 'ASC' });
 
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
@@ -84,12 +84,12 @@ describe('StreamsService', () => {
       expect(headerArgs.get('Accept')).toEqual('application/json');
       expect(httpParams.get('page')).toEqual('0');
       expect(httpParams.get('size')).toEqual('10');
-      expect(httpParams.get('sort')).toEqual('DEFINITION,ASC');
+      expect(httpParams.get('sort')).toEqual('dslText,ASC');
     });
 
     it('should call the definitions service with the right url [desc sort]', () => {
       this.mockHttp.get.and.returnValue(of(this.jsonData));
-      this.streamsService.getDefinitions({ q: '', page: 0, size: 10, sort: 'DEFINITION', order: 'DESC' });
+      this.streamsService.getDefinitions({ q: '', page: 0, size: 10, sort: 'dslText', order: 'DESC' });
 
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
@@ -99,12 +99,12 @@ describe('StreamsService', () => {
       expect(headerArgs.get('Accept')).toEqual('application/json');
       expect(httpParams.get('page')).toEqual('0');
       expect(httpParams.get('size')).toEqual('10');
-      expect(httpParams.get('sort')).toEqual('DEFINITION,DESC');
+      expect(httpParams.get('sort')).toEqual('dslText,DESC');
     });
 
     it('should call the definitions service with the right url [search desc sort]', () => {
       this.mockHttp.get.and.returnValue(of(this.jsonData));
-      this.streamsService.getDefinitions({ q: 'foo', page: 0, size: 10, sort: 'DEFINITION', order: 'DESC' });
+      this.streamsService.getDefinitions({ q: 'foo', page: 0, size: 10, sort: 'dslText', order: 'DESC' });
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
       const httpParams = this.mockHttp.get.calls.mostRecent().args[1].params;
@@ -114,7 +114,7 @@ describe('StreamsService', () => {
       expect(httpParams.get('page')).toEqual('0');
       expect(httpParams.get('size')).toEqual('10');
       expect(httpParams.get('search')).toEqual('foo');
-      expect(httpParams.get('sort')).toEqual('DEFINITION,DESC');
+      expect(httpParams.get('sort')).toEqual('dslText,DESC');
     });
 
   });

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -38,7 +38,7 @@ export class StreamsService {
     q: '',
     page: 0,
     size: 30,
-    sort: 'DEFINITION_NAME',
+    sort: 'name',
     order: OrderParams.ASC,
     itemsSelected: [],
     itemsExpanded: []

--- a/ui/src/app/streams/streams/streams.component.html
+++ b/ui/src/app/streams/streams/streams.component.html
@@ -29,7 +29,7 @@
                                [items]="form.checkboxes"></app-master-checkbox>
         </th>
         <th style="width: 70px">
-          <app-sort id="sort-name" (change)="applySort($event)" [value]="'DEFINITION_NAME'" [sort]="params">
+          <app-sort id="sort-name" (change)="applySort($event)" [value]="'name'" [sort]="params">
             Name
           </app-sort>
         <th>
@@ -45,7 +45,7 @@
                 <li><a style="cursor: pointer" (click)="collapsePage()">Collapse All</a></li>
               </ul>
             </div>
-            <app-sort id="sort-dsl" (change)="applySort($event)" [value]="'DEFINITION'" [sort]="params">
+            <app-sort id="sort-dsl" (change)="applySort($event)" [value]="'dslText'" [sort]="params">
               Definitions
             </app-sort>
           </div>

--- a/ui/src/app/streams/streams/streams.component.spec.ts
+++ b/ui/src/app/streams/streams/streams.component.spec.ts
@@ -333,11 +333,11 @@ describe('StreamsComponent', () => {
       const sortName: HTMLElement = fixture.debugElement.query(By.css('#sort-name a')).nativeElement;
       const sortDsl: HTMLElement = fixture.debugElement.query(By.css('#sort-dsl a')).nativeElement;
       [
-        { click: sortName, nameDesc: true, sort: 'DEFINITION_NAME', order: 'DESC' },
-        { click: sortDsl, dslAsc: true, sort: 'DEFINITION', order: 'ASC' },
-        { click: sortDsl, dslDesc: true, sort: 'DEFINITION', order: 'DESC' },
-        { click: sortName, nameAsc: true, sort: 'DEFINITION_NAME', order: 'ASC' },
-        { click: sortDsl, dslAsc: true, sort: 'DEFINITION', order: 'ASC' }
+        { click: sortName, nameDesc: true, sort: 'name', order: 'DESC' },
+        { click: sortDsl, dslAsc: true, sort: 'dslText', order: 'ASC' },
+        { click: sortDsl, dslDesc: true, sort: 'dslText', order: 'DESC' },
+        { click: sortName, nameAsc: true, sort: 'name', order: 'ASC' },
+        { click: sortDsl, dslAsc: true, sort: 'dslText', order: 'ASC' }
       ].forEach((test) => {
         test.click.click();
         fixture.detectChanges();

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -15,13 +15,13 @@
                                [items]="form.checkboxes"></app-master-checkbox>
         </th>
         <th style="width: 70px">
-          <app-sort id="sort-name" (change)="applySort($event)" [value]="'DEFINITION_NAME'" [sort]="params">
+          <app-sort id="sort-name" (change)="applySort($event)" [value]="'taskName'" [sort]="params">
             Name
           </app-sort>
         </th>
         <th>
           <div class="head-dsl">
-            <app-sort id="sort-dsl" (change)="applySort($event)" [value]="'DEFINITION'" [sort]="params">
+            <app-sort id="sort-dsl" (change)="applySort($event)" [value]="'dslText'" [sort]="params">
               Definitions
             </app-sort>
           </div>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
@@ -298,11 +298,11 @@ describe('TaskDefinitionsComponent', () => {
       const sortName: HTMLElement = fixture.debugElement.query(By.css('#sort-name a')).nativeElement;
       const sortDsl: HTMLElement = fixture.debugElement.query(By.css('#sort-dsl a')).nativeElement;
       [
-        { click: sortName, nameDesc: true, sort: 'DEFINITION_NAME', order: 'DESC' },
-        { click: sortDsl, dslAsc: true, sort: 'DEFINITION', order: 'ASC' },
-        { click: sortDsl, dslDesc: true, sort: 'DEFINITION', order: 'DESC' },
-        { click: sortName, nameAsc: true, sort: 'DEFINITION_NAME', order: 'ASC' },
-        { click: sortDsl, dslAsc: true, sort: 'DEFINITION', order: 'ASC' }
+        { click: sortName, nameDesc: true, sort: 'taskName', order: 'DESC' },
+        { click: sortDsl, dslAsc: true, sort: 'dslText', order: 'ASC' },
+        { click: sortDsl, dslDesc: true, sort: 'dslText', order: 'DESC' },
+        { click: sortName, nameAsc: true, sort: 'taskName', order: 'ASC' },
+        { click: sortDsl, dslAsc: true, sort: 'dslText', order: 'ASC' }
       ].forEach((test) => {
         test.click.click();
         fixture.detectChanges();

--- a/ui/src/app/tasks/tasks.service.ts
+++ b/ui/src/app/tasks/tasks.service.ts
@@ -45,7 +45,7 @@ export class TasksService {
     q: '',
     page: 0,
     size: 30,
-    sort: 'DEFINITION_NAME',
+    sort: 'taskName',
     order: OrderParams.ASC,
     itemsSelected: []
   };

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -1192,7 +1192,7 @@ export const TASK_DEFINITIONS = {
   },
   _links: {
     self: {
-      href: 'http://localhost:4200/tasks/definitions?page=0&size=20&sort=DEFINITION_NAME,asc'
+      href: 'http://localhost:4200/tasks/definitions?page=0&size=20&sort=taskName,asc'
     }
   },
   page: {

--- a/ui/src/app/tests/mocks/streams.ts
+++ b/ui/src/app/tests/mocks/streams.ts
@@ -29,7 +29,7 @@ export class MockStreamsService {
     q: '',
     page: 0,
     size: 30,
-    sort: 'DEFINITION_NAME',
+    sort: 'name',
     order: OrderParams.ASC,
     itemsSelected: [],
     itemsExpanded: []

--- a/ui/src/app/tests/mocks/tasks.ts
+++ b/ui/src/app/tests/mocks/tasks.ts
@@ -33,7 +33,7 @@ export class MockTasksService {
     q: '',
     page: 0,
     size: 20,
-    sort: 'DEFINITION_NAME',
+    sort: 'taskName',
     order: OrderParams.ASC,
     itemsSelected: [],
     itemsExpanded: []


### PR DESCRIPTION
 - Given the JPA configuration changes in the SCDF core 2.x, we need to use the corresponding names for the sorting.
  - Update both the stream/task defintiions pageable query sort params

Resolves #1000