### PR TITLE
Add description to stream and task definition

### DIFF
--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
@@ -63,7 +63,7 @@ describe('StreamGraphDefinitionComponent', () => {
   });
 
   it('check stream in the view', (done) => {
-    component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'deployed');
+    component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'demo description', 'deployed');
     const subscription = component.flo.textToGraphConversionObservable.subscribe(() => {
       subscription.unsubscribe();
       expect(component.flo.getGraph().getElements().length).toEqual(3);
@@ -75,7 +75,7 @@ describe('StreamGraphDefinitionComponent', () => {
   });
 
   it('verify dots in the view', (done) => {
-    component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'deployed');
+    component.stream = new StreamDefinition('test-stream', 'http | filter | null', 'demo description', 'deployed');
 
     const httpMetrics = createStreamStatus('source', 'http', 2);
     const filterMetrics = createStreamStatus('processor', 'filter', 40);

--- a/ui/src/app/streams/model/stream-definition.spec.ts
+++ b/ui/src/app/streams/model/stream-definition.spec.ts
@@ -10,10 +10,11 @@ describe('StreamsDefinition', () => {
 
   describe('basicValidationCheck', () => {
     it('Constructor should setup stream definition properly and expand toggle work correctly.', () => {
-      const streamDefinition = new StreamDefinition('foo', 'bar', 'baz');
+      const streamDefinition = new StreamDefinition('foo', 'bar', 'demo-description', 'baz');
       expect(streamDefinition.name).toBe('foo');
       expect(streamDefinition.dslText).toBe('bar');
       expect(streamDefinition.status).toBe('baz');
+      expect(streamDefinition.description).toBe('demo-description');
       expect(streamDefinition.force).toBe(false);
     });
   });

--- a/ui/src/app/streams/model/stream-definition.ts
+++ b/ui/src/app/streams/model/stream-definition.ts
@@ -13,16 +13,19 @@ export class StreamDefinition {
 
   public dslText: string;
 
+  public description: string;
+
   public status: string;
 
   public deploymentProperties: any;
 
   public force = false;
 
-  constructor(name: string, dslText: string, status: string) {
+  constructor(name: string, dslText: string, description: string, status: string) {
     this.name = name;
     this.dslText = dslText;
     this.status = status;
+    this.description = description;
   }
 
   /**
@@ -31,7 +34,7 @@ export class StreamDefinition {
    * @returns {StreamDefinition}
    */
   public static fromJSON(input): StreamDefinition {
-    const stream = new StreamDefinition(input.name, input.dslText, input.status);
+    const stream = new StreamDefinition(input.name, input.dslText, input.description, input.status);
     if (input.deploymentProperties && input.deploymentProperties.length > 0) {
       stream.deploymentProperties = JSON.parse(input.deploymentProperties);
     }

--- a/ui/src/app/streams/stream-create/create-dialog/create-dialog.component.html
+++ b/ui/src/app/streams/stream-create/create-dialog/create-dialog.component.html
@@ -26,27 +26,66 @@
             Name <em class="required">*</em>
           </label>
           <div class="col-sm-16">
-            <input [disabled]="isStreamCreationInProgress()" class="form-control input-sm" [id]="def.index.toString()"
-                   [name]="def.index.toString()" [formControlName]="def.index.toString()"
-                   type="text" placeholder="<Stream Name>" [ngModel]="def.name"
-                   [dataflowFocus]="i === 0"
-                   (ngModelChange)="changeStreamName(def.index, $event)"/>
+            <div class="input-row">
+              <input
+                    [disabled]="isStreamCreationInProgress()"
+                    class="form-control input-sm"
+                    [id]="def.index.toString()"
+                    [name]="def.index.toString()"
+                    [formControlName]="def.index.toString()"
+                    type="text"
+                    placeholder="<Stream Name>"
+                    [ngModel]="def.name"
+                    [dataflowFocus]="i === 0"
+                    (ngModelChange)="changeStreamName(def.index, $event)"
+                    maxlength="500"
+                />
+              <label>{{ def.name === undefined? 0 : def.name.length }} / 255</label>
+            </div>
             <span *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.required"
                   class="help-block validation-block">
-            Stream name is required!
-          </span>
+              Stream name is required!
+            </span>
             <span
               *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.uniqueResource"
               class="help-block validation-block">
-            Stream name is already taken!
-          </span>
+              Stream name is already taken!
+            </span>
             <span *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.pattern"
                   class="help-block validation-block">
-            Invalid stream name!
-          </span>
+              Invalid stream name!
+            </span>
             <span *ngIf="hasDuplicateName(def)" class="help-block validation-block">
-            Duplicate stream name on the form
-          </span>
+              Duplicate stream name on the form
+            </span>
+            <span *ngIf="getControl(def.index.toString()).errors && getControl(def.index.toString()).errors.maxlength"
+            class="help-block validation-block">
+              Stream name must be less than 255 characters long!
+            </span>
+          </div>
+        </div>
+        <div class="form-group" [class.has-error]="getControl(def.index.toString()+'_desc').invalid">
+          <label [for]="def.index.toString()+'_desc'" class="control-label col-sm-4">Description</label>
+          <div class="col-sm-16">
+            <div class="control-empty input-row">
+              <input
+                    [id]="def.index.toString()+'_desc'"
+                    [name]="def.index.toString()+'_desc'"
+                    [formControlName]="def.index.toString()+'_desc'"
+                    [disabled]="isStreamCreationInProgress()"
+                    class="form-control input-sm"
+                    [ngModel]="def.description"
+                    (ngModelChange)="changeStreamDescription(def.index, $event)"
+                    placeholder="<Stream Description>"
+                    type="text"
+                    maxlength="500"
+              >
+              <label>{{ def.description === undefined? 0 : def.description.length }} / 255</label>
+            </div>
+            <span *ngIf="getControl(def.index.toString()+'_desc').errors && getControl(def.index.toString()+'_desc').errors.maxlength"
+            class="help-block validation-block">
+              Stream description must be less than 255 characters long!
+            </span>
           </div>
         </div>
       </div>

--- a/ui/src/app/streams/stream-create/create-dialog/styles.scss
+++ b/ui/src/app/streams/stream-create/create-dialog/styles.scss
@@ -24,3 +24,17 @@
     font-weight: bold;
   }
 }
+
+.input-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+
+  .input-sm {
+    width: 84%;
+  }
+
+  label {
+    font-size: 12px
+  }
+}

--- a/ui/src/app/streams/stream/summary/stream-summary.component.html
+++ b/ui/src/app/streams/stream/summary/stream-summary.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="stream$ | async as stream; else loading">
 
   <div dataflowLayoutType type="large">
-    <div class="row stream-summary-row">
+    <div *ngIf="stream.streamDefinition.description.length > 0" class="row stream-summary-row">
       <div class="col-md-3">
         <strong>Description:</strong>
       </div>

--- a/ui/src/app/streams/stream/summary/stream-summary.component.html
+++ b/ui/src/app/streams/stream/summary/stream-summary.component.html
@@ -3,6 +3,14 @@
   <div dataflowLayoutType type="large">
     <div class="row stream-summary-row">
       <div class="col-md-3">
+        <strong>Description:</strong>
+      </div>
+      <div class="col-md-21">
+          {{ stream.streamDefinition.description }}
+      </div>
+    </div>
+    <div class="row stream-summary-row">
+      <div class="col-md-3">
         <strong>Definition:</strong>
       </div>
       <div class="col-md-21">

--- a/ui/src/app/streams/stream/summary/stream-summary.component.spec.ts
+++ b/ui/src/app/streams/stream/summary/stream-summary.component.spec.ts
@@ -37,7 +37,6 @@ describe('StreamSummaryComponent', () => {
   const notificationService = new MockNotificationService();
   const modalService = new MockModalService();
   const authService = new MockAuthService();
-  const aboutService = new MocksSharedAboutService();
   const loggerService = new LoggerService();
 
   beforeEach(async(() => {
@@ -61,7 +60,6 @@ describe('StreamSummaryComponent', () => {
         { provide: StreamsService, useValue: streamsService },
         { provide: ActivatedRoute, useValue: activeRoute },
         { provide: BsModalService, useValue: modalService },
-        { provide: SharedAboutService, useValue: aboutService },
         { provide: AuthService, useValue: authService },
         { provide: NotificationService, useValue: notificationService },
         { provide: LoggerService, useValue: loggerService }

--- a/ui/src/app/streams/streams-deploy/streams-deploy.component.spec.ts
+++ b/ui/src/app/streams/streams-deploy/streams-deploy.component.spec.ts
@@ -74,8 +74,8 @@ describe('StreamsDeployComponent', () => {
   it('should display the stream definitions', () => {
     component.open({
       streamDefinitions: [
-        new StreamDefinition('foo', 'foo', 'foo'),
-        new StreamDefinition('bar', 'bar', 'bar'),
+        new StreamDefinition('foo', 'foo', 'demo-description', 'foo'),
+        new StreamDefinition('bar', 'bar', 'demo-description', 'bar'),
       ]
     });
     fixture.detectChanges();
@@ -88,7 +88,7 @@ describe('StreamsDeployComponent', () => {
   it('should display the parameter form when you click Edit deployment parameters', () => {
     component.open({
       streamDefinitions: [
-        new StreamDefinition('foo', 'foo', 'foo'),
+        new StreamDefinition('foo', 'foo', 'demo-description', 'foo'),
       ]
     });
     fixture.detectChanges();
@@ -104,8 +104,8 @@ describe('StreamsDeployComponent', () => {
   it('Should call the right Stream Service method when the multi deploy modal is validated', () => {
     component.open({
       streamDefinitions: [
-        new StreamDefinition('foo', 'foo', 'foo'),
-        new StreamDefinition('bar', 'bar', 'bar'),
+        new StreamDefinition('foo', 'foo', 'demo-description', 'foo'),
+        new StreamDefinition('bar', 'bar', 'demo-description', 'bar'),
       ]
     });
     fixture.detectChanges();
@@ -119,8 +119,8 @@ describe('StreamsDeployComponent', () => {
   it('Should call the close action (header close)', () => {
     component.open({
       streamDefinitions: [
-        new StreamDefinition('foo', 'foo', 'foo'),
-        new StreamDefinition('bar', 'bar', 'bar'),
+        new StreamDefinition('foo', 'foo', 'demo-description', 'foo'),
+        new StreamDefinition('bar', 'bar', 'demo-description', 'bar'),
       ]
     });
     fixture.detectChanges();
@@ -134,8 +134,8 @@ describe('StreamsDeployComponent', () => {
   it('Should call the close action (footer close)', () => {
     component.open({
       streamDefinitions: [
-        new StreamDefinition('foo', 'foo', 'foo'),
-        new StreamDefinition('bar', 'bar', 'bar'),
+        new StreamDefinition('foo', 'foo', 'demo-description', 'foo'),
+        new StreamDefinition('bar', 'bar', 'demo-description', 'bar'),
       ]
     });
     fixture.detectChanges();

--- a/ui/src/app/streams/streams-destroy/streams-destroy.component.spec.ts
+++ b/ui/src/app/streams/streams-destroy/streams-destroy.component.spec.ts
@@ -68,7 +68,7 @@ describe('StreamsDestroyComponent', () => {
   describe('1 stream destroy', () => {
 
     const mock = [
-      new StreamDefinition('foo0', 'foo1|foo2', 'undeployed')
+      new StreamDefinition('foo0', 'foo1|foo2', 'demo-description', 'undeployed')
     ];
 
     beforeEach(() => {
@@ -109,8 +109,8 @@ describe('StreamsDestroyComponent', () => {
   describe('Multiple streams destroy', () => {
 
     const mock = [
-      new StreamDefinition('foo0', 'foo1|foo2', 'undeployed'),
-      new StreamDefinition('bar0', 'bar1|bar2', 'deployed')
+      new StreamDefinition('foo0', 'foo1|foo2', 'demo-description', 'undeployed'),
+      new StreamDefinition('bar0', 'bar1|bar2', 'demo-description', 'deployed')
     ];
 
     beforeEach(() => {
@@ -158,8 +158,8 @@ describe('StreamsDestroyComponent', () => {
     beforeEach(() => {
       component.open({
         streamDefinitions: [
-          new StreamDefinition('foo', 'time|log', 'undeployed'),
-          new StreamDefinition('bar', 'time|log', 'undeployed')
+          new StreamDefinition('foo', 'time|log', 'demo-description', 'undeployed'),
+          new StreamDefinition('bar', 'time|log', 'demo-description', 'undeployed')
         ]
       });
       fixture.detectChanges();

--- a/ui/src/app/streams/streams-undeploy/streams-undeploy.component.spec.ts
+++ b/ui/src/app/streams/streams-undeploy/streams-undeploy.component.spec.ts
@@ -68,7 +68,7 @@ describe('StreamsUndeployComponent', () => {
   describe('1 stream undeploy', () => {
 
     const mock = [
-      new StreamDefinition('foo0', 'foo1|foo2', 'undeployed')
+      new StreamDefinition('foo0', 'foo1|foo2', 'demo-description', 'undeployed')
     ];
 
     beforeEach(() => {
@@ -109,8 +109,8 @@ describe('StreamsUndeployComponent', () => {
   describe('Multiple streams undeploy', () => {
 
     const mock = [
-      new StreamDefinition('foo0', 'foo1|foo2', 'undeployed'),
-      new StreamDefinition('bar0', 'bar1|bar2', 'deployed')
+      new StreamDefinition('foo0', 'foo1|foo2', 'demo-description', 'undeployed'),
+      new StreamDefinition('bar0', 'bar1|bar2', 'demo-description', 'deployed')
     ];
 
     beforeEach(() => {
@@ -158,8 +158,8 @@ describe('StreamsUndeployComponent', () => {
     beforeEach(() => {
       component.open({
         streamDefinitions: [
-          new StreamDefinition('foo', 'time|log', 'undeployed'),
-          new StreamDefinition('bar', 'time|log', 'undeployed')
+          new StreamDefinition('foo', 'time|log', 'demo-description', 'undeployed'),
+          new StreamDefinition('bar', 'time|log', 'demo-description', 'undeployed')
         ]
       });
       fixture.detectChanges();

--- a/ui/src/app/streams/streams.service.spec.ts
+++ b/ui/src/app/streams/streams.service.spec.ts
@@ -134,23 +134,25 @@ describe('StreamsService', () => {
 
     it('should call the create and deploy definition with the right url/params', () => {
       this.mockHttp.post.and.returnValue(of({}));
-      this.streamsService.createDefinition('foobar', 'foo | bar', true);
+      this.streamsService.createDefinition('foobar', 'foo | bar', 'demo-description', true);
       const httpUri = this.mockHttp.post.calls.mostRecent().args[0];
       const httpParams = this.mockHttp.post.calls.mostRecent().args[2].params;
       expect(httpUri).toEqual('/streams/definitions');
       expect(httpParams.get('name')).toEqual('foobar');
       expect(httpParams.get('definition')).toEqual('foo | bar');
+      expect(httpParams.get('description')).toEqual('demo-description');
       expect(httpParams.get('deploy')).toEqual('true');
     });
 
     it('should call the create definition with the right url/params', () => {
       this.mockHttp.post.and.returnValue(of({}));
-      this.streamsService.createDefinition('foobar', 'foo | bar', false);
+      this.streamsService.createDefinition('foobar', 'foo | bar', 'demo-description', false);
       const httpUri = this.mockHttp.post.calls.mostRecent().args[0];
       const httpParams = this.mockHttp.post.calls.mostRecent().args[2].params;
       expect(httpUri).toEqual('/streams/definitions');
       expect(httpParams.get('name')).toEqual('foobar');
       expect(httpParams.get('definition')).toEqual('foo | bar');
+      expect(httpParams.get('description')).toEqual('demo-description');
       expect(httpParams.get('deploy')).toBeNull();
     });
 
@@ -182,7 +184,7 @@ describe('StreamsService', () => {
 
       // expect(this.streamsService.streamDefinitions).toBeDefined();
 
-      const streamDefinition = new StreamDefinition('test', 'time|log', 'undeployed');
+      const streamDefinition = new StreamDefinition('test', 'time|log', 'demo-description', 'undeployed');
       this.streamsService.destroyDefinition(streamDefinition);
 
       const httpUri = this.mockHttp.delete.calls.mostRecent().args[0];
@@ -200,7 +202,7 @@ describe('StreamsService', () => {
 
       // expect(this.streamsService.streamDefinitions).toBeDefined();
 
-      const streamDefinition = new StreamDefinition('test', 'time|log', 'deployed');
+      const streamDefinition = new StreamDefinition('test', 'time|log', 'demo-description', 'deployed');
       this.streamsService.undeployDefinition(streamDefinition);
 
       const httpUri = this.mockHttp.delete.calls.mostRecent().args[0];
@@ -331,8 +333,8 @@ describe('StreamsService', () => {
       this.mockHttp.delete.and.returnValue(of(this.jsonData));
       // expect(this.streamsService.streamDefinitions).toBeDefined();
       const streamDefinitions = [
-        new StreamDefinition('stream1', 'file|filter|ftp', 'deployed'),
-        new StreamDefinition('stream2', 'ftp|filter|file', 'deployed')
+        new StreamDefinition('stream1', 'file|filter|ftp', 'demo-description', 'deployed'),
+        new StreamDefinition('stream2', 'ftp|filter|file', 'demo-description', 'deployed')
       ];
       this.streamsService.destroyMultipleStreamDefinitions(streamDefinitions);
 
@@ -356,8 +358,8 @@ describe('StreamsService', () => {
     it('should call the stream definition service with the right url to deploy multiple stream definitions', () => {
       this.mockHttp.post.and.returnValue(of(this.jsonData));
       // expect(this.streamsService.streamDefinitions).toBeDefined();
-      const stream1 = new StreamDefinition('stream1', 'file|filter|ftp', 'undeployed');
-      const stream2 = new StreamDefinition('stream2', 'file|filter|ftp', 'undeployed');
+      const stream1 = new StreamDefinition('stream1', 'file|filter|ftp', 'demo-description', 'undeployed');
+      const stream2 = new StreamDefinition('stream2', 'file|filter|ftp', 'demo-description', 'undeployed');
       stream1.deploymentProperties = { a: 'a' };
       this.streamsService.deployMultipleStreamDefinitions([stream1, stream2]);
 
@@ -386,8 +388,8 @@ describe('StreamsService', () => {
       this.mockHttp.delete.and.returnValue(of(this.jsonData));
       // expect(this.streamsService.streamDefinitions).toBeDefined();
       const streamDefinitions = [
-        new StreamDefinition('stream1', 'file|filter|ftp', 'deployed'),
-        new StreamDefinition('stream2', 'ftp|filter|file', 'deployed')
+        new StreamDefinition('stream1', 'file|filter|ftp', 'demo-description', 'deployed'),
+        new StreamDefinition('stream2', 'ftp|filter|file', 'demo-description', 'deployed')
       ];
       this.streamsService.undeployMultipleStreamDefinitions(streamDefinitions);
 

--- a/ui/src/app/streams/streams.service.ts
+++ b/ui/src/app/streams/streams.service.ts
@@ -101,14 +101,16 @@ export class StreamsService {
    * Calls the Spring Cloud Data Flow server to create a {@link StreamDefinition}.
    * @param {string} name
    * @param {string} dsl
+   * @param {string} description
    * @param {boolean} deploy
    * @returns {Observable<HttpResponse<any>>}
    */
-  createDefinition(name: string, dsl: string, deploy?: boolean): Observable<HttpResponse<any>> {
+  createDefinition(name: string, dsl: string, description: string, deploy?: boolean): Observable<HttpResponse<any>> {
     const httpHeaders = HttpUtils.getDefaultHttpHeaders();
     let params = new HttpParams({ encoder: new DataflowEncoder() })
       .append('name', name)
-      .append('definition', dsl);
+      .append('definition', dsl)
+      .append('description', description);
     if (deploy) {
       params = params.set('deploy', deploy.toString());
     }

--- a/ui/src/app/streams/streams/deployment-properties-info/deployment-properties-info.component.spec.ts
+++ b/ui/src/app/streams/streams/deployment-properties-info/deployment-properties-info.component.spec.ts
@@ -55,7 +55,7 @@ describe('DeploymentPropertiesInfoComponent', () => {
   });
 
   it('data from stream definition', (done) => {
-    const streamDef = new StreamDefinition('tick', 'time | log', 'deployed');
+    const streamDef = new StreamDefinition('tick', 'time | log', 'demo-description', 'deployed');
     streamDef.deploymentProperties = deploymentProperties;
     component.streamDefinition = streamDef;
     component.deploymentProperties.subscribe(data => {

--- a/ui/src/app/streams/streams/deployment-properties/deployment-properties.component.spec.ts
+++ b/ui/src/app/streams/streams/deployment-properties/deployment-properties.component.spec.ts
@@ -44,26 +44,26 @@ describe('DeploymentPropertiesComponent', () => {
   });
 
   it('should be created', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should populate properties input', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     component.stream.deploymentProperties = { a: 'a', b: 'b' };
     fixture.detectChanges();
     expect(component.deploymentProperties.value).toBe('a=a\nb=b');
   });
 
   it('should not populate properties input (empty)', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     fixture.detectChanges();
     expect(component.deploymentProperties.value).toBe('');
   });
 
   it('should display the platform input (skipper integration)', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     component.stream.deploymentProperties = {};
     fixture.detectChanges();
     const de: DebugElement = fixture.debugElement.query(By.css('#groupPlatform'));
@@ -74,14 +74,14 @@ describe('DeploymentPropertiesComponent', () => {
   });
 
   it('should not populate properties input (invalid data)', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     component.stream.deploymentProperties = 'aa';
     fixture.detectChanges();
     expect(component.deploymentProperties.value).toBe('');
   });
 
   it('should emit cancel event on cancel action', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     fixture.detectChanges();
     const cancelEvent = spyOn(component.cancel, 'emit');
     component.cancelDeployment();
@@ -89,7 +89,7 @@ describe('DeploymentPropertiesComponent', () => {
   });
 
   it('should update the stream definition to deploy and emit event Submit on submit', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     fixture.detectChanges();
     const submitEvent = spyOn(component.submit, 'emit');
     component.deploymentProperties.setValue('a=a');
@@ -99,7 +99,7 @@ describe('DeploymentPropertiesComponent', () => {
   });
 
   it('should update the stream definition to deploy with multiple properties and emit event Submit on submit', () => {
-    component.stream = new StreamDefinition('foo2', 'time |log', 'undeployed');
+    component.stream = new StreamDefinition('foo2', 'time |log', 'demo-description', 'undeployed');
     fixture.detectChanges();
     const submitEvent = spyOn(component.submit, 'emit');
     component.deploymentProperties.setValue('a=a\nb=c=d\ne=f');

--- a/ui/src/app/streams/streams/streams.component.html
+++ b/ui/src/app/streams/streams/streams.component.html
@@ -39,6 +39,9 @@
           <app-sort id="sort-name" (change)="applySort($event)" [value]="'name'" [sort]="params">
             Name
           </app-sort>
+          <th style="width: 150px">
+              Description
+          </th>
         <th>
           <div class="head-dsl">
 
@@ -76,6 +79,10 @@
           </td>
           <td>
             <a style="cursor:pointer" (click)="details(item)">{{ item.name }}</a>
+          </td>
+          <td>
+              {{ item.description.substring(0,20) }}
+              <a *ngIf="item.description.length >= 20" style="cursor:pointer" (click)="details(item)">...</a>
           </td>
           <td>
             <a (click)="toggleExpand(i)" class="link-expand">

--- a/ui/src/app/streams/streams/streams.component.html
+++ b/ui/src/app/streams/streams/streams.component.html
@@ -81,8 +81,8 @@
             <a style="cursor:pointer" (click)="details(item)">{{ item.name }}</a>
           </td>
           <td>
-              {{ item.description.substring(0,20) }}
-              <a *ngIf="item.description.length >= 20" style="cursor:pointer" (click)="details(item)">...</a>
+              {{ item.description.substring(0,15) }}
+              <a *ngIf="item.description.length >= 15" style="cursor:pointer" (click)="details(item)">...</a>
           </td>
           <td>
             <a (click)="toggleExpand(i)" class="link-expand">

--- a/ui/src/app/streams/streams/streams.component.spec.ts
+++ b/ui/src/app/streams/streams/streams.component.spec.ts
@@ -127,14 +127,15 @@ describe('StreamsComponent', () => {
     streamsService.streamDefinitions = STREAM_DEFINITIONS;
     fixture.detectChanges();
     const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table[id=streamDefinitionsTable] tr:first-child td'));
-    expect(des.length).toBe(5);
+    expect(des.length).toBe(6);
     expect(des[1].nativeElement.textContent).toContain('foo2');
-    expect(des[2].nativeElement.textContent).toContain('time |log');
-    expect(des[3].nativeElement.textContent).toContain('UNDEPLOYED');
+    expect(des[2].nativeElement.textContent).toContain('demo-stream');
+    expect(des[3].nativeElement.textContent).toContain('time |log');
+    expect(des[4].nativeElement.textContent).toContain('UNDEPLOYED');
   });
 
   it('can show deployment info', () => {
-    const stream = new StreamDefinition('test', 'time | log', 'unknown');
+    const stream = new StreamDefinition('test', 'time | log', 'demo-description', 'unknown');
     expect(component.canShowDeploymentInfo(stream)).toBeFalsy();
 
     stream.status = undefined;
@@ -232,6 +233,7 @@ describe('StreamsComponent', () => {
             return {
               name: `foo${i}`,
               dslText: 'time |log ',
+              description: 'demo-stream',
               status: 'undeployed',
               statusDescription: 'The app or group is known to the system, but is not currently deployed',
               force: false,

--- a/ui/src/app/tasks/components/tasks.interface.ts
+++ b/ui/src/app/tasks/components/tasks.interface.ts
@@ -17,6 +17,7 @@ export interface TaskLaunchParams {
 export interface TaskCreateParams {
   definition: string;
   name: string;
+  description: string;
 }
 
 export interface TaskScheduleCreateParams {

--- a/ui/src/app/tasks/model/task-definition.ts
+++ b/ui/src/app/tasks/model/task-definition.ts
@@ -4,21 +4,24 @@ export class TaskDefinition {
 
   public name: string;
 
+  public description: string;
+
   public dslText: string;
 
   public composed: boolean;
 
   public status: string;
 
-  constructor(name: string, dslText: string, composed: boolean, status: string) {
+  constructor(name: string, dslText: string, description: string, composed: boolean, status: string) {
     this.name = name;
     this.dslText = dslText;
     this.composed = composed;
     this.status = status;
+    this.description = description;
   }
 
   static fromJSON(input): TaskDefinition {
-    return new TaskDefinition(input.name, input.dslText, input.composed, input.status);
+    return new TaskDefinition(input.name, input.dslText, input.description, input.composed, input.status);
   }
 
   static pageFromJSON(input): Page<TaskDefinition> {

--- a/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.html
+++ b/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.html
@@ -35,13 +35,47 @@
           Name <em class="required">*</em>
         </label>
         <div class="col-sm-16">
-          <input class="form-control input-sm" id="name"
-                 name="name" formControlName="taskName"
-                 type="text" placeholder="<Task Name>"
-                 [dataflowFocus]="true"/>
-          <span *ngIf="form.controls.taskName.errors"
+          <div class="input-row">
+            <input
+                  class="form-control input-sm"
+                  id="name"
+                  name="name"
+                  formControlName="taskName"
+                  type="text"
+                  placeholder="<Task Name>"
+                  [dataflowFocus]="true"
+                  maxlength="500"/>
+            <label>{{ taskName.value.length }} / 255</label>
+          </div>
+          <span *ngIf="form.controls.taskName.errors && form.controls.taskName.errors.required"
                 class="help-block validation-block">
-            The format of your task name is invalid. {{ form.controls.taskName.errors.validateTaskName.reason }}
+            Task name is required!
+          </span>
+          <span *ngIf="form.controls.taskName.errors && form.controls.taskName.errors.maxlength"
+                class="help-block validation-block">
+            Task name must less than 255 characters!
+          </span>
+        </div>
+      </div>
+
+      <div class="form-group" [class.has-error]="form.controls.taskDescription.errors">
+        <label [for]="description" class="control-label col-sm-4 control-label-sm">Description</label>
+        <div class="col-sm-16">
+          <div class="control-empty input-row">
+            <input
+                  class="form-control input-sm"
+                  id="description"
+                  name="description"
+                  formControlName="taskDescription"
+                  type="text"
+                  placeholder="<Task Description>"
+                  [dataflowFocus]="false"
+                  maxlength="500"/>
+            <label>{{ taskDescription.value.length }} / 255</label>
+          </div>
+          <span *ngIf="form.controls.taskDescription.errors && form.controls.taskDescription.errors.maxlength"
+                class="help-block validation-block">
+            Task description must less than 255 characters!
           </span>
         </div>
       </div>

--- a/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.html
+++ b/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.html
@@ -59,7 +59,7 @@
       </div>
 
       <div class="form-group" [class.has-error]="form.controls.taskDescription.errors">
-        <label [for]="description" class="control-label col-sm-4 control-label-sm">Description</label>
+        <label [for]="form.controls.taskDescription" class="control-label col-sm-4 control-label-sm">Description</label>
         <div class="col-sm-16">
           <div class="control-empty input-row">
             <input

--- a/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.ts
+++ b/ui/src/app/tasks/task-definition-create/create-dialog/create-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap';
-import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { TasksService } from '../../tasks.service';
 import { finalize, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -48,7 +48,13 @@ export class TaskDefinitionCreateDialogComponent implements OnInit, OnDestroy {
    * The FormControl used to capture the task name.
    * @type {FormControl}
    */
-  taskName = new FormControl('', validateTaskName);
+  taskName = new FormControl('', [Validators.required, Validators.maxLength(255)]);
+
+  /**
+   * The FormControl used to check the task description length.
+   * @type {FormControl}
+   */
+  taskDescription = new FormControl('', Validators.maxLength(255))
 
   /**
    * Callback to parent which is called when task is created succesfully.
@@ -62,7 +68,8 @@ export class TaskDefinitionCreateDialogComponent implements OnInit, OnDestroy {
               private blockerService: BlockerService,
               private bsModalRef: BsModalRef) {
     this.form = fb.group({
-      'taskName': this.taskName
+      'taskName': this.taskName,
+      'taskDescription': this.taskDescription
     });
   }
 
@@ -106,7 +113,7 @@ export class TaskDefinitionCreateDialogComponent implements OnInit, OnDestroy {
       this.notificationService.error('Some field(s) are missing or invalid.');
     } else {
       this.blockerService.lock();
-      this.tasksService.createDefinition({ name: this.taskName.value, definition: this.dsl })
+      this.tasksService.createDefinition({ name: this.taskName.value, definition: this.dsl, description: this.taskDescription.value })
         .pipe(takeUntil(this.ngUnsubscribe$), finalize(() => this.blockerService.unlock()))
         .subscribe(
           () => {
@@ -134,18 +141,4 @@ export class TaskDefinitionCreateDialogComponent implements OnInit, OnDestroy {
     return this.form.valid;
   }
 
-}
-
-/**
- * Validates the task name.
- *
- * @param formControl the form that contains the task name input.
- * @returns {any} null if successful or the validateProperties message if a failure.
- */
-function validateTaskName(formControl: FormControl) {
-  if (formControl.value.length > 0) {
-    return null;
-  } else {
-    return { validateTaskName: { reason: 'Cannot be empty' } };
-  }
 }

--- a/ui/src/app/tasks/task-definition-create/create-dialog/styles.scss
+++ b/ui/src/app/tasks/task-definition-create/create-dialog/styles.scss
@@ -24,3 +24,17 @@
     font-weight: bold;
   }
 }
+
+.input-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+
+  .input-sm {
+    width: 84%;
+  }
+
+  label {
+    font-size: 12px
+  }
+}

--- a/ui/src/app/tasks/task-definition/summary/task-summary.component.html
+++ b/ui/src/app/tasks/task-definition/summary/task-summary.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="task$ | async as task; else loading">
 
   <div dataflowLayoutType type="large">
-    <div class="row task-summary-row">
+    <div *ngIf="task.taskDefinition.description.length > 0" class="row task-summary-row">
         <div class="col-md-3">
           <strong>Description:</strong>
         </div>

--- a/ui/src/app/tasks/task-definition/summary/task-summary.component.html
+++ b/ui/src/app/tasks/task-definition/summary/task-summary.component.html
@@ -2,6 +2,14 @@
 
   <div dataflowLayoutType type="large">
     <div class="row task-summary-row">
+        <div class="col-md-3">
+          <strong>Description:</strong>
+        </div>
+        <div class="col-md-21">
+          {{ task.taskDefinition.description }}
+        </div>
+    </div>
+    <div class="row task-summary-row">
       <div class="col-md-3">
         <strong>Definition:</strong>
       </div>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -19,6 +19,9 @@
             Name
           </app-sort>
         </th>
+        <th style="width: 150px">
+          Description
+        </th>
         <th>
           <div class="head-dsl">
             <app-sort id="sort-dsl" (change)="applySort($event)" [value]="'dslText'" [sort]="params">
@@ -42,6 +45,10 @@
           </td>
           <td width="200px">
             <a style="cursor:pointer" [routerLink]="'/tasks/definitions/' + item.name">{{ item.name }}</a>
+          </td>
+          <td>
+              {{ item.description.substring(0,20) }}
+              <a *ngIf="item.description.length >= 20" style="cursor:pointer" [routerLink]="'/tasks/definitions/' + item.name">...</a>
           </td>
           <td>
             <app-stream-dsl>{{ item.dslText | truncate: 120 }}</app-stream-dsl>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -47,8 +47,8 @@
             <a style="cursor:pointer" [routerLink]="'/tasks/definitions/' + item.name">{{ item.name }}</a>
           </td>
           <td>
-              {{ item.description.substring(0,20) }}
-              <a *ngIf="item.description.length >= 20" style="cursor:pointer" [routerLink]="'/tasks/definitions/' + item.name">...</a>
+              {{ item.description.substring(0,15) }}
+              <a *ngIf="item.description.length >= 15" style="cursor:pointer" [routerLink]="'/tasks/definitions/' + item.name">...</a>
           </td>
           <td>
             <app-stream-dsl>{{ item.dslText | truncate: 120 }}</app-stream-dsl>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
@@ -117,10 +117,14 @@ describe('TaskDefinitionsComponent', () => {
     tasksService.taskDefinitions = TASK_DEFINITIONS;
     fixture.detectChanges();
     const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table[id=taskDefinitionsTable] tr:first-child td'));
-    expect(des.length).toBe(5);
+    expect(des.length).toBe(6);
+
+    console.log('itt2' + des[1].nativeElement.textContent+des[2].nativeElement.textContent+des[3].nativeElement.textContent+des[4].nativeElement.textContent);
+
     expect(des[1].nativeElement.textContent).toContain('foo');
-    expect(des[2].nativeElement.textContent).toContain('bar');
-    expect(des[3].nativeElement.textContent).toContain('UNKNOWN');
+    expect(des[2].nativeElement.textContent).toContain('demo-description');
+    expect(des[3].nativeElement.textContent).toContain('bar');
+    expect(des[4].nativeElement.textContent).toContain('UNKNOWN');
   });
 
   describe('no task', () => {
@@ -196,6 +200,7 @@ describe('TaskDefinitionsComponent', () => {
             return {
               name: `foo${i}`,
               dslText: 'foo && bar ',
+              description: 'demo-description',
               status: 'unknown',
               composed: true
             };

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
@@ -118,11 +118,8 @@ describe('TaskDefinitionsComponent', () => {
     fixture.detectChanges();
     const des: DebugElement[] = fixture.debugElement.queryAll(By.css('table[id=taskDefinitionsTable] tr:first-child td'));
     expect(des.length).toBe(6);
-
-    console.log('itt2' + des[1].nativeElement.textContent+des[2].nativeElement.textContent+des[3].nativeElement.textContent+des[4].nativeElement.textContent);
-
     expect(des[1].nativeElement.textContent).toContain('foo');
-    expect(des[2].nativeElement.textContent).toContain('demo-description');
+    expect(des[2].nativeElement.textContent).toContain('demo');
     expect(des[3].nativeElement.textContent).toContain('bar');
     expect(des[4].nativeElement.textContent).toContain('UNKNOWN');
   });

--- a/ui/src/app/tasks/task-launch/task-launch.component.spec.ts
+++ b/ui/src/app/tasks/task-launch/task-launch.component.spec.ts
@@ -120,7 +120,7 @@ describe('TaskLaunchComponent', () => {
 
     it('Can select a platform', () => {
       const task = {
-        task: new TaskDefinition('foo', 'timestamp', false, 'COMPLETE'),
+        task: new TaskDefinition('foo', 'timestamp', 'demo-description', false, 'COMPLETE'),
         platforms: [
           new Platform('foo', 'foo', 'foo'),
           new Platform('bar', 'bar', 'bar'),
@@ -131,7 +131,7 @@ describe('TaskLaunchComponent', () => {
 
     it('Can not select a platform', () => {
       const task = {
-        task: new TaskDefinition('foo', 'timestamp', false, 'COMPLETE'),
+        task: new TaskDefinition('foo', 'timestamp', 'demo-description', false, 'COMPLETE'),
         platforms: [
           new Platform('foo', 'foo', 'foo')
         ]

--- a/ui/src/app/tasks/tasks.service.spec.ts
+++ b/ui/src/app/tasks/tasks.service.spec.ts
@@ -266,12 +266,13 @@ describe('TasksService', () => {
 
       it('should call the create definition with the right url/params', () => {
         this.mockHttp.post.and.returnValue(of({}));
-        this.tasksService.createDefinition({ name: 'foo', definition: 'bar && foobar' });
+        this.tasksService.createDefinition({ name: 'foo', definition: 'bar && foobar', description: 'demo-description' });
         const httpUri = this.mockHttp.post.calls.mostRecent().args[0];
         const httpParams = this.mockHttp.post.calls.mostRecent().args[2].params;
         expect(httpUri).toEqual('/tasks/definitions');
         expect(httpParams.get('name')).toEqual('foo');
         expect(httpParams.get('definition')).toEqual('bar && foobar');
+        expect(httpParams.get('description')).toEqual('demo-description');
       });
 
       it('should call the destroy definition with the right url', () => {

--- a/ui/src/app/tasks/tasks.service.ts
+++ b/ui/src/app/tasks/tasks.service.ts
@@ -278,7 +278,8 @@ export class TasksService {
     this.loggerService.log('Create task definition ' + taskCreateParams.definition + ' ' + taskCreateParams.name);
     const params = new HttpParams({ encoder: new DataflowEncoder() })
       .append('definition', taskCreateParams.definition)
-      .append('name', taskCreateParams.name);
+      .append('name', taskCreateParams.name)
+      .append('description', taskCreateParams.description)
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     return this.httpClient
       .post(TasksService.URL.DEFINITIONS, {}, { headers: headers, params: params })

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -1216,7 +1216,7 @@ export const TASK_DEFINITIONS = {
       {
         name: 'foo',
         dslText: 'bar',
-        description: 'demo-description',
+        description: 'demo',
         composed: true,
         status: 'unknown',
         _links: {
@@ -1228,7 +1228,7 @@ export const TASK_DEFINITIONS = {
       {
         name: 'bar2',
         dslText: 'task1',
-        description: 'demo-description',
+        description: 'demo',
         composed: false,
         status: 'unknown',
         _links: {

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -1172,6 +1172,7 @@ export const STREAM_DEFINITIONS = {
       {
         name: 'foo2',
         dslText: 'time |log ',
+        description: 'demo-stream',
         status: 'undeployed',
         statusDescription: 'The app or group is known to the system, but is not currently deployed',
         force: false,
@@ -1184,6 +1185,7 @@ export const STREAM_DEFINITIONS = {
       {
         name: 'foo3',
         dslText: 'time |log ',
+        description: 'demo-stream',
         status: 'undeployed',
         statusDescription: 'The app or group is known to the system, but is currently deployed',
         force: false,
@@ -1214,6 +1216,7 @@ export const TASK_DEFINITIONS = {
       {
         name: 'foo',
         dslText: 'bar',
+        description: 'demo-description',
         composed: true,
         status: 'unknown',
         _links: {
@@ -1225,6 +1228,7 @@ export const TASK_DEFINITIONS = {
       {
         name: 'bar2',
         dslText: 'task1',
+        description: 'demo-description',
         composed: false,
         status: 'unknown',
         _links: {


### PR DESCRIPTION
As stream creator, I should be able to provide a description for a stream & task definition.

This can make it easy for a new joiner to know what is the purpose of the stream and task.

Related to: https://github.com/spring-cloud/spring-cloud-dataflow/issues/1654
Backend side PR merged: https://github.com/spring-cloud/spring-cloud-dataflow/pull/3388
CLI side PR: https://github.com/spring-cloud/spring-cloud-dataflow/pull/3456

<img width="771" alt="Screenshot 2019-08-23 at 19 05 43" src="https://user-images.githubusercontent.com/19280914/63610424-bcf10d00-c5d9-11e9-9642-af125cc2b6a5.png">
<img width="585" alt="Screenshot 2019-08-23 at 19 10 16" src="https://user-images.githubusercontent.com/19280914/63610426-bcf10d00-c5d9-11e9-8153-08f8a47e71b3.png">
<img width="476" alt="Screenshot 2019-08-23 at 19 10 09" src="https://user-images.githubusercontent.com/19280914/63610427-bcf10d00-c5d9-11e9-9257-473e23f279af.png">
<img width="651" alt="Screenshot 2019-08-23 at 19 09 39" src="https://user-images.githubusercontent.com/19280914/63610428-bd89a380-c5d9-11e9-81c3-9c8dc6420079.png">
<img width="698" alt="Screenshot 2019-08-23 at 19 09 00" src="https://user-images.githubusercontent.com/19280914/63610429-bd89a380-c5d9-11e9-8ecc-ec9ff8f8dd8d.png">
<img width="733" alt="Screenshot 2019-08-23 at 19 08 36" src="https://user-images.githubusercontent.com/19280914/63610430-bd89a380-c5d9-11e9-9d3a-e1bf0c944fdd.png">
<img width="902" alt="Screenshot 2019-08-23 at 19 06 43" src="https://user-images.githubusercontent.com/19280914/63610431-be223a00-c5d9-11e9-8e7b-3450e37535e9.png">
<img width="889" alt="Screenshot 2019-08-23 at 19 06 23" src="https://user-images.githubusercontent.com/19280914/63610432-be223a00-c5d9-11e9-803e-5f3e1ed210ec.png">
