### PR TITLE
Remove the rate metrics related logic

### DIFF
--- a/ui/proxy.conf.json
+++ b/ui/proxy.conf.json
@@ -59,7 +59,7 @@
         "secure": false,
         "logLevel": "debug"
     },
-    "/runtime/apps" : {
+    "/runtime" : {
         "target": "http://localhost:9393/",
         "secure": false,
         "logLevel": "debug"

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.html
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.html
@@ -11,13 +11,9 @@
       <td nowrap class="text-left tooltip-property-key"><strong>Guid</strong></td>
       <td class="text-left tooltip-property-value">{{ guid }}</td>
     </tr>
-    <tr *ngIf="!isSource">
-      <td nowrap class="text-left tooltip-property-key"><strong>Incoming</strong></td>
-      <td class="text-left tooltip-property-value">{{ inputMean }}</td>
-    </tr>
-    <tr *ngIf="!isSink">
-      <td nowrap class="text-left tooltip-property-key"><strong>Outgoing</strong></td>
-      <td class="text-left tooltip-property-value">{{ outputMean }}</td>
+    <tr>
+      <td nowrap class="text-left tooltip-property-key"><strong>State</strong></td>
+      <td class="text-left tooltip-property-value">{{ state }}</td>
     </tr>
     </tbody>
   </table>

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.html
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.html
@@ -1,4 +1,4 @@
-<svg:g class="rotatable" [tooltip]="dotTooltip" placement="bottom" container="body" [ngClass]="{deployed: instance}">
+<svg:g class="rotatable" [tooltip]="dotTooltip" placement="bottom" container="body" [ngClass]="{deployed: state == 'deployed', failed: state == 'failed'}">
   <svg:g class="scalable">
     <svg:circle class="instance-dot"/>
   </svg:g>

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.scss
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.scss
@@ -9,6 +9,10 @@
     stroke: $spring-green;
     fill: $flo-shape-fill-color;
   }
+  .failed {
+    stroke: red;
+    fill: $flo-shape-fill-color;
+  }
   stroke: 'gray';
   fill: 'transparent';
   cursor: initial;

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.spec.ts
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.spec.ts
@@ -1,6 +1,6 @@
 import { InstanceDotComponent } from './instance-dot.component';
 import '../support/shapes';
-import { InstanceMetrics, TYPE} from '../../../model/stream-metrics';
+import { InstanceStatus, TYPE} from '../../../model/stream-metrics';
 
 import * as _joint from 'jointjs';
 const joint: any = _joint;
@@ -20,8 +20,6 @@ describe('InstanceDotComponent', () => {
   it('no input', () => {
     expect(component).toBeTruthy();
     expect(component.instance).toBeUndefined();
-    expect(component.isSource).toBeFalsy();
-    expect(component.isSink).toBeFalsy();
     expect(component.guid).toEqual('');
     expect(component.state).toEqual('');
   });
@@ -29,7 +27,7 @@ describe('InstanceDotComponent', () => {
   it('source input', () => {
     const properties = {};
     properties[TYPE] = 'source';
-    component.view = createView(InstanceMetrics.fromJSON({
+    component.view = createView(InstanceStatus.fromJSON({
       guid: 'my-guid',
       index: 0,
       properties: properties,
@@ -37,8 +35,6 @@ describe('InstanceDotComponent', () => {
     }));
 
     expect(component.instance).toBeDefined();
-    expect(component.isSource).toBeTruthy();
-    expect(component.isSink).toBeFalsy();
     expect(component.guid).toEqual('my-guid');
     expect(component.state).toEqual('deployed');
   });
@@ -46,7 +42,7 @@ describe('InstanceDotComponent', () => {
   it('sink input', () => {
     const properties = {};
     properties[TYPE] = 'sink';
-    component.view = createView(InstanceMetrics.fromJSON({
+    component.view = createView(InstanceStatus.fromJSON({
       guid: 'my-guid',
       index: 0,
       properties: properties,
@@ -54,8 +50,6 @@ describe('InstanceDotComponent', () => {
     }));
 
     expect(component.instance).toBeDefined();
-    expect(component.isSource).toBeFalsy();
-    expect(component.isSink).toBeTruthy();
     expect(component.guid).toEqual('my-guid');
     expect(component.state).toEqual('deployed');
   });
@@ -63,7 +57,7 @@ describe('InstanceDotComponent', () => {
   it('processor input', () => {
     const properties = {};
     properties[TYPE] = 'processor';
-    component.view = createView(InstanceMetrics.fromJSON({
+    component.view = createView(InstanceStatus.fromJSON({
       guid: 'my-guid',
       index: 0,
       properties: properties,
@@ -71,13 +65,11 @@ describe('InstanceDotComponent', () => {
     }));
 
     expect(component.instance).toBeDefined();
-    expect(component.isSource).toBeFalsy();
-    expect(component.isSink).toBeFalsy();
     expect(component.guid).toEqual('my-guid');
     expect(component.state).toEqual('deployed');
   });
 
-  function createView(instance: InstanceMetrics): any {
+  function createView(instance: InstanceStatus): any {
     return {
       model: new joint.shapes.flo.InstanceDot({
         attrs: {

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.spec.ts
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.spec.ts
@@ -1,8 +1,9 @@
 import { InstanceDotComponent } from './instance-dot.component';
 import '../support/shapes';
-import { InstanceStatus, TYPE} from '../../../model/stream-metrics';
+import { InstanceStatus, TYPE } from '../../../model/stream-metrics';
 
 import * as _joint from 'jointjs';
+
 const joint: any = _joint;
 
 /**

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.spec.ts
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.spec.ts
@@ -1,6 +1,6 @@
 import { InstanceDotComponent } from './instance-dot.component';
 import '../support/shapes';
-import { InstanceMetrics, TYPE, INPUT_CHANNEL_MEAN, OUTPUT_CHANNEL_MEAN } from '../../../model/stream-metrics';
+import { InstanceMetrics, TYPE} from '../../../model/stream-metrics';
 
 import * as _joint from 'jointjs';
 const joint: any = _joint;
@@ -23,8 +23,7 @@ describe('InstanceDotComponent', () => {
     expect(component.isSource).toBeFalsy();
     expect(component.isSink).toBeFalsy();
     expect(component.guid).toEqual('');
-    expect(component.inputMean).toBeUndefined();
-    expect(component.outputMean).toBeUndefined();
+    expect(component.state).toEqual('');
   });
 
   it('source input', () => {
@@ -34,18 +33,14 @@ describe('InstanceDotComponent', () => {
       guid: 'my-guid',
       index: 0,
       properties: properties,
-      metrics: [
-        {name: INPUT_CHANNEL_MEAN, value: 5},
-        {name: OUTPUT_CHANNEL_MEAN, value: 3.33433}
-      ]
+      state: 'deployed'
     }));
 
     expect(component.instance).toBeDefined();
     expect(component.isSource).toBeTruthy();
     expect(component.isSink).toBeFalsy();
     expect(component.guid).toEqual('my-guid');
-    expect(component.inputMean).toBeUndefined();
-    expect(component.outputMean).toEqual('3.334');
+    expect(component.state).toEqual('deployed');
   });
 
   it('sink input', () => {
@@ -55,18 +50,14 @@ describe('InstanceDotComponent', () => {
       guid: 'my-guid',
       index: 0,
       properties: properties,
-      metrics: [
-        {name: INPUT_CHANNEL_MEAN, value: 5.6758398},
-        {name: OUTPUT_CHANNEL_MEAN, value: 3.33433211}
-      ]
+      state: 'deployed'
     }));
 
     expect(component.instance).toBeDefined();
     expect(component.isSource).toBeFalsy();
     expect(component.isSink).toBeTruthy();
     expect(component.guid).toEqual('my-guid');
-    expect(component.inputMean).toEqual('5.676');
-    expect(component.outputMean).toBeUndefined();
+    expect(component.state).toEqual('deployed');
   });
 
   it('processor input', () => {
@@ -76,18 +67,14 @@ describe('InstanceDotComponent', () => {
       guid: 'my-guid',
       index: 0,
       properties: properties,
-      metrics: [
-        {name: INPUT_CHANNEL_MEAN, value: 5.6758398},
-        {name: OUTPUT_CHANNEL_MEAN, value: 3.33433211}
-      ]
+      state: 'deployed'
     }));
 
     expect(component.instance).toBeDefined();
     expect(component.isSource).toBeFalsy();
     expect(component.isSink).toBeFalsy();
     expect(component.guid).toEqual('my-guid');
-    expect(component.inputMean).toEqual('5.676');
-    expect(component.outputMean).toEqual('3.334');
+    expect(component.state).toEqual('deployed');
   });
 
   function createView(instance: InstanceMetrics): any {

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.ts
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.ts
@@ -1,10 +1,10 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { ElementComponent } from '../../../../shared/flo/support/shape-component';
-import { InstanceMetrics, TYPE } from '../../../model/stream-metrics';
+import { InstanceStatus, TYPE } from '../../../model/stream-metrics';
 import { ApplicationType } from '../../../../shared/model/application-type';
 
 /**
- * Component for displaying "dot" for instance metrics data under the module
+ * Component for displaying "dot" for instance streamStatuses data under the module
  *
  * @author Alex Boyko
  * @author Andy Clement
@@ -17,16 +17,8 @@ import { ApplicationType } from '../../../../shared/model/application-type';
 })
 export class InstanceDotComponent extends ElementComponent {
 
-  get instance(): InstanceMetrics {
+  get instance(): InstanceStatus {
     return this.view ? this.view.model.attr('instance') : undefined;
-  }
-
-  get isSource(): boolean {
-    return this.instance ? this.instance.properties[TYPE] === ApplicationType[ApplicationType.source] : false;
-  }
-
-  get isSink(): boolean {
-    return this.instance ? this.instance.properties[TYPE] === ApplicationType[ApplicationType.sink] : false;
   }
 
   get guid(): string {

--- a/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.ts
+++ b/ui/src/app/streams/components/flo/instance-dot/instance-dot.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { ElementComponent } from '../../../../shared/flo/support/shape-component';
-import { InstanceMetrics, INPUT_CHANNEL_MEAN, OUTPUT_CHANNEL_MEAN, TYPE } from '../../../model/stream-metrics';
+import { InstanceMetrics, TYPE } from '../../../model/stream-metrics';
 import { ApplicationType } from '../../../../shared/model/application-type';
 
 /**
@@ -21,26 +21,6 @@ export class InstanceDotComponent extends ElementComponent {
     return this.view ? this.view.model.attr('instance') : undefined;
   }
 
-  get inputMean(): string {
-    if (this.instance && !this.isSource) {
-      const metric = this.instance.metrics.find(m => m.name === INPUT_CHANNEL_MEAN);
-      if (metric && typeof metric.value === 'number') {
-        return metric.value.toFixed(3);
-      }
-    }
-    return undefined;
-  }
-
-  get outputMean(): string {
-    if (this.instance && !this.isSink) {
-      const metric = this.instance.metrics.find(m => m.name === OUTPUT_CHANNEL_MEAN);
-      if (metric && typeof metric.value === 'number') {
-        return metric.value.toFixed(3);
-      }
-    }
-    return undefined;
-  }
-
   get isSource(): boolean {
     return this.instance ? this.instance.properties[TYPE] === ApplicationType[ApplicationType.source] : false;
   }
@@ -51,6 +31,10 @@ export class InstanceDotComponent extends ElementComponent {
 
   get guid(): string {
     return this.instance ? this.instance.guid : '';
+  }
+
+  get state(): string {
+    return this.instance ? this.instance.state : '';
   }
 
 }

--- a/ui/src/app/streams/components/flo/message-rate/message-rate.component.ts
+++ b/ui/src/app/streams/components/flo/message-rate/message-rate.component.ts
@@ -6,7 +6,7 @@ const MAGNITUDE_NUMBERS = [ 1000000000, 1000000, 1000];
 const MAGNITUDE_LITERALS = ['B', 'M', 'K'];
 
 /**
- * Component for displaying "dot" for instance metrics data under the module
+ * Component for displaying "dot" for instance streamStatuses data under the module
  *
  * @author Alex Boyko
  * @author Andy Clement

--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
@@ -9,14 +9,10 @@ import {
   StreamMetrics,
   ApplicationMetrics,
   INSTANCE_COUNT,
-  INPUT_CHANNEL_MEAN,
-  OUTPUT_CHANNEL_MEAN,
   TYPE
 } from '../../model/stream-metrics';
 import { dia } from 'jointjs';
 import {
-  TYPE_INCOMING_MESSAGE_RATE,
-  TYPE_OUTGOING_MESSAGE_RATE,
   TYPE_INSTANCE_DOT,
   TYPE_INSTANCE_LABEL
 } from '../flo/support/shapes';
@@ -83,9 +79,9 @@ describe('StreamGraphDefinitionComponent', () => {
   it('verify dots in the view', (done) => {
     component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'deployed');
 
-    const httpMetrics = createAppMetrics('source', 'http', 2, 0, 3.4562243);
-    const filterMetrics = createAppMetrics('processor', 'filter', 40, 4.68954, 2.93718423);
-    const nullMetrics = createAppMetrics('sink', 'null', 3, 4.3124, 0);
+    const httpMetrics = createAppMetrics('source', 'http', 2);
+    const filterMetrics = createAppMetrics('processor', 'filter', 40);
+    const nullMetrics = createAppMetrics('sink', 'null', 3);
 
     // Remove 3 instances to have 37/40 label
     filterMetrics.instances.pop();
@@ -136,56 +132,7 @@ describe('StreamGraphDefinitionComponent', () => {
     fixture.detectChanges();
   });
 
-  it('verify message rate labels in the view', (done) => {
-    component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'deployed');
-
-    const httpMetrics = createAppMetrics('source', 'http', 1, 0, 3.4562243);
-    const filterMetrics = createAppMetrics('processor', 'filter', 1, 4.68954, 2.93718423);
-    const nullMetrics = createAppMetrics('sink', 'null', 1, 4.3124, 0);
-
-    const streamMetrics = new StreamMetrics();
-    streamMetrics.name = 'test-stream';
-    streamMetrics.applications = [
-      httpMetrics,
-      filterMetrics,
-      nullMetrics
-    ];
-    component.metrics = streamMetrics;
-
-    const subscription = component.flo.textToGraphConversionObservable.subscribe(() => {
-      subscription.unsubscribe();
-
-      // verify http dots
-      const link1 = component.flo.getGraph().getLinks()[0];
-      let labels = link1.get('labels');
-      expect(Array.isArray(labels)).toBeTruthy();
-      let incomingRate = labels.filter(l => l.type === TYPE_INCOMING_MESSAGE_RATE);
-      expect(incomingRate.length).toEqual(1);
-      expect(incomingRate[0].rate).toEqual(4.68954);
-      let outgoingRate = labels.filter(l => l.type === TYPE_OUTGOING_MESSAGE_RATE);
-      expect(outgoingRate.length).toEqual(1);
-      expect(outgoingRate[0].rate).toEqual(3.4562243);
-
-
-      const link2 = component.flo.getGraph().getLinks()[1];
-      labels = link2.get('labels');
-      expect(Array.isArray(labels)).toBeTruthy();
-      incomingRate = labels.filter(l => l.type === TYPE_INCOMING_MESSAGE_RATE);
-      expect(incomingRate.length).toEqual(1);
-      expect(incomingRate[0].rate).toEqual(4.3124);
-      outgoingRate = labels.filter(l => l.type === TYPE_OUTGOING_MESSAGE_RATE);
-      expect(outgoingRate.length).toEqual(1);
-      expect(outgoingRate[0].rate).toEqual(2.93718423);
-
-      done();
-
-    });
-    // Subscribe to graph changes before running angular change/update cycle
-    fixture.detectChanges();
-  });
-
-  function createAppMetrics(group: string, name: string, numberOfInstances: number,
-                            inRate: number, outRate: number): ApplicationMetrics {
+  function createAppMetrics(group: string, name: string, numberOfInstances: number): ApplicationMetrics {
     const instances = [];
     for (let index = 0; index < numberOfInstances; index++) {
       const properties = {};
@@ -193,20 +140,12 @@ describe('StreamGraphDefinitionComponent', () => {
       instances.push({
         guid: `${name}-${index}`,
         index: index,
-        properties: properties,
-        metrics: [
-          { name: INPUT_CHANNEL_MEAN, value: inRate },
-          { name: OUTPUT_CHANNEL_MEAN, value: outRate }
-        ]
+        properties: properties
       });
     }
     return ApplicationMetrics.fromJSON({
       name: name,
-      instances: instances,
-      aggregateMetrics: [
-        { name: INPUT_CHANNEL_MEAN, value: inRate },
-        { name: OUTPUT_CHANNEL_MEAN, value: outRate }
-      ]
+      instances: instances
     });
   }
 

--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
@@ -6,10 +6,8 @@ import { FloModule } from 'spring-flo';
 import { MetamodelService } from '../flo/metamodel.service';
 import { RenderService } from '../flo/render.service';
 import {
-  StreamMetrics,
-  ApplicationMetrics,
-  INSTANCE_COUNT,
-  TYPE
+  StreamStatuses,
+  StreamStatus
 } from '../../model/stream-metrics';
 import { dia } from 'jointjs';
 import {
@@ -79,17 +77,16 @@ describe('StreamGraphDefinitionComponent', () => {
   it('verify dots in the view', (done) => {
     component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'deployed');
 
-    const httpMetrics = createAppMetrics('source', 'http', 2);
-    const filterMetrics = createAppMetrics('processor', 'filter', 40);
-    const nullMetrics = createAppMetrics('sink', 'null', 3);
+    const httpMetrics = createStreamStatus('source', 'http', 2);
+    const filterMetrics = createStreamStatus('processor', 'filter', 40);
+    const nullMetrics = createStreamStatus('sink', 'null', 3);
 
     // Remove 3 instances to have 37/40 label
     filterMetrics.instances.pop();
     filterMetrics.instances.pop();
     filterMetrics.instances.pop();
-    filterMetrics.instances[0].properties[INSTANCE_COUNT] = 40;
 
-    const streamMetrics = new StreamMetrics();
+    const streamMetrics = new StreamStatuses();
     streamMetrics.name = 'test-stream';
     streamMetrics.applications = [
       httpMetrics,
@@ -115,7 +112,7 @@ describe('StreamGraphDefinitionComponent', () => {
       expect(filter.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_DOT)).toBeUndefined();
       const filterEmbeds = filter.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_LABEL);
       expect(filterEmbeds.length).toEqual(1);
-      expect(filterEmbeds[0].attr('.label/text')).toEqual('37/40');
+      expect(filterEmbeds[0].attr('.label/text')).toEqual('37/37');
 
       // verify null dots
       const nullApp = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'null');
@@ -132,18 +129,15 @@ describe('StreamGraphDefinitionComponent', () => {
     fixture.detectChanges();
   });
 
-  function createAppMetrics(group: string, name: string, numberOfInstances: number): ApplicationMetrics {
+  function createStreamStatus(group: string, name: string, numberOfInstances: number): StreamStatus {
     const instances = [];
     for (let index = 0; index < numberOfInstances; index++) {
-      const properties = {};
-      properties[TYPE] = group;
       instances.push({
         guid: `${name}-${index}`,
         index: index,
-        properties: properties
       });
     }
-    return ApplicationMetrics.fromJSON({
+    return StreamStatus.fromJSON({
       name: name,
       instances: instances
     });

--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.ts
@@ -115,7 +115,7 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
     });
 
     if (moduleMetrics && Array.isArray(moduleMetrics.instances) && moduleMetrics.instances.length > 0) {
-      let instanceCount = moduleMetrics.instances.length;
+      const instanceCount = moduleMetrics.instances.length;
 
       // Label or Dots should be displayed
       const size: dia.Size = cell.get('size');

--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.ts
@@ -2,9 +2,8 @@ import { Component, ViewEncapsulation, Input, OnDestroy } from '@angular/core';
 import { Flo } from 'spring-flo';
 import { StreamDefinition } from '../../model/stream-definition';
 import {
-  StreamMetrics,
-  ApplicationMetrics,
-  INSTANCE_COUNT
+  StreamStatuses,
+  StreamStatus
 } from '../../model/stream-metrics';
 import { ApplicationType } from '../../../shared/model/application-type';
 import { dia } from 'jointjs';
@@ -35,14 +34,14 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
   private ngUnsubscribe$: Subject<any> = new Subject();
 
   flo: Flo.EditorContext;
-  private _metrics: StreamMetrics;
+  private _metrics: StreamStatuses;
   private _subscriptionToGraphUpdates: Subscription;
 
   @Input()
   stream: StreamDefinition;
 
   @Input()
-  set metrics(m: StreamMetrics) {
+  set metrics(m: StreamStatuses) {
     this._metrics = m;
     this.update();
   }
@@ -58,7 +57,7 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
     this.ngUnsubscribe$.complete();
   }
 
-  get metrics(): StreamMetrics {
+  get metrics(): StreamStatuses {
     return this._metrics;
   }
 
@@ -80,7 +79,7 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
       .subscribe(() => this.update());
   }
 
-  private findModuleMetrics(label: string): ApplicationMetrics {
+  private findModuleMetrics(label: string): StreamStatus {
     return this.metrics && Array.isArray(this.metrics.applications) ? this.metrics.applications.find(app => app.name === label) : undefined;
   }
 
@@ -103,7 +102,7 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
     }
   }
 
-  private updateInstanceDecorations(cell: dia.Element, moduleMetrics: ApplicationMetrics) {
+  private updateInstanceDecorations(cell: dia.Element, moduleMetrics: StreamStatus) {
     let label: dia.Cell;
     let dots: dia.Cell[] = [];
     // Find label or dots currently painted
@@ -116,10 +115,7 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
     });
 
     if (moduleMetrics && Array.isArray(moduleMetrics.instances) && moduleMetrics.instances.length > 0) {
-      let instanceCount = Number(moduleMetrics.instances[0].properties[INSTANCE_COUNT]);
-      if (!instanceCount) {
-        instanceCount = moduleMetrics.instances.length;
-      }
+      let instanceCount = moduleMetrics.instances.length;
 
       // Label or Dots should be displayed
       const size: dia.Size = cell.get('size');

--- a/ui/src/app/streams/model/stream-metrics.spec.ts
+++ b/ui/src/app/streams/model/stream-metrics.spec.ts
@@ -1,21 +1,20 @@
-import { StreamMetrics, ApplicationMetrics, InstanceMetrics } from './stream-metrics';
+import { StreamStatuses, StreamStatus, InstanceStatus } from './stream-metrics';
 
 /**
  * Test {@link StreamDefinition} model.
  *
  * @author Glenn Renfro
  */
-describe('InstanceMetrics', () => {
+describe('InstanceStatus', () => {
 
   it('Guid and Index only deserialize', () => {
-    const i = InstanceMetrics.fromJSON({
+    const i = InstanceStatus.fromJSON({
       guid: 'guid',
       index: 8,
       state: 'deployed'
     });
     expect(i.guid).toEqual('guid');
     expect(i.index).toEqual(8);
-    expect(i.properties).toBeUndefined();
     expect(i.state).toEqual('deployed');
   });
 
@@ -24,20 +23,19 @@ describe('InstanceMetrics', () => {
       p1: 'v1',
       p2: 876,
     };
-    const i = InstanceMetrics.fromJSON({
+    const i = InstanceStatus.fromJSON({
       properties: props
     });
     expect(i.guid).toBeUndefined();
     expect(i.index).toBeUndefined();
-    expect(i.properties).toEqual(props);
   });
 
 });
 
-describe('ApplicationMetrics', () => {
+describe('StreamStatus', () => {
 
-  it('Deserialize ApplicationMetrics only name', () => {
-    const a = ApplicationMetrics.fromJSON({
+  it('Deserialize StreamStatus only name', () => {
+    const a = StreamStatus.fromJSON({
       name: 'my-app'
     });
     expect(a.name).toEqual('my-app');
@@ -45,7 +43,7 @@ describe('ApplicationMetrics', () => {
   });
 
   it('Deserialize general case', () => {
-    const a = ApplicationMetrics.fromJSON({
+    const a = StreamStatus.fromJSON({
       name: 'my-app',
       instances: [
         {
@@ -69,10 +67,10 @@ describe('ApplicationMetrics', () => {
 
 });
 
-describe('StreamMetrics', () => {
+describe('StreamStatuses', () => {
 
   it('Deserialize name only', () => {
-    const s = StreamMetrics.fromJSON({
+    const s = StreamStatuses.fromJSON({
       name: 'str1'
     });
     expect(s.name).toEqual('str1');
@@ -80,7 +78,7 @@ describe('StreamMetrics', () => {
   });
 
   it ('General case for deserialize', () => {
-    const s = StreamMetrics.fromJSON({
+    const s = StreamStatuses.fromJSON({
       applications: [
         {
           name: 'app-1'

--- a/ui/src/app/streams/model/stream-metrics.spec.ts
+++ b/ui/src/app/streams/model/stream-metrics.spec.ts
@@ -1,53 +1,22 @@
-import { StreamMetrics, ApplicationMetrics, InstanceMetrics, Metric } from './stream-metrics';
+import { StreamMetrics, ApplicationMetrics, InstanceMetrics } from './stream-metrics';
 
 /**
  * Test {@link StreamDefinition} model.
  *
  * @author Glenn Renfro
  */
-describe('Metric', () => {
-
-  it('Metric simple deserialize', () => {
-    const m = Metric.fromJSON({
-      name: 'metric1',
-      value: 5
-    });
-    expect(m.name).toEqual('metric1');
-    expect(m.value).toEqual(5);
-  });
-
-  it ('Metric extra data present', () => {
-    const m = Metric.fromJSON({
-      name: 'metric',
-      value: 'data',
-      extra: 'more data'
-    });
-    expect(m.name).toEqual('metric');
-    expect(m.value).toEqual('data');
-  });
-
-  it ('Metric data missing', () => {
-    const m = Metric.fromJSON({
-      name: 'metric',
-      extra: 'more data'
-    });
-    expect(m.name).toEqual('metric');
-    expect(m.value).toBeUndefined();
-  });
-
-});
-
 describe('InstanceMetrics', () => {
 
   it('Guid and Index only deserialize', () => {
     const i = InstanceMetrics.fromJSON({
       guid: 'guid',
       index: 8,
+      state: 'deployed'
     });
     expect(i.guid).toEqual('guid');
     expect(i.index).toEqual(8);
     expect(i.properties).toBeUndefined();
-    expect(i.metrics).toEqual([]);
+    expect(i.state).toEqual('deployed');
   });
 
   it('Properties deserialize', () => {
@@ -61,24 +30,6 @@ describe('InstanceMetrics', () => {
     expect(i.guid).toBeUndefined();
     expect(i.index).toBeUndefined();
     expect(i.properties).toEqual(props);
-    expect(i.metrics).toEqual([]);
-  });
-
-  it('Metrics deserialize', () => {
-    const i = InstanceMetrics.fromJSON({
-      metrics: [
-        {name: 'm1', value: 'v1'},
-        {name: 'm2', value: 4}
-      ]
-    });
-    expect(i.guid).toBeUndefined();
-    expect(i.index).toBeUndefined();
-    expect(i.properties).toBeUndefined();
-    expect(i.metrics.length).toEqual(2);
-    expect(i.metrics[0].name).toEqual('m1');
-    expect(i.metrics[0].value).toEqual('v1');
-    expect(i.metrics[1].name).toEqual('m2');
-    expect(i.metrics[1].value).toEqual(4);
   });
 
 });
@@ -91,50 +42,29 @@ describe('ApplicationMetrics', () => {
     });
     expect(a.name).toEqual('my-app');
     expect(a.instances).toEqual([]);
-    expect(a.aggregateMetrics).toEqual([]);
   });
 
   it('Deserialize general case', () => {
     const a = ApplicationMetrics.fromJSON({
       name: 'my-app',
-      aggregateMetrics: [
-        {name: 'a1', value: 'av1'},
-        {name: 'a2', value: 4}
-      ],
       instances: [
         {
           guid: 'i1',
-          index: 0,
-          metrics: [
-            {name: 'm1-1', value: 'v1-1'},
-            {name: 'm2-1', value: 5}
-          ]
+          index: 0
         },
         {
           guid: 'i2',
-          index: 1,
-          metrics: [
-            {name: 'm1-2', value: 'v1-2'},
-            {name: 'm2-2', value: 6}
-          ]
+          index: 1
         },
       ]
     });
     expect(a.name).toEqual('my-app');
 
-    expect(a.aggregateMetrics.length).toEqual(2);
-    expect(a.aggregateMetrics[0].name).toEqual('a1');
-    expect(a.aggregateMetrics[0].value).toEqual('av1');
-    expect(a.aggregateMetrics[1].name).toEqual('a2');
-    expect(a.aggregateMetrics[1].value).toEqual(4);
-
     expect(a.instances.length).toEqual(2);
     expect(a.instances[0].guid).toEqual('i1');
     expect(a.instances[0].index).toEqual(0);
-    expect(a.instances[0].metrics.length).toEqual(2);
     expect(a.instances[1].guid).toEqual('i2');
     expect(a.instances[1].index).toEqual(1);
-    expect(a.instances[1].metrics.length).toEqual(2);
   });
 
 });
@@ -153,26 +83,17 @@ describe('StreamMetrics', () => {
     const s = StreamMetrics.fromJSON({
       applications: [
         {
-          name: 'app-1',
-          aggregateMetrics: [
-            {name: 'a1', value: 'av1'}
-          ],
+          name: 'app-1'
         },
         {
-          name: 'app-2',
-          aggregateMetrics: [
-            {name: 'a2', value: 'av2'},
-            {name: 'm2-2', value: 6}
-          ],
+          name: 'app-2'
         }
       ]
     });
     expect(s.name).toBeUndefined();
     expect(s.applications.length).toEqual(2);
     expect(s.applications[0].name).toEqual('app-1');
-    expect(s.applications[0].aggregateMetrics.length).toEqual(1);
     expect(s.applications[1].name).toEqual('app-2');
-    expect(s.applications[1].aggregateMetrics.length).toEqual(2);
   });
 
 });

--- a/ui/src/app/streams/model/stream-metrics.ts
+++ b/ui/src/app/streams/model/stream-metrics.ts
@@ -8,34 +8,18 @@ export const OUTPUT_CHANNEL_MEAN = 'integration.channel.output.send.mean';
  *
  * @author Alex Boyko
  */
-export class Metric {
-  name: string;
-  value: any;
-
-  static fromJSON(input): Metric {
-    const metric = new Metric();
-    metric.name = input.name;
-    metric.value = input.value;
-    return metric;
-  }
-}
-
 export class InstanceMetrics {
   guid: string;
   index: number;
   properties: {};
-  metrics: Metric[];
+  state: string;
 
   static fromJSON(input): InstanceMetrics {
     const instanceMetrics = new InstanceMetrics();
     instanceMetrics.guid = input.guid;
     instanceMetrics.index = input.index;
     instanceMetrics.properties = input.properties;
-    if (Array.isArray(input.metrics)) {
-      instanceMetrics.metrics = input.metrics.map(Metric.fromJSON);
-    } else {
-      instanceMetrics.metrics = [];
-    }
+    instanceMetrics.state = input.state;
     return instanceMetrics;
   }
 
@@ -44,7 +28,6 @@ export class InstanceMetrics {
 export class ApplicationMetrics {
   name: string;
   instances: InstanceMetrics[];
-  aggregateMetrics: Metric[];
 
   static fromJSON(input) {
     const applicationMetrics = new ApplicationMetrics();
@@ -53,11 +36,6 @@ export class ApplicationMetrics {
       applicationMetrics.instances = input.instances.map(InstanceMetrics.fromJSON);
     } else {
       applicationMetrics.instances = [];
-    }
-    if (Array.isArray(input.aggregateMetrics)) {
-      applicationMetrics.aggregateMetrics = input.aggregateMetrics.map(Metric.fromJSON);
-    } else {
-      applicationMetrics.aggregateMetrics = [];
     }
     return applicationMetrics;
   }

--- a/ui/src/app/streams/model/stream-metrics.ts
+++ b/ui/src/app/streams/model/stream-metrics.ts
@@ -1,64 +1,60 @@
 export const TYPE = 'spring.cloud.dataflow.stream.app.type';
 export const INSTANCE_COUNT = 'spring.cloud.stream.instanceCount';
-export const INPUT_CHANNEL_MEAN = 'integration.channel.input.send.mean';
-export const OUTPUT_CHANNEL_MEAN = 'integration.channel.output.send.mean';
 
 /**
- * StreamMetrics and related model classes
+ * StreamStatuses and related model classes
  *
  * @author Alex Boyko
  */
-export class InstanceMetrics {
+export class InstanceStatus {
   guid: string;
   index: number;
-  properties: {};
   state: string;
 
-  static fromJSON(input): InstanceMetrics {
-    const instanceMetrics = new InstanceMetrics();
-    instanceMetrics.guid = input.guid;
-    instanceMetrics.index = input.index;
-    instanceMetrics.properties = input.properties;
-    instanceMetrics.state = input.state;
-    return instanceMetrics;
+  static fromJSON(input): InstanceStatus {
+    const instanceStatus = new InstanceStatus();
+    instanceStatus.guid = input.guid;
+    instanceStatus.index = input.index;
+    instanceStatus.state = input.state;
+    return instanceStatus;
   }
 
 }
 
-export class ApplicationMetrics {
+export class StreamStatus {
   name: string;
-  instances: InstanceMetrics[];
+  instances: InstanceStatus[];
 
   static fromJSON(input) {
-    const applicationMetrics = new ApplicationMetrics();
-    applicationMetrics.name = input.name;
+    const streamStatus = new StreamStatus();
+    streamStatus.name = input.name;
     if (Array.isArray(input.instances)) {
-      applicationMetrics.instances = input.instances.map(InstanceMetrics.fromJSON);
+      streamStatus.instances = input.instances.map(InstanceStatus.fromJSON);
     } else {
-      applicationMetrics.instances = [];
+      streamStatus.instances = [];
     }
-    return applicationMetrics;
+    return streamStatus;
   }
 }
 
-export class StreamMetrics {
+export class StreamStatuses {
   name: string;
-  applications: ApplicationMetrics[];
+  applications: StreamStatus[];
 
-  static fromJSON(input): StreamMetrics {
-    const streamMetrics = new StreamMetrics();
-    streamMetrics.name = input.name;
+  static fromJSON(input): StreamStatuses {
+    const streamStatuses = new StreamStatuses();
+    streamStatuses.name = input.name;
     if (Array.isArray(input.applications)) {
-      streamMetrics.applications = input.applications.map(ApplicationMetrics.fromJSON);
+      streamStatuses.applications = input.applications.map(StreamStatus.fromJSON);
     } else {
-      streamMetrics.applications = [];
+      streamStatuses.applications = [];
     }
-    return streamMetrics;
+    return streamStatuses;
   }
 
-  static listFromJSON(input): Array<StreamMetrics> {
+  static listFromJSON(input): Array<StreamStatuses> {
     if (Array.isArray(input)) {
-      return input.map(StreamMetrics.fromJSON);
+      return input.map(StreamStatuses.fromJSON);
     }
     return [];
   }

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -301,7 +301,7 @@ describe('StreamsService', () => {
       this.streamsService.getRuntimeStreamStatuses();
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
-      expect(httpUri).toEqual('/runtime/stream');
+      expect(httpUri).toEqual('/runtime/streams');
       expect(headerArgs.get('Content-Type')).toEqual('application/json');
       expect(headerArgs.get('Accept')).toEqual('application/json');
     });
@@ -316,7 +316,7 @@ describe('StreamsService', () => {
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
       const httpParams = this.mockHttp.get.calls.mostRecent().args[1].params;
-      expect(httpUri).toEqual('/runtime/stream');
+      expect(httpUri).toEqual('/runtime/streams');
       expect(headerArgs.get('Content-Type')).toEqual('application/json');
       expect(headerArgs.get('Accept')).toEqual('application/json');
       expect(httpParams.get('names')).toEqual('test1,test2');

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -293,30 +293,30 @@ describe('StreamsService', () => {
 
   });
 
-  describe('metrics', () => {
+  describe('streamStatuses', () => {
 
-    it('should call the streams metrics service no stream names specified', () => {
+    it('should call the streams streamStatuses service no stream names specified', () => {
       this.mockHttp.get.and.returnValue(of(this.jsonData));
-      expect(this.streamsService.getMetrics).toBeDefined();
-      this.streamsService.getMetrics();
+      expect(this.streamsService.getRuntimeStreamStatuses).toBeDefined();
+      this.streamsService.getRuntimeStreamStatuses();
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
-      expect(httpUri).toEqual('/metrics/streams');
+      expect(httpUri).toEqual('/runtime/stream');
       expect(headerArgs.get('Content-Type')).toEqual('application/json');
       expect(headerArgs.get('Accept')).toEqual('application/json');
     });
 
-    it('should call the streams metrics service with stream names specified', () => {
+    it('should call the streams streamStatuses service with stream names specified', () => {
       this.mockHttp.get.and.returnValue(of(this.jsonData));
-      expect(this.streamsService.getMetrics).toBeDefined();
-      this.streamsService.getMetrics(['test1', 'test2']);
+      expect(this.streamsService.getRuntimeStreamStatuses).toBeDefined();
+      this.streamsService.getRuntimeStreamStatuses(['test1', 'test2']);
       const httpHeaders = HttpUtils.getDefaultHttpHeaders();
       const params = new HttpParams()
         .append('names', 'test1,test2');
       const httpUri = this.mockHttp.get.calls.mostRecent().args[0];
       const headerArgs = this.mockHttp.get.calls.mostRecent().args[1].headers;
       const httpParams = this.mockHttp.get.calls.mostRecent().args[1].params;
-      expect(httpUri).toEqual('/metrics/streams');
+      expect(httpUri).toEqual('/runtime/stream');
       expect(headerArgs.get('Content-Type')).toEqual('application/json');
       expect(headerArgs.get('Accept')).toEqual('application/json');
       expect(httpParams.get('names')).toEqual('test1,test2');

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -261,7 +261,7 @@ export class StreamsService {
       params = params.append('names', streamNames.join(','));
     }
     return this.httpClient
-      .get<any>('/runtime/stream', { headers: httpHeaders, params: params })
+      .get<any>('/runtime/streams', { headers: httpHeaders, params: params })
       .pipe(
         map(StreamStatuses.listFromJSON),
         catchError(this.errorHandler.handleError)

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse, HttpParams } from '@angular/common/http';
 import { Observable, forkJoin } from 'rxjs';
 import { StreamDefinition } from './model/stream-definition';
-import { StreamMetrics } from './model/stream-metrics';
+import { StreamStatuses } from './model/stream-metrics';
 import { Page } from '../shared/model/page';
 import { ErrorHandler } from '../shared/model/error-handler';
 import { HttpUtils } from '../shared/support/http.utils';
@@ -250,20 +250,20 @@ export class StreamsService {
   }
 
   /**
-   * Calls the Spring Cloud Data Flow server to get the metrics of a specified stream.
+   * Calls the Spring Cloud Data Flow server to get the streamStatuses of a specified stream.
    * @param {string[]} streamNames
-   * @returns {Observable<StreamMetrics[]>}
+   * @returns {Observable<StreamStatuses[]>}
    */
-  getMetrics(streamNames?: string[]): Observable<StreamMetrics[]> {
+  getRuntimeStreamStatuses(streamNames?: string[]): Observable<StreamStatuses[]> {
     const httpHeaders = HttpUtils.getDefaultHttpHeaders();
     let params = new HttpParams();
     if (streamNames) {
       params = params.append('names', streamNames.join(','));
     }
     return this.httpClient
-      .get<any>('/metrics/streams', { headers: httpHeaders, params: params })
+      .get<any>('/runtime/stream', { headers: httpHeaders, params: params })
       .pipe(
-        map(StreamMetrics.listFromJSON),
+        map(StreamStatuses.listFromJSON),
         catchError(this.errorHandler.handleError)
       );
   }

--- a/ui/src/app/streams/streams/streams.component.spec.ts
+++ b/ui/src/app/streams/streams/streams.component.spec.ts
@@ -47,7 +47,7 @@ import { DATAFLOW_LIST } from '../../shared/components/list/list.component';
  * @author Damien Vitrac
  * @author Gunnar Hillert
  */
-describe('StreamsComponent', () => {
+fdescribe('StreamsComponent', () => {
   let component: StreamsComponent;
   let fixture: ComponentFixture<StreamsComponent>;
   const notificationService = new MockNotificationService();
@@ -451,6 +451,7 @@ describe('StreamsComponent', () => {
       };
       const spy = spyOn(modalService, 'show').and.returnValue(mockBsModalRef);
       component.deploySelectedStreams();
+      fixture.detectChanges();
       expect(spy).toHaveBeenCalledWith(StreamsDeployComponent, { class: 'modal-xl' });
     }));
 
@@ -459,6 +460,7 @@ describe('StreamsComponent', () => {
       mockBsModalRef.content = {
         open: () => of('testing')
       };
+      fixture.detectChanges();
       const spy = spyOn(modalService, 'show').and.returnValue(mockBsModalRef);
       component.undeploySelectedStreams();
       expect(spy).toHaveBeenCalledWith(StreamsUndeployComponent, { class: 'modal-lg' });

--- a/ui/src/app/streams/streams/streams.component.ts
+++ b/ui/src/app/streams/streams/streams.component.ts
@@ -318,7 +318,6 @@ export class StreamsComponent implements OnInit, OnDestroy {
           this.changeExpand();
           this.changeCheckboxes();
           this.updateContext();
-          this.loadStreamMetrics();
         },
         error => {
           this.notificationService.error(AppError.is(error) ? error.getMessage() : error);

--- a/ui/src/app/streams/streams/streams.component.ts
+++ b/ui/src/app/streams/streams/streams.component.ts
@@ -3,7 +3,7 @@ import { Page } from '../../shared/model';
 import { StreamDefinition } from '../model/stream-definition';
 import { StreamsService } from '../streams.service';
 import { Subscription } from 'rxjs';
-import { StreamMetrics } from '../model/stream-metrics';
+import { StreamStatuses } from '../model/stream-metrics';
 import { Router } from '@angular/router';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { StreamsDeployComponent } from '../streams-deploy/streams-deploy.component';
@@ -64,9 +64,9 @@ export class StreamsComponent implements OnInit, OnDestroy {
   metricsSubscription: Subscription;
 
   /**
-   * Array of metrics
+   * Array of streamStatuses
    */
-  metrics: StreamMetrics[];
+  streamStatuses: StreamStatuses[];
 
   /**
    * Modal reference
@@ -265,7 +265,7 @@ export class StreamsComponent implements OnInit, OnDestroy {
     this.appsState$ = this.appsService.appsState();
     this.refresh();
 
-    this.metricsSubscription = IntervalObservable.create(30000).subscribe(() => this.loadStreamMetrics());
+    this.metricsSubscription = IntervalObservable.create(10000).subscribe(() => this.loadStreamMetrics());
   }
 
   /**
@@ -393,7 +393,7 @@ export class StreamsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Loads streams metrics data
+   * Loads streams streamStatuses data
    */
   loadStreamMetrics() {
     const streamNames = this.streamDefinitions && Array.isArray(this.streamDefinitions.items) ?
@@ -402,9 +402,9 @@ export class StreamsComponent implements OnInit, OnDestroy {
         .map(s => s.name.toString())
       : [];
     if (streamNames.length) {
-      this.streamsService.getMetrics(streamNames).subscribe(metrics => this.metrics = metrics);
+      this.streamsService.getRuntimeStreamStatuses(streamNames).subscribe(metrics => this.streamStatuses = metrics);
     } else {
-      this.metrics = [];
+      this.streamStatuses = [];
     }
   }
 
@@ -590,11 +590,11 @@ export class StreamsComponent implements OnInit, OnDestroy {
   /**
    * Metrics for stream
    * @param {string} name
-   * @returns {StreamMetrics}
+   * @returns {StreamStatuses}
    */
-  metricsForStream(name: string): StreamMetrics {
-    if (Array.isArray(this.metrics)) {
-      return this.metrics.find(m => m.name === name);
+  metricsForStream(name: string): StreamStatuses {
+    if (Array.isArray(this.streamStatuses)) {
+      return this.streamStatuses.find(m => m.name === name);
     }
   }
 

--- a/ui/src/app/streams/streams/streams.component.ts
+++ b/ui/src/app/streams/streams/streams.component.ts
@@ -265,7 +265,7 @@ export class StreamsComponent implements OnInit, OnDestroy {
     this.appsState$ = this.appsService.appsState();
     this.refresh();
 
-    this.metricsSubscription = IntervalObservable.create(2000).subscribe(() => this.loadStreamMetrics());
+    this.metricsSubscription = IntervalObservable.create(30000).subscribe(() => this.loadStreamMetrics());
   }
 
   /**
@@ -398,7 +398,7 @@ export class StreamsComponent implements OnInit, OnDestroy {
   loadStreamMetrics() {
     const streamNames = this.streamDefinitions && Array.isArray(this.streamDefinitions.items) ?
       this.streamDefinitions.items
-        .filter(i => i.status === 'deployed')
+        .filter(i => (i.status === 'deployed') || (i.status === 'deploying') || (i.status === 'partial'))
         .map(s => s.name.toString())
       : [];
     if (streamNames.length) {

--- a/ui/src/app/streams/streams/streams.component.ts
+++ b/ui/src/app/streams/streams/streams.component.ts
@@ -318,6 +318,7 @@ export class StreamsComponent implements OnInit, OnDestroy {
           this.changeExpand();
           this.changeCheckboxes();
           this.updateContext();
+          this.loadStreamMetrics();
         },
         error => {
           this.notificationService.error(AppError.is(error) ? error.getMessage() : error);

--- a/ui/src/app/tests/mocks/streams.ts
+++ b/ui/src/app/tests/mocks/streams.ts
@@ -68,7 +68,7 @@ export class MockStreamsService {
     ]);
   }
 
-  getStreamStatuses(streamNames?: string[]): Observable<StreamStatuses[]> {
+  getRuntimeStreamStatuses(streamNames?: string[]): Observable<StreamStatuses[]> {
     return of([]);
   }
 

--- a/ui/src/app/tests/mocks/streams.ts
+++ b/ui/src/app/tests/mocks/streams.ts
@@ -1,7 +1,7 @@
 import { Page } from '../../shared/model/page';
 import { StreamDefinition } from '../../streams/model/stream-definition';
 import { Platform } from '../../streams/model/platform';
-import { StreamMetrics } from '../../streams/model/stream-metrics';
+import { StreamStatuses } from '../../streams/model/stream-metrics';
 import { OrderParams } from '../../shared/components/shared.interface';
 import { StreamHistory } from '../../streams/model/stream-history';
 import { Observable, of } from 'rxjs';
@@ -68,7 +68,7 @@ export class MockStreamsService {
     ]);
   }
 
-  getMetrics(streamNames?: string[]): Observable<StreamMetrics[]> {
+  getStreamStatuses(streamNames?: string[]): Observable<StreamStatuses[]> {
     return of([]);
   }
 


### PR DESCRIPTION
 - Remove all rate metrics related logic from the affected components and fix the tests
 - Increase the metrics poll interval from 2 sec to 30 sec.
 - Allow metrics requests on stream deploying and partial states.

 Resolves #1037