### PR TITLE
Implement deployment properties grouping

### DIFF
--- a/ui/src/app/shared/flo/properties-groups/properties-groups-dialog.component.html
+++ b/ui/src/app/shared/flo/properties-groups/properties-groups-dialog.component.html
@@ -1,0 +1,28 @@
+<div class="modal-header">
+  <h4 class="modal-title pull-left">{{ title }}</h4>
+  <button type="button" class="close pull-right" aria-label="Close" (click)="handleCancel()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<form name="app-properties" (submit)="handleOk()" class="modal-body app-properties">
+
+  <div class="properties"
+       *ngFor="let group of propertiesGroupModels">
+    <div class="line-toggle">
+      <a class="toggle" (click)="collapse(group.title)">
+                <span class="fa" [class.fa-chevron-down]="state[group.title]"
+                      [class.fa-chevron-right]="!state[group.title]"></span>
+        {{group.title}}
+      </a>
+    </div>
+    <div *ngIf="state[group.title]">
+      <properties-group [propertiesGroupModel]="group"
+                        [form]="propertiesFormGroup"></properties-group>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default" (click)="handleCancel()">Close</button>
+    <button type="submit" class="btn btn-primary" [disabled]="okDisabled">OK</button>
+  </div>
+</form>

--- a/ui/src/app/shared/flo/properties-groups/properties-groups-dialog.component.scss
+++ b/ui/src/app/shared/flo/properties-groups/properties-groups-dialog.component.scss
@@ -1,0 +1,79 @@
+@import '../../../../scss/pui-variables';
+
+.properties-group-container .property-row {
+  display: block;
+}
+
+.df-property-row {
+  width: 100%;
+  display:inline-table;
+}
+
+.df-property-label-cell {
+  width: 30%;
+}
+
+.df-property-container {
+  width: 100%
+}
+
+.df-property-control {
+  width: 100%;
+}
+
+.modal-body.app-properties {
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+label.df-property-control {
+  margin-bottom: 0px;
+}
+
+.invalid-property-value .df-form-label {
+  color: $error-3;
+}
+
+.invalid-property-value .df-property-control {
+  outline-color: $error-3;
+  border-color: $error-3;
+  color: $error-3
+}
+
+.validation-error-block {
+  color: $error-3;
+}
+
+.properties {
+
+  .line-toggle {
+    background: #F5F6F7;
+    height: 42px;
+    line-height: 42px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+    position: relative;
+
+    .toggle {
+      display: block;
+      cursor: pointer;
+      position: relative;
+      padding-left: 40px;
+      margin-right: 30px;
+      color: #000;
+      .fa-chevron-right, .fa-chevron-down {
+        position: absolute;
+        top: 12px;
+        left: 15px;
+      }
+      .fa-chevron-right {
+        top: 14px;
+        left: 17px;
+      }
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+}

--- a/ui/src/app/shared/flo/properties-groups/properties-groups-dialog.component.ts
+++ b/ui/src/app/shared/flo/properties-groups/properties-groups-dialog.component.ts
@@ -1,0 +1,148 @@
+import { Component, ViewEncapsulation, OnInit, EventEmitter } from '@angular/core';
+import { BsModalRef } from 'ngx-bootstrap';
+import { FormGroup } from '@angular/forms';
+import { of } from 'rxjs';
+import { Properties } from 'spring-flo';
+import { PropertiesGroupModel } from '../support/properties-group-model';
+import PropertiesSource = Properties.PropertiesSource;
+
+/**
+ * Class to add group title to a model.
+ */
+export class GroupPropertiesGroupModel extends PropertiesGroupModel {
+
+  constructor(propertiesSource: PropertiesSource, public title: string = '') {
+    super(propertiesSource);
+  }
+}
+
+/**
+ * Class to implement PropertiesSource and to have needed features
+ * to support multiple sources.
+ */
+export class GroupPropertiesSource implements PropertiesSource {
+
+  private options: Array<any>;
+
+  constructor(options: Array<any>, public title: string = '') {
+    this.options = options;
+  }
+
+  getProperties(): Promise<Properties.Property[]> {
+    return of(this.options).toPromise();
+  }
+
+  applyChanges(properties: Properties.Property[]): void {
+    // nothing to do as we don't rely calling applyChanges() for model
+    // classes because we have multiple groups so controls and its
+    // properties are accesses manually.
+  }
+}
+
+/**
+ * Class to keep GroupPropertiesSource in one place and to have
+ * emitter to notify user of a new property changes.
+ */
+export class GroupPropertiesSources {
+
+  public confirm = new EventEmitter();
+
+  constructor(public propertiesSources: Array<GroupPropertiesSource>) {
+  }
+
+  applyChanges(properties: Properties.Property[]): void {
+    this.confirm.emit(properties);
+  }
+}
+
+/**
+ * Component for displaying generic properties and capturing their values.
+ *
+ * @author Janne Valkealahti
+ */
+@Component({
+  selector: 'app-properties-groups-dialog-content',
+  templateUrl: 'properties-groups-dialog.component.html',
+  styleUrls: [ 'properties-groups-dialog.component.scss' ],
+  encapsulation: ViewEncapsulation.None
+})
+export class PropertiesGroupsDialogComponent implements OnInit {
+
+  /**
+   * Dialog title.
+   */
+  public title: string;
+
+  /**
+   * Groups are eventually added here and accessed from a template.
+   */
+  propertiesGroupModels: Array<GroupPropertiesGroupModel> = [];
+
+  /**
+   * Template will eventually add controls to this group.
+   */
+  propertiesFormGroup: FormGroup;
+
+  private groupPropertiesSources: GroupPropertiesSources;
+
+  /**
+   * Collapse states for groups are kept here.
+   * i.e. {my.group1: true, my.group2: false}
+   */
+  state: any = {};
+
+  constructor(private bsModalRef: BsModalRef
+  ) {
+    this.propertiesFormGroup = new FormGroup({});
+  }
+
+  handleOk() {
+    const properties: Properties.Property[] = [];
+    this.propertiesGroupModels.forEach(p => {
+      p.getControlsModels().forEach(cm => {
+        properties.push(cm.property);
+      });
+    });
+    this.groupPropertiesSources.applyChanges(properties);
+    this.bsModalRef.hide();
+  }
+
+  handleCancel() {
+    this.bsModalRef.hide();
+  }
+
+  collapse(id: string) {
+    // Collapse already open group, otherwise keep selected
+    // group open and close others.
+    Object.entries(this.state).forEach(e => {
+      if (e[0] === id && e[1]) {
+        this.state[e[0]] = false;
+      } else {
+        this.state[e[0]] = (e[0] === id);
+      }
+    });
+  }
+
+  get okDisabled() {
+    return !(this.propertiesGroupModels.length > 0)
+      || !this.propertiesFormGroup
+      || this.propertiesFormGroup.invalid
+      || !this.propertiesFormGroup.dirty;
+  }
+
+  ngOnInit() {
+  }
+
+  setData(groupPropertiesSources: GroupPropertiesSources) {
+    let first = true;
+    groupPropertiesSources.propertiesSources.forEach(ps => {
+      this.state[ps.title] = first;
+      first = false;
+      const model: GroupPropertiesGroupModel = new GroupPropertiesGroupModel(ps, ps.title);
+      model.load();
+      model.loadedSubject.subscribe();
+      this.propertiesGroupModels.push(model);
+    });
+    this.groupPropertiesSources = groupPropertiesSources;
+  }
+}

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -19,6 +19,7 @@ import { FloModule } from 'spring-flo';
 import { HandleComponent } from './flo/handle/handle.component';
 import { DecorationComponent } from './flo/decoration/decoration.component';
 import { PropertiesDialogComponent } from './flo/properties/properties-dialog.component';
+import { PropertiesGroupsDialogComponent } from './flo/properties-groups/properties-groups-dialog.component';
 import { GraphViewComponent } from './flo/graph-view/graph-view.component';
 import { SharedAboutService } from './services/shared-about.service';
 import { MasterCheckboxComponent } from './components/master-checkbox.component';
@@ -101,6 +102,7 @@ import { BlockerService } from './components/blocker/blocker.service';
     DecorationComponent,
     HandleComponent,
     PropertiesDialogComponent,
+    PropertiesGroupsDialogComponent,
     GraphViewComponent,
     StreamDslComponent,
     TruncatePipe,
@@ -156,6 +158,7 @@ import { BlockerService } from './components/blocker/blocker.service';
     SortComponent,
     HandleComponent,
     PropertiesDialogComponent,
+    PropertiesGroupsDialogComponent,
     GraphViewComponent,
     TruncatePipe,
     TruncatorComponent,

--- a/ui/src/app/streams/streams.module.ts
+++ b/ui/src/app/streams/streams.module.ts
@@ -42,6 +42,7 @@ import { StreamsUndeployComponent } from './streams-undeploy/streams-undeploy.co
 import { StreamsDestroyComponent } from './streams-destroy/streams-destroy.component';
 import { StreamHistoryComponent } from './stream/history/stream-history.component';
 import { StreamHistoryStatusComponent } from './components/stream-history-status/stream-status.component';
+import { PropertiesGroupsDialogComponent } from '../shared/flo/properties-groups/properties-groups-dialog.component';
 
 @NgModule({
   imports: [
@@ -97,6 +98,7 @@ import { StreamHistoryStatusComponent } from './components/stream-history-status
     MessageRateComponent,
     StreamsUndeployComponent,
     StreamDeployAppPropertiesComponent,
+    PropertiesGroupsDialogComponent,
     StreamsDestroyComponent
   ],
   providers: [


### PR DESCRIPTION
- Add new PropertiesGroupsDialogComponent which is more
  opinionated towards showing bigger list of properties.
- Deployment properties are grouped together by group id,
  and groups are sorted to get main group first.
- Dialog will collapse first group and after that one group
  is usually kept open unless user closes already open group.
- Fixes #1174

Result is something like this:
![Screenshot from 2019-04-12 08-06-15](https://user-images.githubusercontent.com/50398/56018461-1aa34d80-5cfa-11e9-9ef8-c7f54a9fc6db.png)
