### PR TITLE
Move apps metadata from Element#attr(...) to Element#prop(...)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
     "npm-check-updates": "^4.1.0",
     "rxjs": "6.5.4",
     "sockjs-client": "1.4.0",
-    "spring-flo": "https://github.com/spring-projects/spring-flo.git#fd0fab7ef49317a5820664fa1829a2728548ff70",
+    "spring-flo": "https://github.com/spring-projects/spring-flo.git#18459824f4059a0abb33e4b6f42705e711884814",
     "stompjs": "2.3.3",
     "tippy.js": "5.2.1",
     "tslib": "1.11.1",

--- a/ui/src/app/shared/flo/support/node-component.ts
+++ b/ui/src/app/shared/flo/support/node-component.ts
@@ -36,7 +36,7 @@ export class NodeComponent extends ElementComponent {
   }
 
   get metadata(): Flo.ElementMetadata {
-    return this.view ? this.view.model.attr('metadata') : undefined;
+    return this.view ? this.view.model.get('metadata') : undefined;
   }
 
   get metaName(): string {
@@ -52,7 +52,7 @@ export class NodeComponent extends ElementComponent {
   }
 
   get isPropertiesShown(): boolean {
-    return this.view ? !this.view.model.attr('metadata/metadata/hide-tooltip-options') : false;
+    return this.view ? !this.view.model.get('metadata')?.metadata?.['hide-tooltip-options'] : false;
   }
 
   get description(): string {

--- a/ui/src/app/shared/flo/support/utils.ts
+++ b/ui/src/app/shared/flo/support/utils.ts
@@ -51,7 +51,7 @@ export class Utils {
   }
 
   static isUnresolved(element: dia.Cell): boolean {
-    return Utils.isUnresolvedMetadata(element.attr('metadata'));
+    return Utils.isUnresolvedMetadata(element.get('metadata'));
   }
 
   static isUnresolvedMetadata(metadata: Flo.ElementMetadata) {

--- a/ui/src/app/shared/services/shared-apps.service.ts
+++ b/ui/src/app/shared/services/shared-apps.service.ts
@@ -13,7 +13,7 @@ export class SharedAppsService {
   /**
    * URL App
    */
-  private static appsUrl = '/apps';
+  protected static appsUrl = '/apps';
 
   /**
    * Constructor
@@ -21,9 +21,9 @@ export class SharedAppsService {
    * @param {LoggerService} loggerService
    * @param {ErrorHandler} errorHandler
    */
-  constructor(private httpClient: HttpClient,
-              private loggerService: LoggerService,
-              private errorHandler: ErrorHandler) {
+  constructor(protected httpClient: HttpClient,
+              protected loggerService: LoggerService,
+              protected errorHandler: ErrorHandler) {
   }
 
   /**

--- a/ui/src/app/streams/components/flo/editor.service.spec.ts
+++ b/ui/src/app/streams/components/flo/editor.service.spec.ts
@@ -301,7 +301,7 @@ describe('Streams Editor Service', () => {
   }
 
   function getName(element: dia.Cell) {
-    return element.attr('metadata/name');
+    return element.get('metadata')?.name;
   }
 
   function setLabel(element: dia.Cell, label: string) {
@@ -485,7 +485,7 @@ describe('editor.service : Auto-Link', () => {
   it('DnD on empty canvas', () => {
     dropOnCanvas(metamodel.get('source').get('http'));
     expect(flo.getGraph().getElements().length).toEqual(1);
-    expect(flo.getGraph().getElements()[0].attr('metadata/name')).toEqual('http');
+    expect(flo.getGraph().getElements()[0].get('metadata')?.name).toEqual('http');
   });
 
   it('Auto-Link: OFF. Drop processor with available source port', () => {

--- a/ui/src/app/streams/components/flo/editor.service.ts
+++ b/ui/src/app/streams/components/flo/editor.service.ts
@@ -105,8 +105,8 @@ export class EditorService implements Flo.Editor {
       // }
     }
 
-    if (cellViewS.model.attr('metadata') && cellViewT.model.attr('metadata')) {
-      const targetGroup = cellViewT.model.attr('metadata/group');
+    if (cellViewS.model.get('metadata') && cellViewT.model.get('metadata')) {
+      const targetGroup = cellViewT.model.get('metadata')?.group;
 
       // Target is a SOURCE node? Disallow link!
       // Target is APP type node? Disallow link!
@@ -115,11 +115,11 @@ export class EditorService implements Flo.Editor {
         return false;
       }
       // Target is an explicit tap? Disallow link!
-      if (cellViewT.model.attr('metadata/name') === 'tap') {
+      if (cellViewT.model.get('metadata')?.name === 'tap') {
         return false;
       }
 
-      const sourceGroup = cellViewS.model.attr('metadata/group');
+      const sourceGroup = cellViewS.model.get('metadata')?.group;
       // SINK, TASK, APP cannot have outgoing links
       if (sourceGroup === ApplicationType[ApplicationType.sink]
         || sourceGroup === ApplicationType[ApplicationType.task]
@@ -140,7 +140,7 @@ export class EditorService implements Flo.Editor {
 
       if (targetIncomingLinks.length > 0) {
         // It is ok if the target is a destination
-        if (cellViewT.model.attr('metadata/name') !== 'destination') {
+        if (cellViewT.model.get('metadata')?.name !== 'destination') {
           return false;
         }
       }
@@ -158,7 +158,7 @@ export class EditorService implements Flo.Editor {
 
         // Invalid if output-port has more than one outgoing link (if not destination)
         // if (magnetS.getAttribute('class') === 'output-port' &&
-        //     cellViewS.model.attr('metadata/name') !== 'destination') {
+        //     cellViewS.model.get('metadata')?.name !== 'destination') {
         //     for (i = 0; i < outgoingSourceLinks.length; i++) {
         //         var selector = outgoingSourceLinks[i].get('source').selector;
         //         // Another link from the 'output-port' is present
@@ -190,8 +190,8 @@ export class EditorService implements Flo.Editor {
     const targetUnderMouse = viewUnderMouse ? viewUnderMouse.model : undefined;
     // If node dropping not enabled then short-circuit
     if (!NODE_DROPPING && !(targetUnderMouse instanceof joint.dia.Link
-      && targetUnderMouse.attr('metadata/name') !== 'tap'
-      && targetUnderMouse.attr('metadata/name') !== 'destination')) {
+      && targetUnderMouse.get('metadata')?.name !== 'tap'
+      && targetUnderMouse.get('metadata')?.name !== 'destination')) {
       return {
         sourceComponent: sourceComponent,
         source: {
@@ -200,7 +200,7 @@ export class EditorService implements Flo.Editor {
       };
     }
     // check if it's a tap being dragged
-    if ((targetUnderMouse instanceof joint.dia.Element) && source.attr('metadata/name') === 'tap') {
+    if ((targetUnderMouse instanceof joint.dia.Element) && source.get('metadata')?.name === 'tap') {
       return {
         sourceComponent: sourceComponent,
         source: {
@@ -268,8 +268,8 @@ export class EditorService implements Flo.Editor {
     }
 
     // Check if drop on a link is allowed
-    const sourceType = source.attr('metadata/name');
-    const sourceGroup = source.attr('metadata/group');
+    const sourceType = source.get('metadata')?.name;
+    const sourceGroup = source.get('metadata')?.group;
     if (targetUnderMouse instanceof joint.dia.Link && !(sourceType === 'destination'
       || sourceGroup === 'sink' || sourceGroup === 'source') && graph.getConnectedLinks(source).length === 0) {
       return {
@@ -452,8 +452,8 @@ export class EditorService implements Flo.Editor {
   }
 
   protected validateConnectedLinks(graph: dia.Graph, element: dia.Element, errors: Array<Flo.Marker>) {
-    const group = element.attr('metadata/group');
-    const type = element.attr('metadata/name');
+    const group = element.get('metadata')?.group;
+    const type = element.get('metadata')?.name;
     const incoming: Array<dia.Link> = [];
     const outgoing: Array<dia.Link> = [];
     const tap: Array<dia.Link> = [];
@@ -538,8 +538,8 @@ export class EditorService implements Flo.Editor {
     //   const group = incomingGroups[channel];
     //
     //   // Error on unresolved channels not present in metamodel
-    //   if (channel && element.attr('metadata') instanceof AppMetadata) {
-    //     const inputChannels = (<AppMetadata> element.attr('metadata')).inputChannels;
+    //   if (channel && element.get('metadata') instanceof AppMetadata) {
+    //     const inputChannels = (<AppMetadata> element.get('metadata')).inputChannels;
     //     if (!Array.isArray(inputChannels) || inputChannels.indexOf(channel) < 0) {
     //       errors.push({
     //         severity: Flo.Severity.Error,
@@ -567,8 +567,8 @@ export class EditorService implements Flo.Editor {
     //   const group = outgoingGroups[channel];
     //
     //   // Error on unresolved channels not present in metamodel
-    //   if (channel && element.attr('metadata') instanceof AppMetadata) {
-    //     const outputChannels = (<AppMetadata> element.attr('metadata')).outputChannels;
+    //   if (channel && element.get('metadata') instanceof AppMetadata) {
+    //     const outputChannels = (<AppMetadata> element.get('metadata')).outputChannels;
     //     if (!Array.isArray(outputChannels) || outputChannels.indexOf(channel) < 0) {
     //       errors.push({
     //         severity: Flo.Severity.Error,
@@ -603,7 +603,7 @@ export class EditorService implements Flo.Editor {
       // const specifiedProperties = element.attr('props');
       // if (specifiedProperties) {
       //     const propertiesRanges = element.attr('propertiesranges');
-      //     const appSchema = element.attr('metadata');
+      //     const appSchema = element.get('metadata');
       //     appSchema.properties().then(appSchemaProperties => {
       //         if (!appSchemaProperties) {
       //             appSchemaProperties = new Map<string, Flo.PropertyMetadata>();
@@ -616,7 +616,7 @@ export class EditorService implements Flo.Editor {
       //                 markers.push({
       //                     severity: Flo.Severity.Error,
       //                     message: 'unrecognized option \'' + propertyName + '\' for app \'' +
-      //                                 element.attr('metadata/name') + '\'',
+      //                                 element.get('metadata')?.name') + '\'',
       //                     range: range
       //                 });
       //             }
@@ -632,10 +632,10 @@ export class EditorService implements Flo.Editor {
 
   private validateMetadata(element: dia.Cell, errors: Array<Flo.Marker>) {
     // Unresolved elements validation
-    if (!element.attr('metadata') || SharedUtils.isUnresolved(element)) {
-      let msg = 'Unknown element \'' + element.attr('metadata/name') + '\'';
-      if (element.attr('metadata/group')) {
-        msg += ' from group \'' + element.attr('metadata/group') + '\'.';
+    if (!element.get('metadata') || SharedUtils.isUnresolved(element)) {
+      let msg = 'Unknown element \'' + element.get('metadata')?.name + '\'';
+      if (element.get('metadata')?.group) {
+        msg += ' from group \'' + element.get('metadata')?.group + '\'.';
       }
       errors.push({
         severity: Flo.Severity.Error,
@@ -660,7 +660,7 @@ export class EditorService implements Flo.Editor {
     return new Promise(resolve => {
       const markers: Map<string | number, Array<Flo.Marker>> = new Map();
       const promises: Promise<void>[] = [];
-      graph.getElements().filter(e => !e.get('parent') && e.attr('metadata')).forEach(e => {
+      graph.getElements().filter(e => !e.get('parent') && e.get('metadata')).forEach(e => {
         promises.push(new Promise<void>((nodeFinished) => {
           this.validateNode(graph, e).then((result) => {
             markers.set(e.id, result);
@@ -855,9 +855,9 @@ export class EditorService implements Flo.Editor {
     const graph = flo.getGraph();
     const source = dragDescriptor.source ? dragDescriptor.source.view.model : undefined;
     const target = dragDescriptor.target ? dragDescriptor.target.view.model : undefined;
-    const type = source.attr('metadata/name');
+    const type = source.get('metadata')?.name;
     // NODE DROPPING TURNED OFF FOR NOW
-    if (NODE_DROPPING && target instanceof joint.dia.Element && target.attr('metadata/name')) {
+    if (NODE_DROPPING && target instanceof joint.dia.Element && target.get('metadata')?.name) {
       if (dragDescriptor.target.cssClassSelector === '.output-port') {
         this.moveNodeOnNode(flo, <dia.Element> source, <dia.Element> target, 'right', true);
         relinking = true;
@@ -885,7 +885,7 @@ export class EditorService implements Flo.Editor {
   private performAutoLinking(flo: Flo.EditorContext, view: dia.CellView) {
     // Search the graph for open ports - if only 1 is found, and it matches what
     // the dropped node needs, join it up!
-    const group = view.model.attr('metadata/group');
+    const group = view.model.get('metadata')?.group;
     const graph = flo.getGraph();
     let wantOpenInputPort = false; // want something with an open input port
     let wantOpenOutputPort = false; // want something with an open output port
@@ -900,8 +900,8 @@ export class EditorService implements Flo.Editor {
     const openPorts = [];
     let linksIn;
 
-    graph.getElements().filter(e => e.id !== view.model.id && e.attr('metadata/name')).forEach(element => {
-      switch (element.attr('metadata/group')) {
+    graph.getElements().filter(e => e.id !== view.model.id && e.get('metadata')?.name).forEach(element => {
+      switch (element.get('metadata')?.group) {
         case ApplicationType[ApplicationType.source]:
           if (wantOpenOutputPort) {
             const primaryLink = graph.getConnectedLinks(element, { outbound: true }).find(l => !l.attr('props/isTapLink'));

--- a/ui/src/app/streams/components/flo/graph-to-text.spec.ts
+++ b/ui/src/app/streams/components/flo/graph-to-text.spec.ts
@@ -666,7 +666,7 @@ describe('graph-to-text', () => {
     }
 
     function getName(element: dia.Cell) {
-      return element.attr('metadata/name');
+      return element.get('metadata')?.name;
     }
 
     function setLabel(element: dia.Cell, label: string) {

--- a/ui/src/app/streams/components/flo/graph-to-text.ts
+++ b/ui/src/app/streams/components/flo/graph-to-text.ts
@@ -70,7 +70,7 @@ export class GraphToTextConverter {
             // What to do depends on the combination of in/out links
             if (linksIn.length === 0) {
                 if (linksOut.length === 0) {
-                    if (node.attr('metadata/group') === 'app') {
+                    if (node.get('metadata')?.group === 'app') {
                         appStream.push(node);
                     } else {
                         // Isolated node, let's put it in the DSL so it is not lost, the graph is a work in progress.
@@ -240,13 +240,13 @@ export class GraphToTextConverter {
                     if (this.isChannel(node) || this.isChannel(stream[i + 1])) {
                         text += ' > ';
                     } else {
-                        if (node.attr('metadata/group') === 'app') {
+                        if (node.get('metadata')?.group === 'app') {
                             text += ' || ';
                         } else {
                             text += ' | ';
                         }
                     }
-                } else if (node.attr('metadata/name') === 'tap') {
+                } else if (node.get('metadata')?.name === 'tap') {
                     text += ' >'; // the graph isn't well formed but convenient to put this on end of DSL
                 }
             }
@@ -302,11 +302,11 @@ export class GraphToTextConverter {
     }
 
     private isNode(element: dia.Element): boolean {
-        return element.attr('metadata/name');
+        return element.get('metadata')?.name;
     }
 
     private isChannel(e: dia.Cell): boolean {
-        return e && (e.attr('metadata/name') === 'tap' || e.attr('metadata/name') === 'destination');
+        return e && (e.get('metadata')?.name === 'tap' || e.get('metadata')?.name === 'destination');
     }
 
     private findPrimaryLink(links: dia.Link[]): dia.Link {
@@ -332,7 +332,7 @@ export class GraphToTextConverter {
     }
 
     private getName(node: dia.Cell): string {
-        const name: string = node.attr('metadata/name');
+        const name: string = node.get('metadata')?.name;
         if (name === 'destination') {
             return ':' + node.attr('props/name');
         } else {
@@ -345,7 +345,7 @@ export class GraphToTextConverter {
     private toTapString(node: dia.Cell): string {
         let appname: string = node.attr('node-name');
         if (!appname) {
-            appname = node.attr('metadata/name');
+            appname = node.get('metadata')?.name;
         }
         // Note: not allowed to tap a destination
         return GraphToTextConverter.DESTINATION_DSL_PREFIX + this.findStreamName(node) + '.' + appname;
@@ -385,7 +385,7 @@ export class GraphToTextConverter {
         let text = '';
         const props = node.attr('props');
         // Tap nodes less likely when fan-in/fan-out supported but may still occur
-        if ('tap' === node.attr('metadata/name') || 'destination' === node.attr('metadata/name')) {
+        if ('tap' === node.get('metadata')?.name || 'destination' === node.get('metadata')?.name) {
             if (props && props.name) {
                 text += GraphToTextConverter.DESTINATION_DSL_PREFIX + props.name;
             } else {
@@ -397,7 +397,7 @@ export class GraphToTextConverter {
             if (label) { // label
                 text += label + ': ';
             }
-            text += node.attr('metadata/name');
+            text += node.get('metadata')?.name;
             if (props) {
                 const propertiesRanges: Map<string, JsonGraph.Range> = new Map();
                 let propertyStart = startCh + text.length;

--- a/ui/src/app/streams/components/flo/properties-editor.service.ts
+++ b/ui/src/app/streams/components/flo/properties-editor.service.ts
@@ -21,9 +21,9 @@ export class PropertiesEditor {
 
   showForNode(element: dia.Element, graph: dia.Graph) {
     const modalRef = this.bsModalService.show(StreamPropertiesDialogComponent, { class: 'modal-properties' });
-    modalRef.content.name = `${element.attr('metadata/name')}`;
-    modalRef.content.version = `${element.attr('metadata/version')}`;
-    modalRef.content.type = `${element.attr('metadata/group').toUpperCase()}`;
+    modalRef.content.name = `${element.get('metadata')?.name}`;
+    modalRef.content.version = `${element.get('metadata')?.version}`;
+    modalRef.content.type = `${element.get('metadata')?.group.toUpperCase()}`;
     // const streamHeads: dia.Cell[] = flo.getGraph().getElements().filter(e => Utils.canBeHeadOfStream(flo.getGraph(), e));
     // const streamNames = streamHeads
     //   .filter(e => e.attr('stream-name') && e !== c)
@@ -46,9 +46,9 @@ export class PropertiesEditor {
 
   showForLink(link: dia.Link) {
     const modalRef = this.bsModalService.show(StreamPropertiesDialogComponent, { class: 'modal-properties' });
-    modalRef.content.name = `${link.attr('metadata/name')}`;
-    modalRef.content.version = `${link.attr('metadata/version')}`;
-    modalRef.content.type = `${link.attr('metadata/group').toUpperCase()}`;
+    modalRef.content.name = `${link.get('metadata')?.name}`;
+    modalRef.content.version = `${link.get('metadata')?.version}`;
+    modalRef.content.type = `${link.get('metadata')?.group.toUpperCase()}`;
     modalRef.content.setData(this.createPropertiesSourceForLink(link));
   }
 

--- a/ui/src/app/streams/components/flo/properties/stream-properties-source.ts
+++ b/ui/src/app/streams/components/flo/properties/stream-properties-source.ts
@@ -27,12 +27,12 @@ export class StreamGraphPropertiesSource extends GraphNodePropertiesSource imple
 
   protected createNotationalProperties(): AppUiProperty[] {
     const notationalProperties = [];
-    if (typeof ApplicationType[this.cell.attr('metadata/group')] === 'number') {
+    if (typeof ApplicationType[this.cell.get('metadata')?.group] === 'number') {
       notationalProperties.push({
         id: 'label',
         name: 'label',
         type: null,
-        defaultValue: this.cell.attr('metadata/name'),
+        defaultValue: this.cell.get('metadata')?.name,
         attr: 'node-name',
         value: this.cell.attr('node-name'),
         description: 'Label of the app',
@@ -56,7 +56,7 @@ export class StreamGraphPropertiesSource extends GraphNodePropertiesSource imple
   }
 
   protected determineAttributeName(metadata: Flo.PropertyMetadata): string {
-    if (this.cell.attr('metadata/group') === 'other') {
+    if (this.cell.get('metadata')?.group === 'other') {
       // For something in the other group (like tap) use the id not the name of the property
       return `props/${metadata.id}`;
     }

--- a/ui/src/app/streams/components/flo/support/utils.ts
+++ b/ui/src/app/streams/components/flo/support/utils.ts
@@ -25,9 +25,9 @@ import { ApplicationType } from '../../../../shared/model';
 export class Utils {
 
   static canBeHeadOfStream(graph: dia.Graph, element: dia.Element): boolean {
-    if (element.attr('metadata')) {
-      if (!element.attr('.input-port') || element.attr('.input-port/display') === 'none') {
-        if (element.attr('metadata/group') === ApplicationType[ApplicationType.app]) {
+    if (element.get('metadata')) {
+      if (!Utils.hasVisibleInputPorts(element)) {
+        if (element.get('metadata')?.group === ApplicationType[ApplicationType.app]) {
           // For APP nodes if one has `stream-name` set then others cannot have `stream-name` property
           // Check current element. If it has `stream-name` property then it's allowed to have it
           if (element.attr('stream-name')) {
@@ -35,7 +35,7 @@ export class Utils {
           }
           // Otherwise check the rest of APP nodes don't have `stream-name` set
           return !graph.getElements()
-            .filter(e => e.attr('metadata/group') === ApplicationType[ApplicationType.app] && e !== element)
+            .filter(e => e.get('metadata')?.group === ApplicationType[ApplicationType.app] && e !== element)
             .find(e => e.attr('stream-name'));
         } else {
           return true;
@@ -44,6 +44,21 @@ export class Utils {
         const incoming = graph.getConnectedLinks(element, {inbound: true});
         const tapLink = incoming.find(l => l.attr('props/isTapLink'));
         if (tapLink) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static hasVisibleInputPorts(element: dia.Element) {
+    const attrs = element.attributes.attrs;
+    const keys = Object.keys(element.attributes.attrs);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (attrs[key] && attrs[key].magnet && attrs[key].port) {
+        // Port should have magnet and port properties
+        if (attrs[key].port === 'input' && (!attrs[key].display || attrs[key].display === 'block')) {
           return true;
         }
       }

--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.spec.ts
@@ -128,7 +128,7 @@ describe('StreamGraphDefinitionComponent', () => {
       subscription.unsubscribe();
 
       // verify http dots
-      const http = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'http');
+      const http = <dia.Element> component.flo.getGraph().getElements().find(e => e.get('metadata')?.name === 'http');
       expect(http).toBeDefined();
       const httpEmbeds = http.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_DOT);
       expect(http.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_LABEL)).toBeUndefined();
@@ -136,7 +136,7 @@ describe('StreamGraphDefinitionComponent', () => {
       httpMetrics.instances.forEach((instance, i) => expect(httpEmbeds[i].attr('instance')).toEqual(instance));
 
       // verify filter label
-      const filter = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'filter');
+      const filter = <dia.Element> component.flo.getGraph().getElements().find(e => e.get('metadata')?.name === 'filter');
       expect(filter).toBeDefined();
       expect(filter.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_DOT)).toBeUndefined();
       const filterEmbeds = filter.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_LABEL);
@@ -144,7 +144,7 @@ describe('StreamGraphDefinitionComponent', () => {
       expect(filterEmbeds[0].attr('.label/text')).toEqual('57/57');
 
       // verify null dots
-      const nullApp = <dia.Element> component.flo.getGraph().getElements().find(e => e.attr('metadata/name') === 'null');
+      const nullApp = <dia.Element> component.flo.getGraph().getElements().find(e => e.get('metadata')?.name === 'null');
       expect(nullApp).toBeDefined();
       const nullEmbeds = nullApp.getEmbeddedCells().filter(c => c.get('type') === TYPE_INSTANCE_DOT);
       expect(nullApp.getEmbeddedCells().find(c => c.get('type') === TYPE_INSTANCE_LABEL)).toBeUndefined();

--- a/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.ts
+++ b/ui/src/app/streams/components/stream-graph-definition/stream-graph-definition.component.ts
@@ -90,11 +90,11 @@ export class StreamGraphDefinitionComponent implements OnDestroy {
   private updateDots() {
     if (this.flo) {
       this.flo.getGraph().getElements().forEach((element) => {
-        const group = element.attr('metadata/group');
+        const group = element.get('metadata')?.group;
         if (typeof ApplicationType[group] === 'number') {
           let label = element.attr('node-name');
           if (!label) {
-            label = element.attr('metadata/name');
+            label = element.get('metadata')?.name;
           }
           this.updateInstanceDecorations(element, this.findModuleMetrics(label));
         }

--- a/ui/src/app/tasks/components/flo/editor.service.spec.ts
+++ b/ui/src/app/tasks/components/flo/editor.service.spec.ts
@@ -119,14 +119,14 @@ describe('Task RenderService', () => {
     component.editor.setDefaultContent(flo, METAMODEL);
     const nodes = flo.getGraph().getElements();
     expect(nodes.length).toBe(2);
-    expect(nodes[0].attr('metadata/name')).toBe('START');
-    expect(nodes[1].attr('metadata/name')).toBe('END');
+    expect(nodes[0].get('metadata')?.name).toBe('START');
+    expect(nodes[1].get('metadata')?.name).toBe('END');
     expect(flo.getGraph().getLinks().length).toBe(0);
   });
 
   it('simple dnd', () => {
     const taskA = dropNodeFromPaletteOnCanvas(METAMODEL.get('task').get('a'), { x: 100, y: 200 });
-    expect(taskA.attr('metadata/name')).toBe('a');
+    expect(taskA.get('metadata')?.name).toBe('a');
     expect(taskA.get('position').x).toBe(100);
     expect(taskA.get('position').y).toBe(200);
     expect(flo.getPaper().findViewByModel(taskA)).toBeDefined();

--- a/ui/src/app/tasks/components/flo/editor.service.ts
+++ b/ui/src/app/tasks/components/flo/editor.service.ts
@@ -83,8 +83,8 @@ export class EditorService implements Flo.Editor {
   }
 
   private validateConnectedLinks(graph: dia.Graph, element: dia.Element, markers: Array<Flo.Marker>) {
-    if (element.attr('metadata') && !Utils.isUnresolved(element)) {
-      const type = element.attr('metadata/name');
+    if (element.get('metadata') && !Utils.isUnresolved(element)) {
+      const type = element.get('metadata')?.name;
       const incoming = graph.getConnectedLinks(element, { inbound: true });
       const outgoing = graph.getConnectedLinks(element, { outbound: true });
 
@@ -193,7 +193,7 @@ export class EditorService implements Flo.Editor {
       const specifiedProperties = element.attr('props');
       if (specifiedProperties) {
         const propertiesRanges = element.attr('propertiesranges');
-        const appSchema = element.attr('metadata');
+        const appSchema = element.get('metadata');
         appSchema.properties().then(appSchemaProperties => {
           if (!appSchemaProperties) {
             appSchemaProperties = new Map<string, Flo.PropertyMetadata>();
@@ -206,7 +206,7 @@ export class EditorService implements Flo.Editor {
               markers.push({
                 severity: Flo.Severity.Error,
                 message: 'unrecognized option \'' + propertyName + '\' for app \'' +
-                  element.attr('metadata/name') + '\'',
+                  element.get('metadata')?.name + '\'',
                 range: range
               });
             }
@@ -222,10 +222,10 @@ export class EditorService implements Flo.Editor {
 
   private validateMetadata(element: dia.Cell, errors: Array<Flo.Marker>) {
     // Unresolved elements validation
-    if (!element.attr('metadata') || Utils.isUnresolved(element)) {
-      let msg = `Unknown element '${element.attr('metadata/name')}'`;
+    if (!element.get('metadata') || Utils.isUnresolved(element)) {
+      let msg = `Unknown element '${element.get('metadata')?.name}'`;
       if (element.attr('metadata/group')) {
-        msg += ` from group '${element.attr('metadata/group')}'.`;
+        msg += ` from group '${element.get('metadata')?.group}'.`;
       }
       errors.push({
         severity: Flo.Severity.Error,
@@ -250,7 +250,7 @@ export class EditorService implements Flo.Editor {
     return new Promise(resolve => {
       const markers: Map<string | number, Array<Flo.Marker>> = new Map();
       const promises: Promise<void>[] = [];
-      graph.getElements().filter(e => !e.get('parent') && e.attr('metadata')).forEach(e => {
+      graph.getElements().filter(e => !e.get('parent') && e.get('metadata')).forEach(e => {
         promises.push(new Promise<void>((nodeFinished) => {
           this.validateNode(graph, e).then((result) => {
             markers.set(e.id, result);
@@ -265,11 +265,11 @@ export class EditorService implements Flo.Editor {
   }
 
   private hasIncomingPort(element: dia.Element): boolean {
-    return element.attr('metadata/group') !== CONTROL_GROUP_TYPE || element.attr('metadata/name') !== START_NODE_TYPE;
+    return element.get('metadata')?.group !== CONTROL_GROUP_TYPE || element.get('metadata')?.name !== START_NODE_TYPE;
   }
 
   private hasOutgoingPort(element: dia.Element): boolean {
-    return element.attr('metadata/group') !== CONTROL_GROUP_TYPE || element.attr('metadata/name') !== END_NODE_TYPE;
+    return element.get('metadata')?.group !== CONTROL_GROUP_TYPE || element.get('metadata')?.name !== END_NODE_TYPE;
   }
 
   calculateDragDescriptor(flo: Flo.EditorContext, draggedView: dia.CellView, viewUnderMouse: dia.CellView,

--- a/ui/src/app/tasks/components/flo/metamodel.service.ts
+++ b/ui/src/app/tasks/components/flo/metamodel.service.ts
@@ -219,7 +219,7 @@ export class MetamodelService implements Flo.Metamodel {
       } else if ((element.get('type') === joint.shapes.flo.LINK_TYPE)
         && element.get('source').id && element.get('target').id) {
         const properties = {};
-        if (element.attr('metadata') && element.attr('props/ExitStatus')) {
+        if (element.get('metadata') && element.attr('props/ExitStatus')) {
           properties['transitionName'] = element.attr('props/ExitStatus');
         }
         links.push(new Link(element.get('source').id, element.get('target').id, properties));

--- a/ui/src/app/tasks/components/flo/node/task-node.component.ts
+++ b/ui/src/app/tasks/components/flo/node/task-node.component.ts
@@ -26,8 +26,8 @@ export class TaskNodeComponent extends NodeComponent {
   showOptions() {
     const modalRef = this.bsModalService.show(TaskPropertiesDialogComponent);
     const element = this.view.model;
-    modalRef.content.title = `Properties for ${element.attr('metadata/name').toUpperCase()}`;
-    modalRef.content.name = element.attr('metadata/name');
+    modalRef.content.title = `Properties for ${element.get('metadata')?.name.toUpperCase()}`;
+    modalRef.content.name = element.get('metadata')?.name;
     modalRef.content.type = 'TASK';
     modalRef.content.setData(new TaskGraphPropertiesSource(element));
   }

--- a/ui/src/app/tasks/components/flo/properties/task-properties-source.ts
+++ b/ui/src/app/tasks/components/flo/properties/task-properties-source.ts
@@ -13,11 +13,11 @@ export class TaskGraphPropertiesSource extends GraphNodePropertiesSource {
 
   protected createNotationalProperties(): Array<AppUiProperty> {
     const notationalProperties = [];
-    if (typeof ApplicationType[this.cell.attr('metadata/group')] === 'number') {
+    if (typeof ApplicationType[this.cell.get('metadata')?.group] === 'number') {
       notationalProperties.push({
         id: 'label',
         name: 'label',
-        defaultValue: this.cell.attr('metadata/name'),
+        defaultValue: this.cell.get('metadata')?.name,
         attr: 'node-label',
         value: this.cell.attr('node-label'),
         description: 'Label of the task',

--- a/ui/src/app/tasks/components/flo/render.service.ts
+++ b/ui/src/app/tasks/components/flo/render.service.ts
@@ -131,7 +131,7 @@ export class RenderService implements Flo.Renderer {
   createLink() {
     const link = new BatchLink();
     this.metamodelService.load().then(function (metamodel) {
-      link.attr('metadata', metamodel.get('links').get('transition'));
+      link.set('metadata', metamodel.get('links').get('transition'));
     });
     return link;
   }
@@ -148,14 +148,14 @@ export class RenderService implements Flo.Renderer {
   handleLinkEvent(context: Flo.EditorContext, event: string, link: dia.Link): void {
     if (event === 'options') {
       const modalRef = this.bsModalService.show(TaskPropertiesDialogComponent, { class: 'modal-properties' });
-      modalRef.content.name = `${link.attr('metadata/name')}`;
+      modalRef.content.name = `${link.get('metadata')?.name}`;
       modalRef.content.type = `TASK`;
       modalRef.content.setData(new TaskGraphPropertiesSource(link));
     }
   }
 
   initializeNewNode(node: dia.Element, viewerDescriptor: Flo.ViewerDescriptor) {
-    const metadata: Flo.ElementMetadata = node.attr('metadata');
+    const metadata: Flo.ElementMetadata = node.get('metadata');
     if (metadata) {
       if (metadata.group === CONTROL_GROUP_TYPE) {
         // nothing to do here yet for control nodes
@@ -179,11 +179,11 @@ export class RenderService implements Flo.Renderer {
   }
 
   refreshVisuals(element: dia.Cell, changedPropertyPath: string, paper: dia.Paper) {
-    if (element instanceof joint.dia.Element && element.attr('metadata')) {
+    if (element instanceof joint.dia.Element && element.get('metadata')) {
       if (changedPropertyPath === 'node-label') {
         const nodeLabel = element.attr('node-label');
         // fitLabel() calls update as necessary, so set label text silently
-        element.attr('.name-label/text', nodeLabel ? nodeLabel : element.attr('metadata/name'));
+        element.attr('.name-label/text', nodeLabel ? nodeLabel : element.get('metadata')?.name);
         // ViewUtils.fitLabelWithFixedLocation(paper, <dia.Element> element, '.name-label', element.attr('.name-label/refX'));
 
         // Update the view to get default label visuals showing without truncation.
@@ -192,7 +192,7 @@ export class RenderService implements Flo.Renderer {
       }
     }
 
-    if (element instanceof joint.dia.Link && element.attr('metadata')) {
+    if (element instanceof joint.dia.Link && element.get('metadata')) {
 
       if (changedPropertyPath === 'props/ExitStatus') {
         // If the exitstatus has been changed from blank to something then this

--- a/ui/src/app/tasks/components/flo/support/layout.ts
+++ b/ui/src/app/tasks/components/flo/support/layout.ts
@@ -25,9 +25,9 @@ export function layout(paper: dia.Paper) {
       g.setNode(node.id, node.get('size'));
 
       // Determine start and end node
-      if (node.attr('metadata/name') === START_NODE_TYPE && node.attr('metadata/group') === CONTROL_GROUP_TYPE) {
+      if (node.get('metadata')?.name === START_NODE_TYPE && node.get('metadata')?.group === CONTROL_GROUP_TYPE) {
         start = node;
-      } else if (node.attr('metadata/name') === END_NODE_TYPE && node.attr('metadata/group') === CONTROL_GROUP_TYPE) {
+      } else if (node.get('metadata')?.name === END_NODE_TYPE && node.get('metadata')?.group === CONTROL_GROUP_TYPE) {
         end = node;
       } else {
         empty = false;


### PR DESCRIPTION
Moving stream app shapes metadata from `Element.attr(...)` into `Element.prop(...)` (or `Element.set(...)`)
`Element` object is being cloned by JointJS core during various operations properties set with `Element.attr(...)` are being cloned while properties set with 'Element.prop(...)` or Element.set(...) not deep cloned but rather assigned. This allows to have methods and keep cached promises.
JoinJS folks recommended to use `Element.attr(...)` only for SVG dom element attributes and keep the "business" data under `Element.prop(...)'