### PR TITLE
Adjust client side parser for unbound app handling

### DIFF
--- a/ui/src/app/shared/services/parser.spec.ts
+++ b/ui/src/app/shared/services/parser.spec.ts
@@ -102,7 +102,7 @@ describe('parser:', () => {
     });
 
     it('long running apps', () => {
-      parseResult = Parser.parse('aaa, bbb', 'stream');
+      parseResult = Parser.parse('aaa|| bbb', 'stream');
       expect(parseResult.lines.length).toEqual(1);
       line = parseResult.lines[0];
       nodes = parseResult.lines[0].nodes;
@@ -116,7 +116,7 @@ describe('parser:', () => {
       expect(node.group).toEqual('UNKNOWN_0');
       expect(node.type).toEqual('app');
       expect(node.name).toEqual('bbb');
-      expectRange(node.range, 5, 0, 8, 0);
+      expectRange(node.range, 6, 0, 9, 0);
     });
 
     it('from source and processor to named destination', () => {
@@ -215,21 +215,21 @@ describe('parser:', () => {
     });
 
     it('list of apps - error checking', () => {
-        parseResult = Parser.parse(':aaa > fff,bbb', 'stream');
+        parseResult = Parser.parse(':aaa > fff||bbb', 'stream');
         error = parseResult.lines[0].errors[0];
-        expect(error.message).toEqual('Don\'t use comma with channels');
+        expect(error.message).toEqual('Don\'t use || with channels');
         expectRange(error.range, 10, 0, 11, 0);
-        parseResult = Parser.parse('aaa,bbb > :zzz', 'stream');
+        parseResult = Parser.parse('aaa||bbb > :zzz', 'stream');
         error = parseResult.lines[0].errors[0];
-        expect(error.message).toEqual('Don\'t use comma with channels');
+        expect(error.message).toEqual('Don\'t use || with channels');
         expectRange(error.range, 3, 0, 4, 0);
-        parseResult = Parser.parse('aaa | bbb, ccc', 'stream');
+        parseResult = Parser.parse('aaa | bbb || ccc', 'stream');
         error = parseResult.lines[0].errors[0];
-        expect(error.message).toEqual('Don\'t mix pipe and comma');
+        expect(error.message).toEqual('Don\'t mix | and || in the same stream definition');
         expectRange(error.range, 4, 0, 5, 0);
-        parseResult = Parser.parse('aaa, bbb| ccc', 'stream');
+        parseResult = Parser.parse('aaa|| bbb| ccc', 'stream');
         error = parseResult.lines[0].errors[0];
-        expect(error.message).toEqual('Don\'t mix pipe and comma');
+        expect(error.message).toEqual('Don\'t mix | and || in the same stream definition');
         expectRange(error.range, 3, 0, 4, 0);
 
         parseResult = Parser.parse('aaa | filter --expression=\'#jsonPath(payload,\'\'$.lang\'\')==\'\'en\'\'\'', 'stream');
@@ -237,15 +237,15 @@ describe('parser:', () => {
         expect(parseResult.lines[0].nodes[1].options.get('expression')).
             toEqual('\'#jsonPath(payload,\'\'$.lang\'\')==\'\'en\'\'\'');
 
-        parseResult = Parser.parse('aaa --bbb=ccc,', 'stream');
+        parseResult = Parser.parse('aaa --bbb=ccc||', 'stream');
         error = parseResult.lines[0].errors[0];
         expect(error.message).toEqual('Out of data');
-        expectRange(error.range, 14, 0, 15, 0);
+        expectRange(error.range, 15, 0, 16, 0);
 
-        parseResult = Parser.parse('aaa --bbb=\'ccc\',', 'stream');
+        parseResult = Parser.parse('aaa --bbb=\'ccc\'||', 'stream');
         error = parseResult.lines[0].errors[0];
         expect(error.message).toEqual('Out of data');
-        expectRange(error.range, 16, 0, 17, 0);
+        expectRange(error.range, 17, 0, 18, 0);
     });
 
     it('error: task with extra data', () => {
@@ -382,12 +382,12 @@ describe('parser:', () => {
     });
 
     it('error: label required unmanaged stream app', () => {
-        parseResult = Parser.parse('bbb, bbb', 'stream');
+        parseResult = Parser.parse('bbb|| bbb', 'stream');
         expect(parseResult.lines.length).toEqual(1);
         error = parseResult.lines[0].errors[0];
         expect(error.message)
           .toEqual('App \'bbb\' should be unique within the definition, use a label to differentiate multiple occurrences');
-        expectRange(error.range, 5, 0, 8, 0);
+        expectRange(error.range, 6, 0, 9, 0);
     });
 
     it('error: rogue option name', () => {
@@ -502,7 +502,7 @@ describe('parser:', () => {
     });
 
     it('check label unmanaged stream apps', () => {
-        parseResult = Parser.parse('aaa, bbb: aaa', 'stream');
+        parseResult = Parser.parse('aaa|| bbb: aaa', 'stream');
         expect((<Parser.StreamApp>parseResult.lines[0].nodes[0]).label).toBeUndefined();
         expect((<Parser.StreamApp>parseResult.lines[0].nodes[1]).label).toEqual('bbb');
         expect(parseResult.lines[0].nodes[0].name).toEqual('aaa');

--- a/ui/src/app/shared/services/parser.ts
+++ b/ui/src/app/shared/services/parser.ts
@@ -372,17 +372,17 @@ class InternalParser {
             const t = this.peekAtToken();
             if (this.isKind(t, TokenKind.PIPE)) {
                 if (usedListDelimiter >= 0) {
-                    throw {'msg': 'Don\'t mix pipe and comma', 'start': usedListDelimiter};
+                    throw {'msg': 'Don\'t mix | and || in the same stream definition', 'start': usedListDelimiter};
                 }
                 usedStreamDelimiter = t.start;
                 this.nextToken();
                 appNodes.push(this.eatApp());
-            } else if (this.isKind(t, TokenKind.COMMA)) {
+            } else if (this.isKind(t, TokenKind.DOUBLE_PIPE)) {
                 if (preceedingSourceChannelSpecified) {
-                    throw {'msg': 'Don\'t use comma with channels', 'start': t.start};
+                    throw {'msg': 'Don\'t use || with channels', 'start': t.start};
                 }
                 if (usedStreamDelimiter >= 0) {
-                    throw {'msg': 'Don\'t mix pipe and comma', 'start': usedStreamDelimiter};
+                    throw {'msg': 'Don\'t mix | and || in the same stream definition', 'start': usedStreamDelimiter};
                 }
                 usedListDelimiter = t.start;
                 this.nextToken();
@@ -394,7 +394,7 @@ class InternalParser {
         }
         const isFollowedBySinkChannel = this.peekToken(TokenKind.GT);
         if (isFollowedBySinkChannel && usedListDelimiter >= 0) {
-            throw {'msg': 'Don\'t use comma with channels', 'start': usedListDelimiter};
+            throw {'msg': 'Don\'t use || with channels', 'start': usedListDelimiter};
         }
         for (let appNumber = 0; appNumber < appNodes.length; appNumber++) {
             appNodes[appNumber].nonStreamApp = !preceedingSourceChannelSpecified && !isFollowedBySinkChannel && (usedStreamDelimiter < 0);

--- a/ui/src/app/shared/services/tokenizer.spec.ts
+++ b/ui/src/app/shared/services/tokenizer.spec.ts
@@ -28,6 +28,14 @@ describe('tokenizer:', () => {
     expectToken(tokens[2], TokenKind.SEMICOLON, 8, 9);
   });
 
+  it('double pipes', () => {
+    tokens = tokenize('abc || def');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.IDENTIFIER, 0, 3, 'abc');
+    expectToken(tokens[1], TokenKind.DOUBLE_PIPE, 4, 6);
+    expectToken(tokens[2], TokenKind.IDENTIFIER, 7, 10, 'def');
+  });
+
   it('single quoted literal', () => {
     tokens = tokenize('\'abc def\'');
     expect(tokens.length).toEqual(1);

--- a/ui/src/app/shared/services/tokenizer.ts
+++ b/ui/src/app/shared/services/tokenizer.ts
@@ -20,6 +20,7 @@ export enum TokenKind {
     EQUALS = '=',
     AND = '&',
     PIPE = '|',
+    DOUBLE_PIPE = '||',
     NEWLINE = '<NEWLINE>',
     COLON = ':',
     GT = '>',
@@ -98,7 +99,7 @@ class Tokenizer {
 
     private isArgValueIdentifierTerminator(ch: string, quoteOpen: boolean): boolean {
         return (ch === '|' && !quoteOpen) || (ch === ';' && !quoteOpen) || ch === '\0' || (ch === ' ' && !quoteOpen) ||
-            (ch === '\t' && !quoteOpen) || (ch === '>' && !quoteOpen) || (ch === ',' && !quoteOpen) ||
+            (ch === '\t' && !quoteOpen) || (ch === '>' && !quoteOpen) ||
             ch === '\r' || ch === '\n';
     }
 
@@ -281,7 +282,11 @@ class Tokenizer {
                     this.pushCharToken(TokenKind.AND);
                     break;
                 case '|':
-                    this.pushCharToken(TokenKind.PIPE);
+                    if (this.isTwoCharToken(TokenKind.DOUBLE_PIPE)) {
+                        this.pushPairToken(TokenKind.DOUBLE_PIPE);
+                    } else {
+                        this.pushCharToken(TokenKind.PIPE);
+                    }
                     break;
                 case ' ':
                 case '\t':

--- a/ui/src/app/streams/components/flo/graph-to-text.spec.ts
+++ b/ui/src/app/streams/components/flo/graph-to-text.spec.ts
@@ -104,7 +104,7 @@ describe('graph-to-text', () => {
         const appA = createApp('appA');
         const appB = createApp('appB');
         dsl = convertGraphToText(graph);
-        expect(dsl).toEqual('appA, appB');
+        expect(dsl).toEqual('appA || appB');
     });
 
     it('non stream apps with properties', () => {
@@ -112,7 +112,7 @@ describe('graph-to-text', () => {
         setProperties(appA, new Map([['aaa', 'bbb']]));
         const appB = createApp('appB');
         dsl = convertGraphToText(graph);
-        expect(dsl).toEqual('appA --aaa=bbb, appB');
+        expect(dsl).toEqual('appA --aaa=bbb || appB');
     });
 
     it('non stream apps with properties 2', () => {
@@ -123,7 +123,7 @@ describe('graph-to-text', () => {
         setProperties(appC, new Map([['ccc', 'ddd']]));
         setProperties(appC, new Map([['eee', 'fff']]));
         dsl = convertGraphToText(graph);
-        expect(dsl).toEqual('appA --aaa=bbb, appB, appC --ccc=ddd --eee=fff');
+        expect(dsl).toEqual('appA --aaa=bbb || appB || appC --ccc=ddd --eee=fff');
     });
 
     it('mix apps/streams on graph', () => {
@@ -142,7 +142,7 @@ describe('graph-to-text', () => {
       const appB = createApp('appB');
       appA.attr('stream-name', 'stream-1');
       dsl = convertGraphToText(graph);
-      expect(dsl).toEqual('stream-1=appA, appB');
+      expect(dsl).toEqual('stream-1=appA || appB');
     });
 
     it('non stream apps stream-name on second node', () => {
@@ -150,7 +150,7 @@ describe('graph-to-text', () => {
       const appB = createApp('appB');
       appB.attr('stream-name', 'stream-1');
       dsl = convertGraphToText(graph);
-      expect(dsl).toEqual('stream-1=appB, appA');
+      expect(dsl).toEqual('stream-1=appB || appA');
     });
 
     it('basic - multiple properties', () => {

--- a/ui/src/app/streams/components/flo/graph-to-text.ts
+++ b/ui/src/app/streams/components/flo/graph-to-text.ts
@@ -242,7 +242,7 @@ class GraphToTextConverter {
                         text += ' > ';
                     } else {
                         if (node.attr('metadata/group') === 'app') {
-                            text += ', ';
+                            text += ' || ';
                         } else {
                             text += ' | ';
                         }

--- a/ui/src/app/streams/components/flo/text-to-graph.spec.ts
+++ b/ui/src/app/streams/components/flo/text-to-graph.spec.ts
@@ -64,9 +64,20 @@ describe('text-to-graph', () => {
     });
 
     it('jsongraph: two separate apps should be unconnected', () => {
-        graph = getGraph('aaa, bbb');
+        graph = getGraph('aaa|| bbb');
         expect(graph.streamdefs.length).toEqual(1);
-        expect(graph.streamdefs[0].def).toEqual('aaa, bbb');
+        expect(graph.streamdefs[0].def).toEqual('aaa || bbb');
+        expect(graph.nodes[0].name).toEqual('aaa');
+        expect(graph.nodes[0].group).toEqual('app');
+        expect(graph.nodes[1].name).toEqual('bbb');
+        expect(graph.nodes[1].group).toEqual('app');
+        expect(graph.links.length).toEqual(0);
+    });
+
+    it('jsongraph: two separate apps should be unconnected: 2', () => {
+        graph = getGraph('aaa || bbb');
+        expect(graph.streamdefs.length).toEqual(1);
+        expect(graph.streamdefs[0].def).toEqual('aaa || bbb');
         expect(graph.nodes[0].name).toEqual('aaa');
         expect(graph.nodes[0].group).toEqual('app');
         expect(graph.nodes[1].name).toEqual('bbb');

--- a/ui/src/app/streams/components/flo/text-to-graph.ts
+++ b/ui/src/app/streams/components/flo/text-to-graph.ts
@@ -171,7 +171,7 @@ class TextToGraphConverter {
                             if (parsedNode.type !== 'app') {
                                 streamdef = streamdef + '| ';
                             } else {
-                                streamdef = streamdef + ', ';
+                                streamdef = streamdef + ' || ';
                             }
                         }
                         graphNode = {


### PR DESCRIPTION
This change adjusts the client side syntax to '||' from
',' for unbound apps so that it matches the server side.
It has adjusted the tokenizer, the parser as well as the
text-to-graph and graph-to-text code. Tests have been updated
to recognize the new syntax and messages.

Fixes #1005