### PR TITLE
Fix blockerService usage for errors

### DIFF
--- a/ui/src/app/apps/apps-add/properties/apps-bulk-import-properties.component.ts
+++ b/ui/src/app/apps/apps-add/properties/apps-bulk-import-properties.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { AppsService } from '../../apps.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { BulkImportParams } from '../../components/apps.interface';
@@ -114,15 +114,13 @@ export class AppsBulkImportPropertiesComponent implements OnDestroy {
         this.form.get('properties').value.toString()
       );
       this.appsService.bulkImportApps(reqImportBulkApps)
-        .pipe(takeUntil(this.ngUnsubscribe$))
+        .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(() => {
           this.notificationService.success('Apps Imported.');
           this.router.navigate(['apps']);
         }, () => {
           this.notificationService.error('An error occurred while importing Apps. ' +
             'Please check the server logs for more details.');
-        }, () => {
-          this.blockerService.unlock();
         });
     }
   }

--- a/ui/src/app/apps/apps-add/register/apps-register.component.ts
+++ b/ui/src/app/apps/apps-add/register/apps-register.component.ts
@@ -3,7 +3,7 @@ import { Subscription, Subject } from 'rxjs';
 import { Router } from '@angular/router';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { AppsRegisterValidator } from './apps-register.validator';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { ApplicationType } from '../../../shared/model/application-type';
 import { AppsService } from '../../apps.service';
 import { NotificationService } from '../../../shared/services/notification.service';
@@ -108,7 +108,7 @@ export class AppsRegisterComponent implements OnInit, OnDestroy {
       }).filter((a) => a != null);
       this.blockerService.lock();
       this.appsService.registerApps(applications)
-        .pipe(takeUntil(this.ngUnsubscribe$))
+        .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(
           data => {
             this.notificationService.success(`${data.length} App(s) registered.`);
@@ -116,8 +116,6 @@ export class AppsRegisterComponent implements OnInit, OnDestroy {
           },
           error => {
             this.notificationService.error(AppError.is(error) ? error.getMessage() : error);
-          }, () => {
-            this.blockerService.unlock();
           }
         );
     }

--- a/ui/src/app/apps/apps-add/uri/apps-bulk-import-uri.component.ts
+++ b/ui/src/app/apps/apps-add/uri/apps-bulk-import-uri.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Subscription, Subject } from 'rxjs';
 import { Router } from '@angular/router';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { AppsService } from '../../apps.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { AppsAddValidator } from '../apps-add.validator';
@@ -80,14 +80,12 @@ export class AppsBulkImportUriComponent implements OnDestroy {
         force: this.form.get('force').value,
         properties: null,
         uri: this.form.get('uri').value.toString()
-      }).pipe(takeUntil(this.ngUnsubscribe$))
+      }).pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(data => {
           this.notificationService.success('Apps Imported.');
           this.router.navigate(['apps']);
         }, (error) => {
           this.notificationService.error(AppError.is(error) ? error.getMessage() : error);
-        }, () => {
-          this.blockerService.unlock();
         });
     }
   }

--- a/ui/src/app/apps/apps-unregister/apps-unregister.component.ts
+++ b/ui/src/app/apps/apps-unregister/apps-unregister.component.ts
@@ -6,6 +6,7 @@ import { NotificationService } from '../../shared/services/notification.service'
 import { LoggerService } from '../../shared/services/logger.service';
 import { AppError } from '../../shared/model/error.model';
 import { BlockerService } from '../../shared/components/blocker/blocker.service';
