### PR TITLE
Fix property filtering check in stream deploy

### DIFF
--- a/ui/src/app/streams/stream-deploy/builder/builder.component.spec.ts
+++ b/ui/src/app/streams/stream-deploy/builder/builder.component.spec.ts
@@ -102,6 +102,39 @@ describe('StreamDeployBuilderComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('Get properties', () => {
+
+    it('deployment should have correct values', () => {
+      const builderDeploymentProperties  = {
+        global: [
+          {id: 'mock.my-string', defaultValue: 'foo', value: 'bar'},
+          {id: 'mock.my-boolean', defaultValue: true, value: false}
+        ],
+        apps: {}
+      };
+      const ret = component.getDeploymentProperties(builderDeploymentProperties);
+      expect(ret.length).toBe(2);
+      expect(ret[0].key).toBe('mock.my-string');
+      expect(ret[0].value).toBe('bar');
+      expect(ret[1].key).toBe('mock.my-boolean');
+      expect(ret[1].value).toBe(false);
+    });
+
+    it('apps should have correct values', () => {
+      const builderAppsProperties  = {
+        fake: [
+          {id: 'mock.my-string', defaultValue: 'foo', value: 'bar'},
+          {id: 'mock.my-boolean', defaultValue: true, value: false}
+        ]
+      };
+      const ret = component.getAppProperties(builderAppsProperties, 'fake');
+      expect(ret.length).toBe(2);
+      expect(ret[0].key).toBe('mock.my-string');
+      expect(ret[0].value).toBe('bar');
+      expect(ret[1].key).toBe('mock.my-boolean');
+      expect(ret[1].value).toBe(false);
+    });
+  });
 
   describe('Form values', () => {
 

--- a/ui/src/app/streams/stream-deploy/builder/builder.component.ts
+++ b/ui/src/app/streams/stream-deploy/builder/builder.component.ts
@@ -625,14 +625,14 @@ export class StreamDeployBuilderComponent implements OnInit, OnDestroy {
    * @param {string} appId
    * @returns {Array}
    */
-  getDeploymentProperties(builderDeploymentProperties: {global: [], apps: {}}, appId?: string): Array<{ key: string, value: string }> {
+  getDeploymentProperties(builderDeploymentProperties: {global: any[], apps: any}, appId?: string): Array<{ key: string, value: any }> {
     const deploymentProperties = appId ? builderDeploymentProperties.apps[appId] : builderDeploymentProperties.global;
     if (!deploymentProperties) {
       return [];
     }
 
     return deploymentProperties.map((property: Properties.Property) => {
-      if (property.value && property.value !== undefined && property.value.toString() !== ''
+      if (property.value !== null && property.value !== undefined && property.value.toString() !== ''
         && property.value !== property.defaultValue) {
         return {
           key: `${property.id}`,
@@ -704,13 +704,13 @@ export class StreamDeployBuilderComponent implements OnInit, OnDestroy {
    * @param {string} appId
    * @returns {Array}
    */
-  getAppProperties(builderAppsProperties: {}, appId: string): Array<{ key: string, value: string }> {
+  getAppProperties(builderAppsProperties: {}, appId: string): Array<{ key: string, value: any }> {
     const appProperties = builderAppsProperties[appId];
     if (!appProperties) {
       return [];
     }
     return appProperties.map((property: Properties.Property) => {
-      if (property.value && property.value !== undefined && property.value.toString() !== ''
+      if (property.value !== null && property.value !== undefined && property.value.toString() !== ''
         && property.value !== property.defaultValue) {
         if (property.id.startsWith(`${appId}.`)) {
           return {


### PR DESCRIPTION
- Fix case where property value is actually boolean and
  its default value true and then setting it to false.
  Now simply doing using `property.value !== null` instead of
  `property.value` which would naturally might be false with a boolean type.
- Added test for these two functions getDeploymentProperties and getAppProperties.
- Fixes #1191