### PR TITLE
Track platform info in Audit history

### DIFF
--- a/ui/src/app/audit/audit-record-details/audit-record-details.component.html
+++ b/ui/src/app/audit/audit-record-details/audit-record-details.component.html
@@ -64,7 +64,14 @@
         <pre class="audit-pre">{{ auditRecord.auditData | json }}</pre>
       </div>
     </div>
-
+    <div class="row audit-summary-row">
+      <div class="col-md-3">
+        <strong>Platform Name:</strong>
+      </div>
+      <div class="col-md-21">
+        {{ auditRecord.platformName ? auditRecord.platformName : 'N/A' }}
+      </div>
+    </div>
   </div>
 
 </app-page>

--- a/ui/src/app/audit/audit-record/audit-record.component.html
+++ b/ui/src/app/audit/audit-record/audit-record.component.html
@@ -54,6 +54,11 @@
                     id="sort-auditData">Data
           </app-sort>
         </th>
+        <th>
+          <app-sort [indeterminate]="true" (change)="applySort($event)" [value]="'platformName'" [sort]="params"
+                    id="sort-auditData">Platform name
+          </app-sort>
+        </th>
         <th class="text-center">&nbsp;</th>
       </tr>
       </thead>
@@ -79,6 +84,9 @@
         </td>
         <td class="dataflow-truncator-width">
           <dataflow-truncator [input]="item.auditData" trailPosition="start" trail="…"></dataflow-truncator>
+        </td>
+        <td nowrap="">
+          {{item.platformName || 'N/A'}}
         </td>
         <td class="table-actions" width="10px" nowrap="">
           <app-list-row-actions [item]="item" (action)="applyAction($event.action, $event.args)"

--- a/ui/src/app/audit/audit-record/audit-record.component.spec.ts
+++ b/ui/src/app/audit/audit-record/audit-record.component.spec.ts
@@ -118,7 +118,7 @@ describe('AuditRecordComponent', () => {
 
     it('should populate audit records', () => {
       const des: DebugElement[] = fixture.debugElement.queryAll(By.css('#table tr td'));
-      expect(des.length).toBe(8 * 4);
+      expect(des.length).toBe(9 * 4);
       expect(des[0].nativeElement.textContent).toContain('1');
       // expect(des[1].nativeElement.textContent).toContain('2018-10-16T13:36:01.720Z');
       expect(des[2].nativeElement.textContent).toContain('CREATE');
@@ -126,6 +126,7 @@ describe('AuditRecordComponent', () => {
       expect(des[4].nativeElement.textContent).toContain('foo1');
       expect(des[5].nativeElement.textContent).toContain('N/A');
       expect(des[6].nativeElement.textContent).toContain('bar1');
+      expect(des[7].nativeElement.textContent).toContain('kubernetes');
     });
 
     it('should refresh the page', () => {

--- a/ui/src/app/audit/components/audit-record-action/audit-record-action.component.ts
+++ b/ui/src/app/audit/components/audit-record-action/audit-record-action.component.ts
@@ -56,5 +56,4 @@ export class AuditRecordActionComponent implements OnChanges {
     }
   }
 
-
 }

--- a/ui/src/app/audit/components/audit-record-operation/audit-record-operation.component.ts
+++ b/ui/src/app/audit/components/audit-record-operation/audit-record-operation.component.ts
@@ -57,5 +57,4 @@ export class AuditRecordOperationComponent implements OnChanges {
     }
   }
 
-
 }

--- a/ui/src/app/shared/model/audit-record.model.ts
+++ b/ui/src/app/shared/model/audit-record.model.ts
@@ -16,6 +16,7 @@ export class AuditRecord implements Serializable<AuditRecord> {
   public createdOn: DateTime;
   public auditAction: string;
   public auditOperation: string;
+  public platformName: string;
 
   public static fromJSON(input) {
     return new AuditRecord().deserialize(input);
@@ -44,6 +45,7 @@ export class AuditRecord implements Serializable<AuditRecord> {
     this.createdOn = DateTime.fromISO(input.createdOn);
     this.auditAction = input.auditAction;
     this.auditOperation = input.auditOperation;
+    this.platformName = input.platformName;
     return this;
   }
 

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -1359,6 +1359,7 @@ export const AUDIT_RECORDS = {
         createdOn: '2018-10-16T13:36:01.720Z',
         auditAction: 'CREATE',
         auditOperation: 'APP_REGISTRATION',
+        platformName: 'kubernetes',
         _links: {
           self: {
             self: 'http://localhost:4200/audit-records/1'


### PR DESCRIPTION
As a user, while launching Tasks against different platform backends (cf, k8s, etc.) in v2.0, I can't seem to find out where the actual execution occurred. It'd be good to keep track of the platform where the Tasks were launched, and surface that information in the UI.

Resolves: https://github.com/spring-cloud/spring-cloud-dataflow/issues/2891

![image](https://user-images.githubusercontent.com/19280914/69918415-ebe90b80-1471-11ea-8cfa-fae3d02b89fa.png)
