### PR TITLE
Stream view with instance dots integrated

### DIFF
--- a/ui/src/app/flo/shared/flo.scss
+++ b/ui/src/app/flo/shared/flo.scss
@@ -21,6 +21,7 @@ $navy-2: #243641;
 $navy-11: #F5F6F7;
 $base-unit: 8px;
 $navy-6: #788E9A;
+$blue-3: hsl(198, 66%, 57%);
 $blue-4: #1F8ACC;
 $dark-2: $navy-2;
 
@@ -991,6 +992,28 @@ table.zoom-canvas-control {
 }
 .tippy-box[data-theme~='error'][data-placement^='right'] > .tippy-arrow::before {
   border-right-color: #c21d00;
+}
+
+.deploying .stream-module {
+  .flo-port {
+    fill: $blue-3;
+  }
+}
+
+.undeployed .stream-module {
+  .flo-port {
+    fill: $navy-7;
+  }
+}
+
+.unknown .stream-module {
+
+}
+
+.deployed .stream-module {
+  .flo-port {
+    fill: #80b600;
+  }
 }
 
 

--- a/ui/src/app/flo/stream-flo.module.ts
+++ b/ui/src/app/flo/stream-flo.module.ts
@@ -19,6 +19,7 @@ import { ContentAssistService } from './stream/content-assist.service';
 import { ClarityModule } from '@clr/angular';
 import { SharedFloModule } from './shared-flo.module';
 import { SharedModule } from '../shared/shared.module';
+import { RuntimeStreamFloViewComponent } from './stream/component/runtime-view.component';
 
 @NgModule({
   declarations: [
@@ -28,6 +29,7 @@ import { SharedModule } from '../shared/shared.module';
     StreamNodeComponent,
     StreamPropertiesDialogComponent,
     StreamFloViewComponent,
+    RuntimeStreamFloViewComponent,
     StreamFloCreateComponent,
   ],
   imports: [
@@ -50,6 +52,7 @@ import { SharedModule } from '../shared/shared.module';
   ],
   exports: [
     StreamFloViewComponent,
+    RuntimeStreamFloViewComponent,
     StreamFloCreateComponent
   ]
 })

