### PR TITLE
Bring stream parser client side in line with server side

### DIFF
--- a/ui/src/app/shared/services/parser.spec.ts
+++ b/ui/src/app/shared/services/parser.spec.ts
@@ -390,6 +390,32 @@ describe('parser:', () => {
         expectRange(error.range, 6, 0, 9, 0);
     });
 
+    it('error: special chars at start of argument values', () => {
+        parseResult = Parser.parse('aaa --bbb= --ccc=ddd', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('expected argument value');
+        expectRange(error.range, 11, 0, 12, 0);
+
+        parseResult = Parser.parse('aaa --bbb=| --ccc=ddd', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('expected argument value');
+        expectRange(error.range, 10, 0, 11, 0);
+
+        parseResult = Parser.parse('aaa --bbb=; --ccc=ddd', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('expected argument value');
+        expectRange(error.range, 10, 0, 11, 0);
+
+        parseResult = Parser.parse('aaa --bbb=> --ccc=ddd', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('expected argument value');
+        expectRange(error.range, 10, 0, 11, 0);
+    });
+
     it('error: rogue option name', () => {
         parseResult = Parser.parse('aaa --|=99 ', 'stream');
         error = parseResult.lines[0].errors[0];

--- a/ui/src/app/shared/services/tokenizer.ts
+++ b/ui/src/app/shared/services/tokenizer.ts
@@ -258,6 +258,10 @@ class Tokenizer {
                     // consuming everything up to the next special char.
                     // This allows SpEL expressions to be used without quoting in many
                     // situations
+                    // If the next char is a special char then the argument value is missing
+                    if (this.isArgValueIdentifierTerminator(ch, false)) {
+                        throw {'msg': 'expected argument value', 'start': this.pos};
+                    }
                     this.lexArgValueIdentifier();
                 }
                 this.justProcessedEquals = false;


### PR DESCRIPTION
Per issue 2499 the server side handling of special chars in
argument values changes. This is the client side change that
brings the client side parser in line with that.

Resolves #2499