### PR TITLE
gh-1004 Fix: Can't access `Add applications` dialog without CREATE role

### DIFF
--- a/ui/src/app/about/about.service.spec.ts
+++ b/ui/src/app/about/about.service.spec.ts
@@ -47,8 +47,6 @@ describe('AboutService', () => {
       'securityInfo':
       {
           'authenticationEnabled': false,
-          'authorizationEnabled': false,
-          'formLogin': false,
           'authenticated': false,
           'username': null,
           'roles':

--- a/ui/src/app/about/components/about-more/about-details.component.html
+++ b/ui/src/app/about/components/about-more/about-details.component.html
@@ -67,24 +67,6 @@
           </strong>
         </div>
         <div class="line">
-          <span>Authorization Enabled: </span>
-          <strong *ngIf="dataflowVersionInfo.securityInfo.isAuthorizationEnabled" id="authorizationEnabled">
-            <span class="fa fa-check"></span>
-          </strong>
-          <strong *ngIf="!dataflowVersionInfo.securityInfo.isAuthorizationEnabled" id="authorizationDisabled">
-            <span class="fa fa-close"></span>
-          </strong>
-        </div>
-        <div class="line">
-          <span>Form Login: </span>
-          <strong *ngIf="dataflowVersionInfo.securityInfo.isFormLogin" id="formLoginEnabled">
-            <span class="fa fa-check"></span>
-          </strong>
-          <strong *ngIf="!dataflowVersionInfo.securityInfo.isFormLogin" id="formLoginDisabled">
-            <span class="fa fa-close"></span>
-          </strong>
-        </div>
-        <div class="line">
           <span>Authenticated: </span>
           <strong *ngIf="dataflowVersionInfo.securityInfo.isAuthenticated" id="authenticateEnabled">
             <span class="fa fa-check"></span>
@@ -255,7 +237,7 @@
             <strong>{{ dataflowVersionInfo.runtimeEnvironment.taskLauncher.springBootVersion }}</strong>
           </div>
           <div class="line">
-            <span>Spring Versionv</span>
+            <span>Spring Version: </span>
             <strong>{{ dataflowVersionInfo.runtimeEnvironment.taskLauncher.springVersion }}</strong>
           </div>
         </div>

--- a/ui/src/app/about/components/about-more/about-details.component.spec.ts
+++ b/ui/src/app/about/components/about-more/about-details.component.spec.ts
@@ -74,9 +74,8 @@ describe('AboutDetailsComponent', () => {
     validateSpansExists(['analyticsEnabled', 'streamsEnabled', 'tasksEnabled', 'schedulerEnabled']);
 
     // Verify Security Information
-    validateColumnValues('securityInformationTable', ['Authentication', 'Authorization',
-      'Form Login', 'Authenticated', 'Username', 'Roles'], 0);
-    validateSpansExists(['authenticationEnabled', 'authorizationEnabled', 'formLoginEnabled', 'authenticateEnabled']);
+    validateColumnValues('securityInformationTable', ['Authentication', 'Authenticated', 'Username', 'Roles'], 0);
+    validateSpansExists(['authenticationEnabled', 'authenticateEnabled']);
     validateTdValue('username', 'joe');
     validateTdValue('roles', 'base_role');
 
@@ -121,9 +120,8 @@ describe('AboutDetailsComponent', () => {
     validateSpansExists(['analyticsDisabled', 'streamsDisabled', 'tasksDisabled', 'schedulerDisabled']);
 
     // Verify Security Information
-    validateColumnValues('securityInformationTable', ['Authentication', 'Authorization',
-      'Form Login', 'Authenticated', 'Username', 'Roles'], 0);
-    validateSpansExists(['authenticationDisabled', 'authorizationDisabled', 'formLoginDisabled', 'authenticateDisabled']);
+    validateColumnValues('securityInformationTable', ['Authentication', 'Authenticated', 'Username', 'Roles'], 0);
+    validateSpansExists(['authenticationDisabled', 'authenticateDisabled']);
     validateTdValue('username', 'joe');
     validateTdValue('roles', 'base_role');
   });

--- a/ui/src/app/apps/apps/apps.component.html
+++ b/ui/src/app/apps/apps/apps.component.html
@@ -1,5 +1,4 @@
 <app-page id="applications-list">
-
   <app-page-head>
     <app-page-head-title><strong>Applications</strong></app-page-head-title>
     <app-page-head-actions [dataflowAppRoles]="['ROLE_CREATE']">

--- a/ui/src/app/auth/auth.service.spec.ts
+++ b/ui/src/app/auth/auth.service.spec.ts
@@ -14,8 +14,6 @@ describe('AuthService', () => {
     };
     this.jsonData = {
       'authenticationEnabled': true,
-      'authorizationEnabled': true,
-      'formLogin': true,
       'authenticated': true,
       'username': 'foo',
       'roles':

--- a/ui/src/app/auth/feature-disabled.component.spec.ts
+++ b/ui/src/app/auth/feature-disabled.component.spec.ts
@@ -1,97 +1,29 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NgBusyModule } from 'ng-busy';
-import { FormsModule } from '@angular/forms';
-import { LogoutComponent } from './logout.component';
-import { MockNotificationService } from '../tests/mocks/notification';
-import { MockActivatedRoute } from '../tests/mocks/activated-route';
-import { ActivatedRoute } from '@angular/router';
-import { MockAboutService } from '../tests/mocks/about';
-import { MockAuthService } from '../tests/mocks/auth';
-import { AuthService } from './auth.service';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AboutService } from '../about/about.service';
-import { NotificationService } from '../shared/services/notification.service';
-import { LoggerService } from '../shared/services/logger.service';
-import { of } from 'rxjs';
+import { FeatureDisabledComponent } from './feature-disabled.component';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
-describe('LogoutComponent', () => {
-  let component: LogoutComponent;
-  let fixture: ComponentFixture<LogoutComponent>;
-  const notificationService = new MockNotificationService();
-  let activeRoute: MockActivatedRoute;
-  const authService = new MockAuthService();
-  const aboutService = new MockAboutService();
-  const loggerService = new LoggerService();
+describe('FeatureDisabledComponent', () => {
+  let component: FeatureDisabledComponent;
+  let fixture: ComponentFixture<FeatureDisabledComponent>;
+  let debugElement: DebugElement;
 
   beforeEach( async(() => {
-    activeRoute = new MockActivatedRoute();
     TestBed.configureTestingModule({
-      imports: [
-        NgBusyModule,
-        FormsModule,
-        RouterTestingModule.withRoutes([])
-      ],
-      declarations:   [ LogoutComponent ],
-      providers: [
-        { provide: AboutService, useValue: aboutService },
-        { provide: AuthService, useValue: authService },
-        { provide: NotificationService, useValue: notificationService },
-        { provide: ActivatedRoute, useValue: {
-            params: of({returnUrl: '/apps'})
-          }
-        },
-        { provide: LoggerService, useValue: loggerService }
-      ]
+      declarations:   [ FeatureDisabledComponent ],
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(LogoutComponent);
+    fixture = TestBed.createComponent(FeatureDisabledComponent);
     component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
   });
 
-  it('Logout should call logout on the auth service if authentication is'
-    + ' enabled and the user is authenticated.', () => {
-
-    authService.securityInfo.isAuthenticated = true;
-    authService.securityInfo.username = 'Berlin';
-
-    const navigate = spyOn((<any>component).router, 'navigate');
-    const logout = spyOn(authService as AuthService, 'logout').and.callThrough();
-
+  it('FeatureDisabledComponent should be instantiated.', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
-    expect(authService.securityInfo.isAuthenticated).toBe(false);
-    expect(authService.securityInfo.username).toEqual('');
-    expect(logout).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith(['login']);
-  });
-
-  it('Logout should just redirect to the root of the app as '
-    + 'authentication is not enabled.', () => {
-
-    authService.securityInfo.isAuthenticationEnabled = false;
-
-    const navigate = spyOn((<any>component).router, 'navigate');
-    const logout = spyOn(authService as AuthService, 'logout').and.callThrough();
-
-    fixture.detectChanges();
-
-    expect(navigate).toHaveBeenCalledWith(['']);
-    expect(logout).not.toHaveBeenCalled();
-  });
-
-  it('Logout should just redirect to the root of the app as '
-    + 'the user is not authenticated.', () => {
-
-    authService.securityInfo.isAuthenticated = false;
-    const navigate = spyOn((<any>component).router, 'navigate');
-    const logout = spyOn(authService as AuthService, 'logout').and.callThrough();
-
-    fixture.detectChanges();
-
-    expect(navigate).toHaveBeenCalledWith(['']);
-    expect(logout).not.toHaveBeenCalled();
+    expect(debugElement.query(By.css('h1')).nativeElement.innerText).toBe('Feature Disabled');
   });
 });

--- a/ui/src/app/auth/logout.component.spec.ts
+++ b/ui/src/app/auth/logout.component.spec.ts
@@ -60,12 +60,13 @@ describe('LogoutComponent', () => {
     const navigate = spyOn((<any>component).router, 'navigate');
     const logout = spyOn(authService as AuthService, 'logout').and.callThrough();
 
+    spyOn(window, 'open');
+
     fixture.detectChanges();
     expect(component).toBeTruthy();
     expect(authService.securityInfo.isAuthenticated).toBe(false);
     expect(authService.securityInfo.username).toEqual('');
-    expect(logout).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith(['login']);
+    expect(window.open).toHaveBeenCalledWith('//' + window.location.host + '/logout', '_self');
   });
 
   it('Logout should just redirect to the root of the app as '

--- a/ui/src/app/auth/logout.component.ts
+++ b/ui/src/app/auth/logout.component.ts
@@ -45,29 +45,13 @@ export class LogoutComponent implements OnInit, OnDestroy {
     }
 
     this.loggerService.log('Logging out ...');
-    if (this.authService.securityInfo.isFormLogin) {
-      this.authService.logout()
-      .pipe(takeUntil(this.ngUnsubscribe$))
-      .subscribe(
-        result => {
-          this.aboutService.featureInfo.reset();
-          this.notificationService.success('Logged out.');
-          this.router.navigate(['login']);
-        },
-        error => {
-          this.aboutService.featureInfo.reset();
-          this.notificationService.error(AppError.is(error) ? error.getMessage() : error);
-        },
-      );
-    } else {
-      this.loggerService.log(`Logging out user ${this.authService.securityInfo.username} (OAuth)`);
-      this.authService.clearLocalSecurity();
-      this.aboutService.featureInfo.reset();
+    this.loggerService.log(`Logging out user ${this.authService.securityInfo.username} (OAuth)`);
+    this.authService.clearLocalSecurity();
+    this.aboutService.featureInfo.reset();
 
-      const logoutUrl = '//' + window.location.host + '/logout';
-      this.loggerService.log('Redirecting to ' + logoutUrl);
-      window.open(logoutUrl, '_self');
-    }
+    const logoutUrl = '//' + window.location.host + '/logout';
+    this.loggerService.log('Redirecting to ' + logoutUrl);
+    window.open(logoutUrl, '_self');
   }
 
   /**

--- a/ui/src/app/auth/support/auth.guard.ts
+++ b/ui/src/app/auth/support/auth.guard.ts
@@ -43,8 +43,7 @@ export class AuthGuard implements CanActivate {
 
     if (securityInfo.isAuthenticationEnabled) {
       this.loggerService.log(`Determining authorizations ... ` +
-        `[authentication enabled: ${securityInfo.isAuthenticationEnabled}, ` +
-        `authorization enabled: ${securityInfo.isAuthorizationEnabled}]`, route.data);
+        `[authentication enabled: ${securityInfo.isAuthenticationEnabled}]`, route.data);
     }
 
     if (securityInfo.canAccess(rolesNeeded)) {
@@ -52,7 +51,7 @@ export class AuthGuard implements CanActivate {
     }
 
     if (securityInfo.isAuthenticationEnabled) {
-      if (securityInfo.isAuthorizationEnabled && securityInfo.isAuthenticated) {
+      if (securityInfo.isAuthenticated) {
         this.loggerService.log('You do not have any of the necessary role(s) ' + rolesNeeded);
         this.router.navigate(['roles-missing']);
       } else {

--- a/ui/src/app/shared/model/about/about-info.model.spec.ts
+++ b/ui/src/app/shared/model/about/about-info.model.spec.ts
@@ -31,8 +31,6 @@ describe('AboutInfo', () => {
           },
           "securityInfo": {
             "authenticationEnabled": false,
-            "authorizationEnabled": false,
-            "formLogin": false,
             "authenticated": false,
             "username": null,
             "roles": []

--- a/ui/src/app/shared/model/about/security-info.model.spec.ts
+++ b/ui/src/app/shared/model/about/security-info.model.spec.ts
@@ -67,13 +67,12 @@ describe('SecurityInfo', () => {
       securityInfo.roles = [];
       expect(securityInfo.canAccess(['VIEW'])).toBe(true);
     });
-    it('no roles but authnticated user should have access with the VIEW role as authorization is disabled', () => {
+    it('no roles and authenticated user should not have access with the VIEW role', () => {
       const securityInfo = new SecurityInfo();
       securityInfo.isAuthenticated = true;
       securityInfo.isAuthenticationEnabled = true;
-      securityInfo.isAuthorizationEnabled = false;
       securityInfo.roles = [];
-      expect(securityInfo.canAccess(['VIEW'])).toBe(true);
+      expect(securityInfo.canAccess(['VIEW'])).toBe(false);
     });
   });
 
@@ -83,8 +82,6 @@ describe('SecurityInfo', () => {
       const securityInfo = new SecurityInfo();
       securityInfo.isAuthenticated = true;
       securityInfo.isAuthenticationEnabled = false;
-      securityInfo.isAuthorizationEnabled = false;
-      securityInfo.isFormLogin = true;
       securityInfo.username = 'Kamehameha';
       securityInfo.roles = ['VIEW', 'EDIT', 'MANAGE'];
 
@@ -92,8 +89,6 @@ describe('SecurityInfo', () => {
 
       expect(securityInfo.isAuthenticated).toBe(false);
       expect(securityInfo.isAuthenticationEnabled).toBe(true);
-      expect(securityInfo.isAuthorizationEnabled).toBe(true);
-      expect(securityInfo.isFormLogin).toBe(true);
       expect(securityInfo.username).toBe('');
       expect(securityInfo.roles.length).toBe(0);
     });
@@ -104,8 +99,6 @@ describe('SecurityInfo', () => {
       const json = {
         authenticated: true,
         authenticationEnabled: true,
-        authorizationEnabled: true,
-        formLogin: true,
         username: 'Kamehameha',
         roles: ['R1', 'R2']
       };
@@ -113,8 +106,6 @@ describe('SecurityInfo', () => {
       const securityInfo = new SecurityInfo().deserialize(json);
       expect(securityInfo.isAuthenticated).toBe(true);
       expect(securityInfo.isAuthenticationEnabled).toBe(true);
-      expect(securityInfo.isAuthorizationEnabled).toBe(true);
-      expect(securityInfo.isFormLogin).toBe(true);
       expect(securityInfo.username).toBe('Kamehameha');
       expect(securityInfo.roles.length).toBe(2);
       expect(securityInfo.roles).toEqual(['R1', 'R2']);

--- a/ui/src/app/shared/model/about/security-info.model.ts
+++ b/ui/src/app/shared/model/about/security-info.model.ts
@@ -7,8 +7,6 @@ import { Serializable } from '../serialization/serializable.model';
 export class SecurityInfo implements Serializable<SecurityInfo> {
 
   public isAuthenticationEnabled = true;
-  public isAuthorizationEnabled = true;
-  public isFormLogin = true;
   public isAuthenticated = false;
   public username = '';
   public roles: string[] = [];
@@ -18,8 +16,6 @@ export class SecurityInfo implements Serializable<SecurityInfo> {
    */
   public reset() {
     this.isAuthenticationEnabled = true;
-    this.isAuthorizationEnabled = true;
-    this.isFormLogin = true;
     this.isAuthenticated = false;
     this.username = '';
     this.roles = [];
@@ -27,8 +23,6 @@ export class SecurityInfo implements Serializable<SecurityInfo> {
 
   public deserialize(input) {
     this.isAuthenticationEnabled = input.authenticationEnabled,
-    this.isAuthorizationEnabled = input.authorizationEnabled,
-    this.isFormLogin = input.formLogin,
     this.isAuthenticated = input.authenticated,
     this.username = input.username,
     this.roles = input.roles as string[];
@@ -66,13 +60,9 @@ export class SecurityInfo implements Serializable<SecurityInfo> {
       found = true;
     } else {
       if (this.isAuthenticated) {
-        if (this.isAuthorizationEnabled) {
           if (this.hasAnyRoleOf(appRoles)) {
             found = true;
           }
-        } else {
-          found = true;
-        }
       } else {
         found = false;
       }

--- a/ui/src/app/tests/mocks/about.ts
+++ b/ui/src/app/tests/mocks/about.ts
@@ -95,8 +95,6 @@ export class MockAboutService {
   private getSecurityInfo() {
     const securityInfo = new SecurityInfo();
     securityInfo.isAuthenticationEnabled = true;
-    securityInfo.isAuthorizationEnabled = true;
-    securityInfo.isFormLogin = true;
     securityInfo.isAuthenticated = true;
     securityInfo.roles = ['base_role'];
     securityInfo.username = 'joe';
@@ -173,8 +171,6 @@ export class MockAboutService {
       dataFlowVersion = this.getDataflowVersionInfo();
       if (!this._isFeatureEnabled) {
         dataFlowVersion.securityInfo.isAuthenticationEnabled = false;
-        dataFlowVersion.securityInfo.isAuthorizationEnabled = false;
-        dataFlowVersion.securityInfo.isFormLogin = false;
         dataFlowVersion.securityInfo.isAuthenticated = false;
         dataFlowVersion.featureInfo.analyticsEnabled = false;
         dataFlowVersion.featureInfo.streamsEnabled = false;

--- a/ui/src/app/tests/mocks/auth.ts
+++ b/ui/src/app/tests/mocks/auth.ts
@@ -15,17 +15,18 @@ export class MockAuthService {
   login(loginRequest: LoginRequest): Observable<SecurityInfo> {
 
     this.securityInfo.isAuthenticationEnabled = true;
-    this.securityInfo.isAuthorizationEnabled = true;
-    this.securityInfo.isFormLogin = true;
     this.securityInfo.isAuthenticated = true;
     this.securityInfo.username = 'Pele';
     this.securityInfo.roles = ['ROLE_VIEW', 'ROLE_CREATE', 'ROLE_MANAGE'];
-
     return of(this.securityInfo);
   }
 
   logout(): Observable<SecurityInfo> {
     this.securityInfo.reset();
     return of(this.securityInfo);
+  }
+
+  public clearLocalSecurity() {
+    this.securityInfo.reset();
   }
 }


### PR DESCRIPTION
- remove occurrences of `securityInfo` properties `isAuthorizationEnabled` and `isFormLogin`
- fix tests
- fix + refactor `feature-disabled` component spec
- fix small spelling issue on `About` details page
- remove `AuthorizationEnabled` and `FormLogin` references from `About` details page

resolves https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/1004