--- a/ui/src/app/flo/stream/component/runtime-view.component.spec.ts
+++ b/ui/src/app/flo/stream/component/runtime-view.component.spec.ts
@@ -1,0 +1,171 @@
+import { ApplicationRef, ComponentFactoryResolver } from '@angular/core';
+import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { dia } from 'jointjs';
+import { RuntimeStreamFloViewComponent } from './runtime-view.component';
+import { MetamodelService } from '../metamodel.service';
+import { MockSharedAppService } from '../../../tests/service/app.service.mock';
+import { StreamsModule } from '../../../streams/streams.module';
+import { RenderService } from '../render.service';
+import { Stream } from '../../../shared/model/stream.model';
+import { TYPE_INSTANCE_DOT, TYPE_INSTANCE_LABEL } from '../support/shapes';
+import { AppStatus, StreamStatus } from '../../../shared/model/metrics.model';
+
+/**
+ * Test {@link StreamGraphDefinitionComponent}.
+ *
+ * @author Alex Boyko
+ */
+describe('RuntimeStreamFloViewComponent', () => {
+  let component: RuntimeStreamFloViewComponent;
+  let fixture: ComponentFixture<RuntimeStreamFloViewComponent>;
+  const metamodelService = new MetamodelService(new MockSharedAppService());
+
+  let applicationRef: ApplicationRef;
+  let resolver: ComponentFactoryResolver;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StreamsModule
+      ],
+    });
+  }));
+
+  beforeEach(
+    inject(
+      [
+        ApplicationRef,
+        ComponentFactoryResolver
+      ],
+      (
+        _applicationRef: ApplicationRef,
+        _resolver: ComponentFactoryResolver
+      ) => {
+        applicationRef = _applicationRef;
+        resolver = _resolver;
+      }
+    )
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RuntimeStreamFloViewComponent);
+    component = fixture.componentInstance;
+    fixture.componentInstance.metamodel = metamodelService;
+    fixture.componentInstance.renderer = new RenderService(metamodelService, resolver,
+      fixture.debugElement.injector, applicationRef);
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(component.dsl).toBeUndefined();
+    expect(component.flo).toBeDefined();
+  });
+
+  it('check empty read-only view', () => {
+    expect(component.flo.noPalette).toBeTruthy();
+    expect(component.flo.readOnlyCanvas).toBeTruthy();
+    expect(component.flo.getGraph().getCells().length).toEqual(0);
+  });
+
+  it('check stream in the view', (done) => {
+    component.stream = Stream.parse({
+      streamName: 'test-stream',
+      dslText: 'http | filter | null',
+      originalDslText: 'http | filter | null',
+      description: 'demo description',
+      status: 'deployed'
+    });
+    const subscription = component.flo.textToGraphConversionObservable.subscribe(() => {
+      subscription.unsubscribe();
+      expect(component.flo.getGraph().getElements().length).toEqual(3);
+      expect(component.flo.getGraph().getLinks().length).toEqual(2);
+      done();
+    });
+    // Subscribe to graph changes before running angular change/update cycle
+    fixture.detectChanges();
+  });
+
+  it('verify dots in the view', (done) => {
+    component.stream = Stream.parse({
+      streamName: 'test-stream',
+      dslText: 'http | filter | null',
+      originalDslText: 'http | filter | null',
+      description: 'demo description',
+      status: 'deployed'
+    });
+
+    const httpMetrics = createStreamStatus('source', 'http', 2);
+    const filterMetrics = createStreamStatus('processor', 'filter', 60);
+    const nullMetrics = createStreamStatus('sink', 'null', 3);
+
+    // Remove 3 instances to have 57/60 label
+    filterMetrics.instances.pop();
+    filterMetrics.instances.pop();
+    filterMetrics.instances.pop();
+
+    const streamMetrics = new StreamStatus;
+    streamMetrics.name = 'test-stream';
+    streamMetrics.applications = [
+      httpMetrics,
+      filterMetrics,
+      nullMetrics
+    ];
+    component.metrics = streamMetrics;
+
+    const subscription = component.flo.textToGraphConversionObservable.subscribe(() => {
+      subscription.unsubscribe();
+
+      // verify http dots
+      const http = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'http');
+      expect(http).toBeDefined();
+      const httpEmbeds = http.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_DOT);
+      expect(http.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_LABEL)).toBeUndefined();
+      expect(httpEmbeds.length).toEqual(2);
+      httpMetrics.instances.forEach((instance, i) => expect(httpEmbeds[i].attr('instance')).toEqual(instance));
+
+      // verify filter label
+      const filter = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'filter');
+      expect(filter).toBeDefined();
+      expect(filter.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_DOT)).toBeUndefined();
+      const filterEmbeds = filter.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_LABEL);
+      expect(filterEmbeds.length).toEqual(1);
+      expect(filterEmbeds[0].attr('.label/text')).toEqual('57/57');
+
+      // verify null dots
+      const nullApp = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'null');
+      expect(nullApp).toBeDefined();
+      const nullEmbeds = nullApp.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_DOT);
+      expect(nullApp.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_LABEL)).toBeUndefined();
+      expect(nullEmbeds.length).toEqual(3);
+      nullMetrics.instances.forEach((instance, i) => expect(nullEmbeds[i].attr('instance')).toEqual(instance));
+
+      done();
+
+    });
+    // Subscribe to graph changes before running angular change/update cycle
+    fixture.detectChanges();
+  });
+
+  function createStreamStatus(group: string, name: string, numberOfInstances: number): AppStatus {
+    const instances = [];
+    for (let index = 0; index < numberOfInstances; index++) {
+      instances.push({
+        guid: `${name}-${index}`,
+        index: index,
+        status: 'deployed'
+      });
+    }
+    return AppStatus.parse({
+      deploymentId: `${name}-${group}`,
+      state: 'deployed',
+      name: name,
+      instances: {
+        _embedded: {
+          appInstanceStatusResourceList: instances
+        }
+      }
+    });
+  }
+
+});

