### PR TITLE
Disable destroy/schedule actions for sub tasks of a composed task

### DIFF
--- a/ui/src/app/tasks/model/task-definition.spec.ts
+++ b/ui/src/app/tasks/model/task-definition.spec.ts
@@ -11,6 +11,7 @@ describe('TaskDefinition', () => {
       expect(taskDefinition.name).toBe('foo');
       expect(taskDefinition.dslText).toBe('bar');
       expect(taskDefinition.composed).toBe(true);
+      expect(taskDefinition.composedTaskElement).toBe(false);
       expect(taskDefinition.status).toBe('unknown');
     });
 

--- a/ui/src/app/tasks/model/task-definition.ts
+++ b/ui/src/app/tasks/model/task-definition.ts
@@ -1,4 +1,4 @@
-import { Page } from '../../shared/model';
+import {Page} from '../../shared/model';
 import {TaskExecution} from "./task-execution";
 
 export class TaskDefinition {
@@ -13,19 +13,22 @@ export class TaskDefinition {
 
   public status: string;
 
-  public lastTaskExecution: TaskExecution
+  public composedTaskElement: boolean;
 
-  constructor(name: string, dslText: string, description: string, composed: boolean, status: string, lastTaskExecution: TaskExecution) {
+  public lastTaskExecution: TaskExecution;
+
+  constructor(name: string, dslText: string, description: string, composed: boolean, status: string, composedTaskElement: boolean, lastTaskExecution: TaskExecution) {
     this.name = name;
     this.dslText = dslText;
     this.composed = composed;
     this.status = status;
     this.description = description ? description : '';
+    this.composedTaskElement = composedTaskElement;
     this.lastTaskExecution = lastTaskExecution;
   }
 
   static fromJSON(input): TaskDefinition {
-    return new TaskDefinition(input.name, input.dslText, input.description, input.composed, input.status, input.lastTaskExecution);
+    return new TaskDefinition(input.name, input.dslText, input.description, input.composed, input.status, input.composedTaskElement, input.lastTaskExecution);
   }
 
   static pageFromJSON(input): Page<TaskDefinition> {
@@ -35,5 +38,4 @@ export class TaskDefinition {
     }
     return page;
   }
-
 }

--- a/ui/src/app/tasks/task-definition/task-definition.component.html
+++ b/ui/src/app/tasks/task-definition/task-definition.component.html
@@ -19,7 +19,7 @@
         Schedule
       </button>
       <button name="stream-remove" type="button" (click)="destroy(task.definition)" id="task-remove"
-              class="btn btn-danger btn-fa" title="Destroy" [dataflowAppRoles]="['ROLE_DESTROY']">
+              class="btn btn-danger btn-fa" title="Destroy" [dataflowAppRoles]="['ROLE_DESTROY']" *ngIf="!(task.definition.composedTaskElement)">
         <span class="fa fa-trash"></span>
         Destroy task
       </button>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.html
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.html
@@ -41,7 +41,7 @@
         <tr>
           <td class="cell-checkbox" [dataflowAppRoles]="['ROLE_DESTROY']">
             <input [dataflowAppRoles]="['ROLE_CREATE']" type="checkbox" (change)="changeCheckboxes()"
-                   [(ngModel)]="form.checkboxes[i]"/>
+                   [(ngModel)]="form.checkboxes[i]" *ngIf="!item.composedTaskElement"/>
           </td>
           <td width="200px">
             <a style="cursor:pointer" [routerLink]="'/tasks/definitions/' + item.name">{{ item.name }}</a>
@@ -58,7 +58,7 @@
           </td>
           <td class="table-actions" width="10px" nowrap="">
             <app-list-row-actions [item]="item" (action)="applyAction($event.action, $event.args)"
-                                  [actions]="taskActions(i)"></app-list-row-actions>
+                                  [actions]="taskActions(i, item.composedTaskElement)"></app-list-row-actions>
           </td>
         </tr>
       </ng-container>

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.spec.ts
@@ -376,6 +376,65 @@ describe('TaskDefinitionsComponent', () => {
 
   });
 
+  const TASK_DEFINITIONS_SAMPLE = {
+    _embedded: {
+      taskDefinitionResourceList: [
+        {
+          name: 'foo',
+          dslText: 'bar',
+          description: 'demo',
+          composed: true,
+          status: 'unknown',
+          composedTaskElement: true,
+          _links: {
+            self: {
+              href: 'http://localhost:4200/tasks/definitions/foo'
+            }
+          }
+        }
+      ]
+    },
+    _links: {
+      self: {
+        href: 'http://localhost:4200/tasks/definitions?page=0&size=20&sort=taskName,asc'
+      }
+    },
+    page: {
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+      number: 0
+    }
+  };
+
+  describe('Task action on composed task elements', () => {
+
+    beforeEach(() => {
+      tasksService.tasksContext.page = 0;
+      tasksService.taskDefinitions = TASK_DEFINITIONS;
+      fixture.detectChanges();
+    });
+
+    it('should not delete a task', () => {
+      const spy = spyOn(component, 'destroy');
+      component.applyAction('destroy', tasksService.taskDefinitions._embedded.taskDefinitionResourceList[0]);
+      !expect(spy).toHaveBeenCalled();
+    });
+
+    it('should navigate to the detail task', () => {
+      const navigate = spyOn((<any>component).router, 'navigate');
+      component.applyAction('details', tasksService.taskDefinitions._embedded.taskDefinitionResourceList[0]);
+      expect(navigate).toHaveBeenCalledWith(['tasks/definitions/foo']);
+    });
+
+    it('Should navigate to the launch page.', () => {
+      const navigate = spyOn((<any>component).router, 'navigate');
+      component.applyAction('launch', tasksService.taskDefinitions._embedded.taskDefinitionResourceList[0]);
+      expect(navigate).toHaveBeenCalledWith(['tasks/definitions/launch/foo']);
+    });
+
+  });
+
   describe('Task Schedule enable', () => {
 
     beforeEach(() => {

--- a/ui/src/app/tasks/task-definitions/task-definitions.component.ts
+++ b/ui/src/app/tasks/task-definitions/task-definitions.component.ts
@@ -158,8 +158,9 @@ export class TaskDefinitionsComponent implements OnInit, OnDestroy {
    * Task Actions
    * @param {TaskDefinition} item
    * @param {number} index
+   * @param {boolean} composedTaskElement
    */
-  taskActions(index: number) {
+  taskActions(index: number, composedTaskElement: boolean) {
     return [
       {
         id: 'details-task' + index,
@@ -203,7 +204,7 @@ export class TaskDefinitionsComponent implements OnInit, OnDestroy {
         action: 'schedule',
         title: 'Schedule task',
         disabled: !this.schedulesEnabled,
-        hidden: !this.schedulesEnabled || !this.authService.securityInfo.canAccess(['ROLE_SCHEDULE'])
+        hidden: !this.schedulesEnabled || !this.authService.securityInfo.canAccess(['ROLE_SCHEDULE']) || composedTaskElement
       },
       {
         id: 'delete-schedules' + index,
@@ -211,7 +212,7 @@ export class TaskDefinitionsComponent implements OnInit, OnDestroy {
         action: 'delete-schedules',
         title: 'Delete schedule',
         disabled: !this.schedulesEnabled,
-        hidden: !this.schedulesEnabled || !this.authService.securityInfo.canAccess(['ROLE_SCHEDULE'])
+        hidden: !this.schedulesEnabled || !this.authService.securityInfo.canAccess(['ROLE_SCHEDULE']) || composedTaskElement
       },
       {
         divider: true,
@@ -222,7 +223,7 @@ export class TaskDefinitionsComponent implements OnInit, OnDestroy {
         icon: 'trash',
         action: 'destroy',
         title: 'Destroy task',
-        hidden: !this.authService.securityInfo.canAccess(['ROLE_DESTROY'])
+        hidden: !this.authService.securityInfo.canAccess(['ROLE_DESTROY']) || composedTaskElement
       },
     ];
   }

--- a/ui/src/app/tasks/task-launch/task-launch.component.spec.ts
+++ b/ui/src/app/tasks/task-launch/task-launch.component.spec.ts
@@ -1,30 +1,30 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
-import { TasksService } from '../tasks.service';
-import { MockActivatedRoute } from '../../tests/mocks/activated-route';
-import { MockNotificationService } from '../../tests/mocks/notification';
-import { DataflowDateTimePipe } from '../../shared/pipes/dataflow-date-time.pipe';
-import { MockTasksService } from '../../tests/mocks/tasks';
-import { TASK_DEFINITIONS } from '../../tests/mocks/mock-data';
-import { TaskLaunchComponent } from './task-launch.component';
-import { LoaderComponent } from '../../shared/components/loader/loader.component';
-import { NotificationService } from '../../shared/services/notification.service';
-import { MockRoutingStateService } from '../../tests/mocks/routing-state';
-import { RoutingStateService } from '../../shared/services/routing-state.service';
-import { DATAFLOW_LIST } from '../../shared/components/list/list.component';
-import { PagerComponent } from '../../shared/components/pager/pager.component';
-import { DATAFLOW_PAGE } from '../../shared/components/page/page.component';
-import { NgxPaginationModule } from 'ngx-pagination/dist/ngx-pagination';
-import { BsDropdownModule, PopoverModule, TooltipModule } from 'ngx-bootstrap';
-import { KvRichTextComponent } from '../../shared/components/kv-rich-text/kv-rich-text.component';
-import { ClipboardModule, ClipboardService } from 'ngx-clipboard';
-import { Platform } from '../../shared/model/platform';
-import { TaskDefinition } from '../model/task-definition';
-import { By } from '@angular/platform-browser';
-import { TippyDirective } from '../../shared/directives/tippy.directive';
-import { BlockerService } from '../../shared/components/blocker/blocker.service';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute} from '@angular/router';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {RouterTestingModule} from '@angular/router/testing';
+import {TasksService} from '../tasks.service';
+import {MockActivatedRoute} from '../../tests/mocks/activated-route';
+import {MockNotificationService} from '../../tests/mocks/notification';
+import {DataflowDateTimePipe} from '../../shared/pipes/dataflow-date-time.pipe';
+import {MockTasksService} from '../../tests/mocks/tasks';
+import {TASK_DEFINITIONS} from '../../tests/mocks/mock-data';
+import {TaskLaunchComponent} from './task-launch.component';
+import {LoaderComponent} from '../../shared/components/loader/loader.component';
+import {NotificationService} from '../../shared/services/notification.service';
+import {MockRoutingStateService} from '../../tests/mocks/routing-state';
+import {RoutingStateService} from '../../shared/services/routing-state.service';
+import {DATAFLOW_LIST} from '../../shared/components/list/list.component';
+import {PagerComponent} from '../../shared/components/pager/pager.component';
+import {DATAFLOW_PAGE} from '../../shared/components/page/page.component';
+import {NgxPaginationModule} from 'ngx-pagination/dist/ngx-pagination';
+import {BsDropdownModule, PopoverModule, TooltipModule} from 'ngx-bootstrap';
+import {KvRichTextComponent} from '../../shared/components/kv-rich-text/kv-rich-text.component';
+import {ClipboardModule, ClipboardService} from 'ngx-clipboard';
+import {Platform} from '../../shared/model/platform';
+import {TaskDefinition} from '../model/task-definition';
+import {By} from '@angular/platform-browser';
+import {TippyDirective} from '../../shared/directives/tippy.directive';
+import {BlockerService} from '../../shared/components/blocker/blocker.service';
 
 /**
  * Test {@link TaskLaunchComponent}.
@@ -125,7 +125,7 @@ describe('TaskLaunchComponent', () => {
 
     it('Can select a platform', () => {
       const task = {
-        task: new TaskDefinition('foo', 'timestamp', 'demo-description', false, 'COMPLETE', null),
+        task: new TaskDefinition('foo', 'timestamp', 'demo-description', false, 'COMPLETE', false, null),
         platforms: [
           new Platform('foo', 'foo', 'foo'),
           new Platform('bar', 'bar', 'bar'),
@@ -136,7 +136,7 @@ describe('TaskLaunchComponent', () => {
 
     it('Can not select a platform', () => {
       const task = {
-        task: new TaskDefinition('foo', 'timestamp', 'demo-description', false, 'COMPLETE', null),
+        task: new TaskDefinition('foo', 'timestamp', 'demo-description', false, 'COMPLETE', false,null),
         platforms: [
           new Platform('foo', 'foo', 'foo')
         ]

--- a/ui/src/app/tests/mocks/mock-data.ts
+++ b/ui/src/app/tests/mocks/mock-data.ts
@@ -1337,6 +1337,7 @@ export const TASK_DEFINITIONS = {
         description: 'demo',
         composed: true,
         status: 'unknown',
+        composedTaskElement: false,
         _links: {
           self: {
             href: 'http://localhost:4200/tasks/definitions/foo'
@@ -1348,6 +1349,7 @@ export const TASK_DEFINITIONS = {
         dslText: 'task1',
         description: 'demo',
         composed: false,
+        composedTaskElement: false,
         status: 'unknown',
         _links: {
           self: {


### PR DESCRIPTION
 - Check for the task definition attribute `composdTaskElement` and perform disable actions based on this
 - Update the corresponding html template files
 - Update tests

Resolves #1437