### PR TITLE
Populate deployer properties

### DIFF
--- a/ui/src/app/shared/model/platform.ts
+++ b/ui/src/app/shared/model/platform.ts
@@ -2,6 +2,7 @@
  * Represents a Platform.
  *
  * @author Damien Vitrac
+ * @author Janne Valkealahti
  */
 export class Platform {
 
@@ -11,10 +12,13 @@ export class Platform {
 
   public description: String;
 
-  constructor(name: String = '', type: String = '', description: String = '') {
+  public options: Array<any>;
+
+  constructor(name: String = '', type: String = '', description: String = '', options: Array<any> = []) {
     this.name = name;
     this.type = type;
     this.description = description;
+    this.options = options;
   }
 
   /**
@@ -23,7 +27,7 @@ export class Platform {
    * @returns {Platform}
    */
   static fromJSON(inputJson): Platform {
-    return new Platform(inputJson.name, inputJson.type, inputJson.description);
+    return new Platform(inputJson.name, inputJson.type, inputJson.description, inputJson.options);
   }
 
   /**

--- a/ui/src/app/streams/stream-deploy/builder/builder.component.html
+++ b/ui/src/app/streams/stream-deploy/builder/builder.component.html
@@ -95,6 +95,14 @@
             </div>
 
             <!-- 6 -->
+            <div *ngIf="state.specificPlatform">
+              <div *ngIf="builder.builderDeploymentProperties.global.length > 0"
+                   class="line-body">
+                <div class="form-control form-control-label">
+                  Properties
+                </div>
+              </div>
+            </div>
             <div *ngIf="state.specificPlatform"
                  formArrayName="specificPlatform">
               <div class="line-body" *ngFor="let f of builder.formGroup.get('specificPlatform').controls;let i = index"
@@ -217,6 +225,18 @@
             <!-- 5 -->
             <div class="line-toggle"></div>
 
+            <div class="line-body"
+                 *ngIf="state.specificPlatform && builder.builderDeploymentProperties.global.length > 0">
+              <div class="form-control form-control-label">
+                <strong>{{ getDeploymentProperties(builder.builderDeploymentProperties).length }}</strong>
+                <span> /</span> {{ builder.builderDeploymentProperties.global.length }} properties
+                <button tabindex="{{ 101 }}" type="button" (click)="openDeploymentProperties(builder)"
+                        class="btn btn-primary">
+                  <span class="fa fa-pencil"></span>
+                </button>
+              </div>
+            </div>
+
             <!-- 6 -->
             <div *ngIf="state.specificPlatform"
                  formArrayName="specificPlatform">
@@ -287,6 +307,18 @@
               <div class="line-toggle"></div>
 
               <!-- 6 -->
+              <!-- track visibility from global as those are same as per apps -->
+              <div class="line-body" *ngIf="state.specificPlatform && builder.builderDeploymentProperties.global.length > 0">
+                <div class="form-control form-control-label">
+                  <strong>{{ getDeploymentProperties(builder.builderDeploymentProperties, app.name).length }}</strong>
+                  <span> /</span> {{ builder.builderDeploymentProperties.apps[app.name].length }} properties
+                  <button tabindex="{{ 101 }}" type="button" (click)="openDeploymentProperties(builder, app.name)"
+                      class="btn btn-primary">
+                    <span class="fa fa-pencil"></span>
+                  </button>
+                </div>
+              </div>
+
               <div *ngIf="state.specificPlatform"
                    formArrayName="specificPlatform">
                 <div class="line-body"

--- a/ui/src/app/streams/stream-deploy/builder/builder.component.spec.ts
+++ b/ui/src/app/streams/stream-deploy/builder/builder.component.spec.ts
@@ -1,0 +1,132 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockNotificationService } from '../../../tests/mocks/notification';
+import { MockStreamsService } from '../../../tests/mocks/streams';
+import { StreamsService } from '../../streams.service';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockActivatedRoute } from '../../../tests/mocks/activated-route';
+import { ActivatedRoute } from '@angular/router';
+import { MocksSharedAboutService } from '../../../tests/mocks/shared-about';
+import { SharedAboutService } from '../../../shared/services/shared-about.service';
+import { BsDropdownModule, ModalModule, TooltipModule } from 'ngx-bootstrap';
+import { AppTypeComponent } from '../../../apps/components/app-type/app-type.component';
+import { NotificationService } from '../../../shared/services/notification.service';
+import { LoggerService } from '../../../shared/services/logger.service';
+import { DATAFLOW_PAGE } from 'src/app/shared/components/page/page.component';
+import { PagerComponent } from '../../../shared/components/pager/pager.component';
+import { DATAFLOW_LIST } from '../../../shared/components/list/list.component';
+import { APPS_2, STREAM_DEFINITIONS } from '../../../tests/mocks/mock-data';
+import { RoutingStateService } from '../../../shared/services/routing-state.service';
+import { MockRoutingStateService } from '../../../tests/mocks/routing-state';
+import { LoaderComponent } from '../../../shared/components/loader/loader.component';
+import { StreamDeployFreeTextComponent } from '../free-text/free-text.component';
+import { StreamDeployBuilderComponent } from '../builder/builder.component';
+import { NgxPaginationModule } from 'ngx-pagination/dist/ngx-pagination';
+import { StreamDeployBuilderErrorsComponent } from '../builder/errors/errors.component';
+import { FocusDirective } from '../../../shared/directives/focus.directive';
+import { StreamDeployService } from 'src/app/streams/stream-deploy/stream-deploy.service';
+import { MockSharedAppService } from 'src/app/tests/mocks/shared-app';
+import { MockAppsService } from '../../../tests/mocks/apps';
+import { ClipboardModule, ClipboardService } from 'ngx-clipboard';
+import { BlockerService } from '../../../shared/components/blocker/blocker.service';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+/**
+ * Test {@link StreamDeployBuilderComponent}.
+ *
+ * @author Janne Valkealahti
+ */
+describe('StreamDeployBuilderComponent', () => {
+  let component: StreamDeployBuilderComponent;
+  let fixture: ComponentFixture<StreamDeployBuilderComponent>;
+  const notificationService = new MockNotificationService();
+  const streamsService = new MockStreamsService();
+  const sharedAboutService = new MocksSharedAboutService();
+  const appsService = new MockAppsService();
+  const sharedAppService = new MockSharedAppService();
+  let activeRoute: MockActivatedRoute;
+  const loggerService = new LoggerService();
+  const routingStateService = new MockRoutingStateService();
+  const streamDeployService = new StreamDeployService(streamsService as any, sharedAppService, appsService as any);
+
+  beforeEach(async(() => {
+    activeRoute = new MockActivatedRoute();
+
+    TestBed.configureTestingModule({
+      declarations: [
+        PagerComponent,
+        DATAFLOW_PAGE,
+        DATAFLOW_LIST,
+        LoaderComponent,
+        AppTypeComponent,
+        StreamDeployFreeTextComponent,
+        StreamDeployBuilderComponent,
+        StreamDeployBuilderErrorsComponent,
+        FocusDirective
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        TooltipModule.forRoot(),
+        ModalModule.forRoot(),
+        BsDropdownModule.forRoot(),
+        NgxPaginationModule,
+        ClipboardModule,
+        RouterTestingModule.withRoutes([])
+      ],
+      providers: [
+        { provide: StreamsService, useValue: streamsService },
+        { provide: ActivatedRoute, useValue: activeRoute },
+        { provide: SharedAboutService, useValue: sharedAboutService },
+        { provide: NotificationService, useValue: notificationService },
+        { provide: RoutingStateService, useValue: routingStateService },
+        { provide: StreamDeployService, useValue: streamDeployService },
+        { provide: LoggerService, useValue: loggerService },
+        ClipboardService,
+        BlockerService
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    streamsService.streamDefinitions = STREAM_DEFINITIONS;
+    fixture = TestBed.createComponent(StreamDeployBuilderComponent);
+    component = fixture.componentInstance;
+    notificationService.clearAll();
+  });
+
+  it('should be created', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+
+  describe('Form values', () => {
+
+    beforeEach(() => {
+      appsService.mock = Object.assign({}, JSON.parse(JSON.stringify(APPS_2)));
+      component.id = 'foo2';
+      fixture.detectChanges();
+    });
+
+    it('platform select changes to modal controls', () => {
+      const s: DebugElement[] = fixture.debugElement.queryAll(By.css('select'));
+      expect(s.length).toBe(3);
+      const platform = s[0].nativeElement;
+      platform.value = platform.options[1].value;
+      platform.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      expect(platform.value).toContain('default');
+      // we don't show 'No properties' but have '0 / 1 properties'
+      const tr: DebugElement[] = fixture.debugElement.queryAll(By.css('.form-control > strong'));
+      expect(tr.length).toBe(3);
+      expect(tr[0].nativeElement.textContent).toContain('0');
+      expect(tr[1].nativeElement.textContent).toContain('0');
+      expect(tr[2].nativeElement.textContent).toContain('0');
+    });
+
+  });
+
+});

--- a/ui/src/app/streams/stream-deploy/stream-deploy.service.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.service.ts
@@ -20,6 +20,7 @@ import { Platform } from '../../shared/model/platform';
  * Provides {@link StreamDeployConfig} related services.
  *
  * @author Damien Vitrac
+ * @author Janne Valkealahti
  */
 @Injectable()
 export class StreamDeployService {
@@ -150,7 +151,8 @@ export class StreamDeployService {
             return {
               key: platform.name,
               name: platform.name,
-              type: platform.type
+              type: platform.type,
+              options: platform.options
             };
           })
         };

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -1121,6 +1121,51 @@ export const APPS = {
   number: 0
 };
 
+export const APPS_2 = {
+  items: [
+    {
+      name: 'time',
+      type: 'source',
+      uri: 'https://foo.bar:1.0.0',
+      version: '1.0.0',
+      defaultVersion: true,
+      versions: [
+        {
+          version: '0.0.1',
+          uri: 'https://foo.bar:0.0.1',
+          defaultVersion: false,
+          metadata: [
+            { name: 'foo1', description: 'bar1' },
+            { name: 'foo2', description: 'bar2' }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'log',
+      type: 'sink',
+      uri: 'https://bar.foo:0.0.1 ',
+      version: '0.0.1',
+      defaultVersion: true,
+      versions: [
+        {
+          version: '0.0.1',
+          uri: 'https://foo.bar:0.0.1',
+          defaultVersion: true,
+          metadata: [
+            { name: 'foo1', description: 'bar1' },
+            { name: 'foo2', description: 'bar2' }
+          ]
+        }
+      ]
+    }
+  ],
+  size: 20,
+  totalElements: 2,
+  totalPages: 1,
+  number: 0
+};
+
 export const STREAM_DEFINITIONS = {
   _embedded: {
     streamDefinitionResourceList: [

--- a/ui/src/app/tests/mocks/streams.ts
+++ b/ui/src/app/tests/mocks/streams.ts
@@ -63,7 +63,9 @@ export class MockStreamsService {
 
   getPlatforms(): Observable<Platform[]> {
     return of([
-      Platform.fromJSON({name: 'default', type: 'local', description: ''}),
+      Platform.fromJSON({name: 'default', type: 'local', description: '',
+        options: [{id: 'spring.cloud.deployer.local.opt1', name: 'opt1'}]
+      }),
       Platform.fromJSON({name: 'foo', type: 'bar', description: 'foobar'})
     ]);
   }


### PR DESCRIPTION
- Use modal dialog to handle deployment properties per global
  and apps using dialog components made for apps.
- Add options field to platform as that is now coming from
  skipper via dataflow.
- Change some mocks and add basic tests for StreamDeployBuilderComponent.
- Fixes #1153