--- a/ui/src/app/flo/stream/component/runtime-view.component.ts
+++ b/ui/src/app/flo/stream/component/runtime-view.component.ts
@@ -1,0 +1,199 @@
+import { Subscription, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { Component, ViewEncapsulation, Input, OnDestroy } from '@angular/core';
+import { Flo } from 'spring-flo';
+import { dia } from 'jointjs';
+import { AppStatus, StreamStatus } from '../../../shared/model/metrics.model';
+import { Stream } from '../../../shared/model/stream.model';
+import { MetamodelService } from '../metamodel.service';
+import { RenderService } from '../render.service';
+import { ApplicationType } from '../../../shared/model/app.model';
+import { TYPE_INSTANCE_DOT, TYPE_INSTANCE_LABEL } from '../support/shapes';
+
+import * as _joint from 'jointjs';
+
+const joint: any = _joint;
+
+
+@Component({
+  selector: 'app-runtime-stream-flo-view',
+  styleUrls: [
+    '../../../../../node_modules/spring-flo/dist/flo.css',
+    '../../shared/flo.scss',
+  ],
+  template: `
+    <app-graph-view [dsl]="dsl" [ngClass]="status ? status : 'undeployed'" (floApi)="setEditorContext($event)"
+                    [metamodel]="metamodel" [renderer]="renderer" [paperPadding]="40"></app-graph-view>
+  `,
+  encapsulation: ViewEncapsulation.None
+})
+export class RuntimeStreamFloViewComponent implements OnDestroy {
+
+  private ngUnsubscribe$: Subject<any> = new Subject();
+
+  flo: Flo.EditorContext;
+  private _metrics: StreamStatus;
+  private _subscriptionToGraphUpdates: Subscription;
+
+  @Input()
+  stream: Stream;
+
+  @Input()
+  set metrics(m: StreamStatus) {
+    this._metrics = m;
+    this.update();
+  }
+
+  constructor(public metamodel: MetamodelService, public renderer: RenderService) {
+  }
+
+  ngOnDestroy() {
+    if (this._subscriptionToGraphUpdates) {
+      this._subscriptionToGraphUpdates.unsubscribe();
+    }
+    this.ngUnsubscribe$.next();
+    this.ngUnsubscribe$.complete();
+  }
+
+  get metrics(): StreamStatus {
+    return this._metrics;
+  }
+
+  get dsl(): string {
+    return this.stream ? this.stream.dslText.toString() : undefined;
+  }
+
+  get status(): string[] {
+    return this.stream && this.stream.status ? [this.stream.status.toString()] : ['unknown'];
+  }
+
+  setEditorContext(editorContext: Flo.EditorContext) {
+    this.flo = editorContext;
+    if (this._subscriptionToGraphUpdates) {
+      this._subscriptionToGraphUpdates.unsubscribe();
+    }
+    this._subscriptionToGraphUpdates = this.flo.textToGraphConversionObservable
+      .pipe(takeUntil(this.ngUnsubscribe$))
+      .subscribe(() => this.update());
+  }
+
+  private findModuleMetrics(label: string): AppStatus {
+    return this.metrics?.applications?.find(app => app.name === label);
+  }
+
+  private update() {
+    this.updateDots();
+  }
+
+  private updateDots() {
+    if (this.flo) {
+      this.flo.getGraph().getElements().forEach((element) => {
+        const group = element.attr('metadata/group');
+        if (typeof ApplicationType[group] === 'number') {
+          let label = element.attr('node-name');
+          if (!label) {
+            label = element.attr('metadata/name');
+          }
+          this.updateInstanceDecorations(element, this.findModuleMetrics(label));
+        }
+      });
+    }
+  }
+
+  private updateInstanceDecorations(cell: dia.Element, moduleMetrics: AppStatus) {
+    let label: dia.Cell;
+    let dots: dia.Cell[] = [];
+    // Find label or dots currently painted
+    cell.getEmbeddedCells().forEach(embed => {
+      if (embed.get('type') === TYPE_INSTANCE_LABEL) {
+        label = embed;
+      } else if (embed.get('type') === TYPE_INSTANCE_DOT) {
+        dots.push(embed);
+      }
+    });
+
+    if (moduleMetrics && Array.isArray(moduleMetrics.instances) && moduleMetrics.instances.length > 0) {
+      const instanceCount = moduleMetrics.instances.length;
+
+      // Label or Dots should be displayed
+      const size: dia.Size = cell.get('size');
+      const position: dia.Point = cell.get('position');
+
+      const x = position.x + size.width / 2;
+      const y = position.y + size.height + 7;
+
+      const diameter = 14;
+      const padding = 4;
+      const maxLanes = 2;
+      // Calculate max number of dots that we can fit on one lane under the shape
+      const maxDotsPerLine = Math.ceil((size.width - padding) / (padding + diameter));
+      // Calculate the number of lanes required to display dots
+      const lanesNeeded = Math.ceil(instanceCount / maxDotsPerLine);
+      // If number of lanes is too large display label
+      if (lanesNeeded > maxLanes) {
+        // Label should be displayed - remove dots
+        dots.forEach(e => e.remove());
+        if (!label) {
+          // Create label if it's not on the graph yet
+          label = new joint.shapes.flo.InstanceLabel({
+            position: { x: x, y: y }
+          });
+          this.flo.getGraph().addCell(label);
+          cell.embed(label);
+        }
+        const deployedNumber = moduleMetrics.instances.length;
+        label.attr('.label/text', deployedNumber + '/' + instanceCount);
+      } else {
+        // Dots should be displayed - remove the label
+        if (label) {
+          label.remove();
+        }
+        if (dots.length !== instanceCount) {
+          // Number of dots has changed. Remove old dots and create new ones
+          dots.forEach(e => e.remove());
+          dots = [];
+          // Initialize data structure to store tooltip for each dot
+          let dotY = y;
+
+          for (let lane = 0; lane < lanesNeeded; lane++) {
+            const numberOfDots = (lane === lanesNeeded - 1) ? instanceCount - lane * maxDotsPerLine : maxDotsPerLine;
+            const even = numberOfDots % 2 === 0;
+            let dotX = x - (Math.floor(numberOfDots / 2) * (diameter + padding) + (even ? -padding / 2 : diameter / 2));
+            for (let i = 0; i < numberOfDots; i++) {
+              const idx = lane * maxDotsPerLine + i/* + 1*/;
+              const data = idx < moduleMetrics.instances.length ? moduleMetrics.instances[idx] : undefined;
+              const dot = new joint.shapes.flo.InstanceDot({
+                position: { x: dotX, y: dotY },
+                size: { width: diameter, height: diameter },
+                attrs: {
+                  instance: data
+                }
+              });
+              this.flo.getGraph().addCell(dot);
+              cell.embed(dot);
+              dotX += diameter + padding;
+              dots.push(dot);
+            }
+            dotY += diameter + padding;
+          }
+        } else {
+          dots.forEach((dot: dia.Cell, i: number) => {
+            if (i < moduleMetrics.instances.length) {
+              dot.attr('instance', moduleMetrics.instances[i]);
+            } else {
+              dot.attr('instance', null);
+              dot.removeAttr('instance');
+            }
+          });
+        }
+      }
+    } else {
+      // Label or Dots should NOT be displayed for undeployed modules - remove them
+      if (label) {
+        label.remove();
+      }
+      dots.forEach(e => e.remove());
+    }
+  }
+
+}

--- a/ui/src/app/streams/streams/streams.component.html
+++ b/ui/src/app/streams/streams/streams.component.html
@@ -86,11 +86,13 @@
       <button class="action-item" (click)="destroy([stream])">Destroy</button>
       <button class="action-item" grafanaDashboardStream [stream]="stream">Grafana Dashboard</button>
     </clr-dg-action-overflow>
-    <ng-template [(clrIfExpanded)]="expended[stream.name]"
+    <ng-template [clrIfExpanded]="expanded[stream.name]" (clrIfExpandedChange)="toggleExpand(stream.name)"
                  ngProjectAs="clr-dg-row-detail">
       <clr-dg-row-detail>
         <div class="clr-detail-flo">
-          <app-stream-flo-view id="{{stream.name}}"></app-stream-flo-view>
+          <!--<app-stream-flo-view id="{{stream.name}}"></app-stream-flo-view>-->
+          <app-runtime-stream-flo-view [stream]="stream" [metrics]="metricsForStream(stream.name)">
+          </app-runtime-stream-flo-view>
         </div>
       </clr-dg-row-detail>
     </ng-template>

--- a/ui/src/app/streams/streams/streams.component.spec.ts
+++ b/ui/src/app/streams/streams/streams.component.spec.ts
@@ -61,6 +61,7 @@ describe('streams/streams/streams.component.ts', () => {
   });
 
   it('should display the datagrid, pagination, action bar', async (done) => {
+    component.timeSubscription = <any> {}; // hack to disable setting the timer, otherwise it times out
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();

--- a/ui/src/app/streams/streams/streams.component.ts
+++ b/ui/src/app/streams/streams/streams.component.ts
@@ -1,3 +1,4 @@
+import { Subscription, timer } from 'rxjs';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 import { Router } from '@angular/router';
@@ -8,6 +9,7 @@ import { UndeployComponent } from './undeploy/undeploy.component';
 import { DatagridComponent } from '../../shared/component/datagrid/datagrid.component';
 import { ContextService } from '../../shared/service/context.service';
 import { MultiDeployComponent } from './multi-deploy/multi-deploy.component';
+import { StreamStatus } from '../../shared/model/metrics.model';
 
 @Component({
   selector: 'app-streams-list',
@@ -15,10 +17,25 @@ import { MultiDeployComponent } from './multi-deploy/multi-deploy.component';
 })
 export class StreamsComponent extends DatagridComponent implements OnDestroy, OnInit {
   page: StreamPage;
-  expended: object;
+  expanded: {};
   @ViewChild('destroyModal', { static: true }) destroyModal: DestroyComponent;
   @ViewChild('undeployModal', { static: true }) undeployModal: UndeployComponent;
   @ViewChild('multiDeployModal', { static: true }) multiDeployModal: MultiDeployComponent;
+
+  /**
+   * Metrics Subscription
+   */
+  metricsSubscription: Subscription;
+
+  /**
+   * Array of streamStatuses
+   */
+  streamStatuses: StreamStatus[] = [];
+
+  /**
+   * Time Subscription
+   */
+  timeSubscription: Subscription;
 
   constructor(private streamService: StreamService,
               protected contextService: ContextService,
@@ -27,13 +44,19 @@ export class StreamsComponent extends DatagridComponent implements OnDestroy, On
   }
 
   ngOnInit(): void {
-    this.expended = this.contextService.get('streams.expended') || [];
+    this.expanded = this.contextService.get('streams.expended') || [];
     super.ngOnInit();
   }
 
   ngOnDestroy(): void {
+    if (this.metricsSubscription) {
+      this.metricsSubscription.unsubscribe();
+    }
+    if (this.timeSubscription) {
+      this.timeSubscription.unsubscribe();
+    }
     super.ngOnDestroy();
-    this.updateContext('expended', this.expended);
+    this.updateContext('expended', this.expanded);
   }
 
   refresh(state: ClrDatagridStateInterface) {
@@ -46,13 +69,18 @@ export class StreamsComponent extends DatagridComponent implements OnDestroy, On
           this.attachColumns();
           const mergeExpended = {};
           page.items.forEach((item) => {
-            mergeExpended[item.name] = this.expended[item.name] || false;
+            mergeExpended[item.name] = this.expanded[item.name] || false;
           });
-          this.expended = mergeExpended;
+          this.expanded = mergeExpended;
           this.page = page;
           this.updateGroupContext(params);
           this.selected = [];
           this.loading = false;
+
+          if (!this.timeSubscription) {
+            this.updateMetrics();
+            this.timeSubscription = timer(0, 10 * 1000).subscribe(() => this.updateMetrics());
+          }
         });
     }
   }
@@ -79,6 +107,63 @@ export class StreamsComponent extends DatagridComponent implements OnDestroy, On
 
   create() {
     this.router.navigateByUrl(`streams/list/create`);
+  }
+
+  /**
+   * Update the list of selected checkbox
+   */
+  private updateMetrics() {
+    const expandedStreams = this.page.items.filter(s => this.expanded[s.name]);
+    if (expandedStreams.length > 0) {
+      const deployedStreamNames = expandedStreams
+        .filter(s => {
+          const status = s.status.toLowerCase();
+          return (status === 'deployed') || (status === 'deploying') || (status === 'partial')
+        })
+        .map(s => s.name.toString());
+      if (deployedStreamNames.length) {
+        if (this.metricsSubscription) {
+          this.metricsSubscription.unsubscribe();
+        }
+        this.metricsSubscription = this.streamService.getRuntimeStreamStatuses(deployedStreamNames)
+          .subscribe(metrics => {
+            this.streamStatuses = metrics;
+          });
+      }
+    } else {
+      this.streamStatuses = [];
+    }
+  }
+
+  /**
+   * Toogle Expand
+   */
+  toggleExpand(streamName: string) {
+    if (this.expanded[streamName]) {
+      delete this.expanded[streamName];
+    } else {
+      this.expanded[streamName] = true;
+    }
+    this.updateMetrics();
+  }
+
+  get handler() {
+    return false;
+  }
+
+  set handler(value) {
+    console.log('HANDLE ' + value);
+  }
+
+  /**
+   * Metrics for stream
+   * @param {string} name
+   * @returns {StreamStatus}
+   */
+  metricsForStream(name: string): StreamStatus {
+    if (Array.isArray(this.streamStatuses)) {
+      return this.streamStatuses.find(m => m.name === name);
+    }
   }
 
 }


### PR DESCRIPTION
Missing stream graph view able to show instance dots.

If metrics are not to be shown over the stream graph (as message rates are gone), in other words if instance dots are not desired and there are no plans to show any other metrics data of stream runtime data then this SHOULD NOT be merged and instead other related component SHOULD be removed.
cc: @sabbyanandan 