### PR TITLE
Add drop down action for add new schedule

### DIFF
--- a/ui/src/app/tasks/task-schedules/task-schedules.component.spec.ts
+++ b/ui/src/app/tasks/task-schedules/task-schedules.component.spec.ts
@@ -262,6 +262,12 @@ describe('TaskSchedulesComponent', () => {
       expect(navigate).toHaveBeenCalledWith(['tasks/schedules/foo1']);
     });
 
+    it('should navigate to the add new schedule', () => {
+      const navigate = spyOn((<any>component).router, 'navigate');
+      component.applyAction('create', TaskSchedule.fromJSON(tasksService.taskSchedules._embedded.scheduleInfoResourceList[0]));
+      expect(navigate).toHaveBeenCalledWith(['tasks/schedules/create/bar1']);
+    });
+
     it('should navigate to the detail schedule (link)', () => {
       const line: DebugElement = fixture.debugElement.queryAll(By.css('#taskSchedulesTable tbody tr'))[0];
       const navigate = spyOn((<any>component).router, 'navigate');

--- a/ui/src/app/tasks/task-schedules/task-schedules.component.ts
+++ b/ui/src/app/tasks/task-schedules/task-schedules.component.ts
@@ -158,6 +158,15 @@ export class TaskSchedulesComponent implements OnInit, OnDestroy {
         icon: 'trash',
         action: 'destroy',
         title: 'Delete schedule'
+      },
+      {
+        divider: true
+      },
+      {
+        id: 'create-schedule' + index,
+        icon: 'clock-o',
+        action: 'create',
+        title: 'Add new schedule'
       }
     ];
   }
@@ -165,7 +174,7 @@ export class TaskSchedulesComponent implements OnInit, OnDestroy {
   /**
    * Apply Action
    * @param action
-   * @param arg
+   * @param args
    */
   applyAction(action: string, args?: any) {
     switch (action) {
@@ -177,6 +186,9 @@ export class TaskSchedulesComponent implements OnInit, OnDestroy {
         break;
       case 'destroySelected':
         this.destroySelectedSchedules();
+        break;
+      case 'create':
+        this.createNewSchedule(args);
         break;
     }
   }
@@ -311,6 +323,14 @@ export class TaskSchedulesComponent implements OnInit, OnDestroy {
    */
   taskDetails(taskSchedule: TaskSchedule) {
     this.router.navigate([`tasks/definitions/${taskSchedule.taskName}`]);
+  }
+
+  /**
+   * Route to create {@link TaskSchedule} page.
+   * @param {TaskSchedule} taskSchedule
+   */
+  createNewSchedule(taskSchedule: TaskSchedule) {
+    this.router.navigate([`tasks/schedules/create/${taskSchedule.taskName}`]);
   }
 
 }

--- a/ui/src/app/tasks/tasks-routing.module.ts
+++ b/ui/src/app/tasks/tasks-routing.module.ts
@@ -102,7 +102,7 @@ const taskRoutes: Routes = [
       {
         path: 'schedules/create/:id',
         component: TaskScheduleCreateComponent,
-      },
+      }
     ]
   }
 ];


### PR DESCRIPTION
  - At Schedules list page, user can now click the action drop down for each schedule to create another new schedule.
  - Add test

Resolves #1243