+import { finalize } from 'rxjs/operators';
 
 /**
  * Applications Unregister modal
@@ -64,7 +65,7 @@ export class AppsUnregisterComponent {
   unregister() {
     this.loggerService.log(`Proceeding to unregister ${this.applications.length} application(s).`, this.applications);
     this.blockerService.lock();
-    this.appsService.unregisterApps(this.applications).subscribe(
+    this.appsService.unregisterApps(this.applications).pipe(finalize(() => this.blockerService.unlock())).subscribe(
       data => {
         if (data.length === 1) {
           this.notificationService.success('Successfully removed app "'
@@ -77,8 +78,6 @@ export class AppsUnregisterComponent {
       }, error => {
         this.notificationService.error(AppError.is(error) ? error.getMessage() : error);
         this.close();
-      }, () => {
-        this.blockerService.unlock();
       });
   }
 

--- a/ui/src/app/streams/stream-create/create-dialog/create-dialog.component.ts
+++ b/ui/src/app/streams/stream-create/create-dialog/create-dialog.component.ts
@@ -8,7 +8,7 @@ import { StreamsService } from '../../streams.service';
 import { Properties } from 'spring-flo';
 import { Router } from '@angular/router';
 import { SharedAboutService } from '../../../shared/services/shared-about.service';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { Modal } from '../../../shared/components/modal/modal-abstract';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { LoggerService } from '../../../shared/services/logger.service';
@@ -347,7 +347,7 @@ export class StreamCreateDialogComponent extends Modal implements OnInit, OnDest
       const def = this.streamDefs[index];
       this.blockerService.lock();
       this.streamService.createDefinition(def.name, def.def, false)
-        .pipe(takeUntil(this.ngUnsubscribe$))
+        .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(() => {
           this.loggerService.log('Stream ' + def.name + ' created OK');
           // Stream created successfully, mark it as created
@@ -360,7 +360,6 @@ export class StreamCreateDialogComponent extends Modal implements OnInit, OnDest
             setTimeout(() => {
               this.bsModalRef.hide();
               this.notificationService.success('Stream(s) have been created successfully');
-              this.blockerService.unlock();
             }, PROGRESS_BAR_WAIT_TIME);
             this.router.navigate(['streams']);
           } else {
@@ -388,7 +387,6 @@ export class StreamCreateDialogComponent extends Modal implements OnInit, OnDest
           } else {
             this.notificationService.error(`Failed to create stream '${def.name}'`);
           }
-          this.blockerService.unlock();
         });
     }
   }

--- a/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
+++ b/ui/src/app/streams/stream-deploy/stream-deploy.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Observable, Subject, EMPTY, of } from 'rxjs';
-import { catchError, map, mergeMap, takeUntil } from 'rxjs/operators';
+import { catchError, finalize, map, mergeMap, takeUntil } from 'rxjs/operators';
 import { saveAs } from 'file-saver/FileSaver';
 import { SharedAboutService } from '../../shared/services/shared-about.service';
 import { StreamsService } from '../streams.service';
@@ -251,7 +251,7 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
       obs = obs.pipe(mergeMap(val => this.streamsService.deployDefinition(this.refConfig.id, propertiesMap)));
     }
     this.blockerService.lock();
-    obs.pipe(takeUntil(this.ngUnsubscribe$))
+    obs.pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
       .subscribe(data => {
           if (isDeployed) {
             this.notificationService.success(`Successfully updated stream definition "${this.refConfig.id}"`);
@@ -263,8 +263,6 @@ export class StreamDeployComponent implements OnInit, OnDestroy {
         error => {
           const err = error.message ? error.message : error.toString();
           this.notificationService.error(err ? err : 'An error occurred during the stream deployment update.');
-        }, () => {
-          this.blockerService.unlock();
         }
       );
   }

--- a/ui/src/app/streams/streams-destroy/streams-destroy.component.ts
+++ b/ui/src/app/streams/streams-destroy/streams-destroy.component.ts
@@ -4,7 +4,7 @@ import { StreamDefinition } from '../model/stream-definition';
 import { StreamsService } from '../streams.service';
 import { Modal } from '../../shared/components/modal/modal-abstract';
 import { Observable, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { NotificationService } from '../../shared/services/notification.service';
 import { LoggerService } from '../../shared/services/logger.service';
 import { BlockerService } from '../../shared/components/blocker/blocker.service';
@@ -62,7 +62,7 @@ export class StreamsDestroyComponent extends Modal implements OnDestroy {
     this.loggerService.log(`Proceeding to destroy ${this.streamDefinitions.length} stream definition(s).`, this.streamDefinitions);
     this.blockerService.lock();
     this.streamsService.destroyMultipleStreamDefinitions(this.streamDefinitions)
-      .pipe(takeUntil(this.ngUnsubscribe$))
+      .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
       .subscribe((data) => {
         let successMessgage: string;
         if (data.length > 1) {
@@ -79,8 +79,6 @@ export class StreamsDestroyComponent extends Modal implements OnDestroy {
           'Please check the server logs for more details.');
         this.confirm.emit('done');
         this.cancel();
-      }, () => {
-        this.blockerService.unlock();
       });
   }
 

--- a/ui/src/app/streams/streams-undeploy/streams-undeploy.component.ts
+++ b/ui/src/app/streams/streams-undeploy/streams-undeploy.component.ts
@@ -4,7 +4,7 @@ import { StreamDefinition } from '../model/stream-definition';
 import { StreamsService } from '../streams.service';
 import { Modal } from '../../shared/components/modal/modal-abstract';
 import { Observable, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { NotificationService } from '../../shared/services/notification.service';
 import { LoggerService } from '../../shared/services/logger.service';
 import { BlockerService } from '../../shared/components/blocker/blocker.service';
@@ -60,7 +60,7 @@ export class StreamsUndeployComponent extends Modal implements OnDestroy {
     this.blockerService.lock();
     this.streamsService
       .undeployMultipleStreamDefinitions(this.streamDefinitions)
-      .pipe(takeUntil(this.ngUnsubscribe$))
+      .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
       .subscribe((data) => {
         this.notificationService.success(`${data.length} stream definition(s) undeploy.`);
         this.confirm.emit('done');
@@ -70,8 +70,6 @@ export class StreamsUndeployComponent extends Modal implements OnDestroy {
           'Please check the server logs for more details.');
         this.confirm.emit('done');
         this.cancel();
-      }, () => {
-        this.blockerService.unlock();
       });
   }
 

--- a/ui/src/app/streams/streams/streams.component.ts
+++ b/ui/src/app/streams/streams/streams.component.ts
@@ -11,7 +11,7 @@ import { StreamsUndeployComponent } from '../streams-undeploy/streams-undeploy.c
 import { StreamsDestroyComponent } from '../streams-destroy/streams-destroy.component';
 import { SortParams, OrderParams, ListDefaultParams } from '../../shared/components/shared.interface';
 import { StreamListParams } from '../components/streams.interface';
-import { mergeMap, takeUntil, map } from 'rxjs/operators';
+import { mergeMap, takeUntil, map, finalize } from 'rxjs/operators';
 import { AppsService } from '../../apps/apps.service';
 import { AppRegistration } from '../../shared/model/app-registration.model';
 import { NotificationService } from '../../shared/services/notification.service';
@@ -535,14 +535,12 @@ export class StreamsComponent implements OnInit, OnDestroy {
     this.blockerService.lock();
     this.streamsService
       .undeployDefinition(item)
-      .pipe(takeUntil(this.ngUnsubscribe$))
+      .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
       .subscribe(data => {
         this.notificationService.success(`Successfully undeployed stream definition "${item.name}"`);
       }, () => {
         this.notificationService.error('An error occurred while undeploying Stream. ' +
           'Please check the server logs for more details.');
-      }, () => {
-        this.blockerService.unlock();
       });
   }
 

--- a/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.ts
+++ b/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { TasksService } from '../../tasks.service';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { LoggerService } from '../../../shared/services/logger.service';
@@ -107,7 +107,7 @@ export class TaskDefinitionCreateDialogComponent implements OnInit, OnDestroy {
     } else {
       this.blockerService.lock();
       this.tasksService.createDefinition({ name: this.taskName.value, definition: this.dsl })
-        .pipe(takeUntil(this.ngUnsubscribe$))
+        .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(
           () => {
             this.loggerService.log('Succesfully created task', this.taskName.value, this.dsl);
@@ -120,8 +120,6 @@ export class TaskDefinitionCreateDialogComponent implements OnInit, OnDestroy {
           (error) => {
             this.notificationService.error(AppError.is(error) ? error.getMessage() : error);
             this.bsModalRef.hide();
-          }, () => {
-            this.blockerService.unlock();
           }
         );
     }

--- a/ui/src/app/tasks/task-definitions-destroy/task-definitions-destroy.component.ts
+++ b/ui/src/app/tasks/task-definitions-destroy/task-definitions-destroy.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, OnDestroy } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap';
 import { Modal } from '../../shared/components/modal/modal-abstract';
 import { Observable, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { TaskDefinition } from '../model/task-definition';
 import { TasksService } from '../tasks.service';
 import { NotificationService } from '../../shared/services/notification.service';
@@ -68,7 +68,7 @@ export class TaskDefinitionsDestroyComponent extends Modal implements OnDestroy 
     this.loggerService.log(`Proceeding to destroy ${this.taskDefinitions.length} task definition(s).`, this.taskDefinitions);
     this.blockerService.lock();
     this.tasksService.destroyDefinitions(this.taskDefinitions)
-      .pipe(takeUntil(this.ngUnsubscribe$))
+      .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
       .subscribe((data) => {
         this.notificationService.success(`${data.length} task definition(s) destroyed.`);
         this.confirm.emit('done');
@@ -78,8 +78,6 @@ export class TaskDefinitionsDestroyComponent extends Modal implements OnDestroy 
           'Please check the server logs for more details.');
         this.confirm.emit('done');
         this.cancel();
-      }, () => {
-        this.blockerService.unlock();
       });
   }
 

--- a/ui/src/app/tasks/task-schedule-create/task-schedule-create.component.ts
+++ b/ui/src/app/tasks/task-schedule-create/task-schedule-create.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { RoutingStateService } from '../../shared/services/routing-state.service';
 import { Observable, EMPTY, Subject, of, throwError } from 'rxjs';
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { catchError, map, mergeMap, takeUntil } from 'rxjs/operators';
+import { catchError, finalize, map, mergeMap, takeUntil } from 'rxjs/operators';
 import { TasksService } from '../tasks.service';
 import { FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
 import { TaskScheduleCreateValidator } from './task-schedule-create.validator';
@@ -183,7 +183,7 @@ export class TaskScheduleCreateComponent implements OnInit {
 
       this.blockerService.lock();
       this.tasksService.createSchedules(scheduleParams)
-        .pipe(takeUntil(this.ngUnsubscribe$))
+        .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(
           data => {
             if (scheduleParams.length === 1) {
@@ -195,8 +195,6 @@ export class TaskScheduleCreateComponent implements OnInit {
           },
           error => {
             this.notificationService.error(AppError.is(error) ? error.getMessage() : error);
-          }, () => {
-            this.blockerService.unlock();
           }
         );
     }

--- a/ui/src/app/tasks/task-schedules-destroy/task-schedules-destroy.component.ts
+++ b/ui/src/app/tasks/task-schedules-destroy/task-schedules-destroy.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, OnDestroy } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap';
 import { Modal } from '../../shared/components/modal/modal-abstract';
 import { Observable, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { TasksService } from '../tasks.service';
 import { NotificationService } from '../../shared/services/notification.service';
 import { LoggerService } from '../../shared/services/logger.service';
@@ -67,7 +67,7 @@ export class TaskSchedulesDestroyComponent extends Modal implements OnDestroy {
     this.loggerService.log(`Proceeding to delete ${this.taskSchedules.length} task schedule(s).`, this.taskSchedules);
     this.blockerService.lock();
     this.tasksService.destroySchedules(this.taskSchedules)
-      .pipe(takeUntil(this.ngUnsubscribe$))
+      .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
       .subscribe((data) => {
         this.notificationService.success(`${data.length} task schedule(s) deleted.`);
         this.confirm.emit('done');
@@ -77,8 +77,6 @@ export class TaskSchedulesDestroyComponent extends Modal implements OnDestroy {
           'Please check the server logs for more details.');
         this.confirm.emit('done');
         this.cancel();
-      }, () => {
-        this.blockerService.unlock();
       });
   }
 


### PR DESCRIPTION
- We've used combination of error or complete to unlock
  BlockerService where unlock really needs to happen on
  both stages as error and complete are terminating. Move
  unblock calls to pipeline with finalize.
- This same logic is done to all use of BlockerService.
- Fixes #1176