### PR TITLE
Fix PropertiesDialogComponent count limiting

### DIFF
--- a/ui/src/app/shared/flo/properties/properties-dialog.component.html
+++ b/ui/src/app/shared/flo/properties/properties-dialog.component.html
@@ -16,7 +16,7 @@
       <button class="btn btn-primary" (click)="showProperties = true">Show all the properties</button>
     </div>
 
-    <div *ngIf="propertiesGroupModel.getControlsModels().length < 50 || showProperties">
+    <div *ngIf="propertiesGroupModel.getControlsModels().length <= 50 || showProperties">
 
       <properties-group *ngIf="propertiesGroupModel" [propertiesGroupModel]="propertiesGroupModel"
                         [form]="propertiesFormGroup"></properties-group>


### PR DESCRIPTION
- Fix case where properties count is exactly limit 50 by
  using equal or lower operator.
- Fixes #1172