### PR TITLE
Add settings page

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -82,7 +82,7 @@
       </clr-vertical-nav-group>
       <clr-vertical-nav-group routerLinkActive="active"
                               clrVerticalNavGroupExpanded="false">
-        <clr-icon shape="cog" clrVerticalNavIcon></clr-icon>
+        <clr-icon shape="briefcase" clrVerticalNavIcon></clr-icon>
         Manage
         <clr-vertical-nav-group-children>
           <a
@@ -107,18 +107,14 @@
           </a>
         </clr-vertical-nav-group-children>
       </clr-vertical-nav-group>
+      <a clrVerticalNavLink routerLink="settings" routerLinkActive="active">
+        <clr-icon shape="cog" clrVerticalNavIcon></clr-icon>
+        Settings
+      </a>
       <a clrVerticalNavLink routerLink="dev/dashboard" routerLinkActive="active" *ngIf="isDevEnv">
         <clr-icon shape="bug" clrVerticalNavIcon></clr-icon>
         Dev. mode
       </a>
-
-      <div class="clr-vertical-nav-bottom">
-        <button class="btn btn-sm btn-link" (click)="toggleDarkTheme()">
-          <clr-icon shape="sun" *ngIf="darkThemeIsActive"></clr-icon>
-          <clr-icon shape="moon" *ngIf="!darkThemeIsActive"></clr-icon>
-          {{!darkThemeIsActive ? 'Dark' : 'Light'}}
-        </button>
-      </div>
     </clr-vertical-nav>
     <div class="content-area">
       <router-outlet></router-outlet>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { ThemeService } from './layout/theme/theme.service';
 import { SecurityService } from './security/service/security.service';
 import { environment } from '../environments/environment';
 
@@ -12,24 +11,11 @@ export class AppComponent {
   shouldProtect = this.securityService.shouldProtect();
   securityEnabled = this.securityService.securityEnabled();
 
-  toggleDarkTheme() {
-    this.themeService.switchTheme(this.themeService.getTheme() === 'dark' ? 'default' : 'dark');
-  }
-
-  get darkThemeIsActive() {
-    return this.themeService.getTheme() === 'dark';
-  }
-
   get isDevEnv() {
     return !environment.production;
   }
 
   constructor(
-    private themeService: ThemeService,
     private securityService: SecurityService
-  ) {
-    if (this.themeService.getTheme() === 'dark') {
-      themeService.switchTheme('dark');
-    }
-  }
+  ) { }
 }

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -16,13 +16,15 @@ import { StreamsModule } from './streams/streams.module';
 import { TasksJobsModule } from './tasks-jobs/tasks-jobs.module';
 import { ManageModule } from './manage/manage.module';
 import { SecurityModule } from './security/security.module';
+import { SettingsModule } from './settings/settings.module';
 import { SecurityService } from './security/service/security.service';
-import { map, mergeMap } from 'rxjs/operators';
+import { map, mergeMap, switchMap } from 'rxjs/operators';
 import { Security } from './shared/model/security.model';
 import { of } from 'rxjs';
 import { ROOT_REDUCERS, metaReducers } from './reducers/reducer';
 import { DevModule } from './dev/dev.module';
 import { EffectsModule } from '@ngrx/effects';
+import { SettingsService } from './settings/service/settings.service';
 
 @NgModule({
   declarations: [
@@ -42,6 +44,7 @@ import { EffectsModule } from '@ngrx/effects';
     TasksJobsModule,
     ManageModule,
     SecurityModule,
+    SettingsModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {
@@ -57,7 +60,7 @@ import { EffectsModule } from '@ngrx/effects';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: (securityService: SecurityService, aboutService: AboutService) => {
+      useFactory: (securityService: SecurityService, aboutService: AboutService, settingsService: SettingsService) => {
         return () => {
           return securityService.load()
             .pipe(
@@ -71,10 +74,14 @@ import { EffectsModule } from '@ngrx/effects';
                 }
                 return of(security);
               })
-            ).toPromise();
+            )
+            .pipe(
+              switchMap(() => settingsService.load())
+            )
+            .toPromise();
         };
       },
-      deps: [SecurityService, AboutService],
+      deps: [SecurityService, AboutService, SettingsService],
       multi: true
     }
   ],

--- a/ui/src/app/settings/component/settings.component.html
+++ b/ui/src/app/settings/component/settings.component.html
@@ -1,0 +1,20 @@
+<h1>Settings</h1>
+<div>
+  <form clrForm>
+
+    <clr-select-container>
+      <label>Theme</label>
+      <select clrSelect
+        name="theme"
+        [value]="themeActiveSetting$ | async"
+        (change)="themeActiveSettingOnChange($event.target.value)" >
+        <option value="default">default</option>
+        <option value="dark">dark</option>
+      </select>
+      <clr-control-helper>
+        You can choose between dark and default theme
+      </clr-control-helper>
+    </clr-select-container>
+
+  </form>
+</div>

--- a/ui/src/app/settings/component/settings.component.spec.ts
+++ b/ui/src/app/settings/component/settings.component.spec.ts
@@ -1,0 +1,49 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { StoreModule } from '@ngrx/store';
+import { ClarityModule } from '@clr/angular';
+import { SettingsComponent } from './settings.component';
+import * as fromSettings from '../store/settings.reducer';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+  let mockStore: MockStore;
+
+  const initialState = {
+    [fromSettings.settingsFeatureKey]: {
+      settings: [
+        { name: fromSettings.themeActiveKey, value: fromSettings.themeActiveDefault }
+      ]
+    }
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        ClarityModule,
+        StoreModule.forRoot({})
+      ],
+      providers: [
+        provideMockStore({ initialState })
+      ],
+      declarations: [
+        SettingsComponent
+      ]
+    })
+    .compileComponents();
+    mockStore = TestBed.inject(MockStore);
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/src/app/settings/component/settings.component.ts
+++ b/ui/src/app/settings/component/settings.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { themeActiveKey } from '../store/settings.reducer';
+import { SettingsService } from '../service/settings.service';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.css']
+})
+export class SettingsComponent implements OnInit {
+
+  themeActiveSetting$ = this.settingsService.themeActiveSetting();
+
+  constructor(
+    private settingsService: SettingsService
+  ) { }
+
+  ngOnInit() {
+  }
+
+  themeActiveSettingOnChange(theme: string) {
+    this.settingsService.dispatch({ name: themeActiveKey, value: theme });
+  }
+}

--- a/ui/src/app/settings/service/settings.service.spec.ts
+++ b/ui/src/app/settings/service/settings.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { StoreModule } from '@ngrx/store';
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      HttpClientModule,
+      StoreModule.forRoot({}),
+    ]
+  }));
+
+  it('should be created', () => {
+    const service: SettingsService = TestBed.get(SettingsService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/ui/src/app/settings/service/settings.service.ts
+++ b/ui/src/app/settings/service/settings.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
+import { Observable, of, from } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { themeActiveKey, themeActiveDefault, getThemeActiveSetting } from '../store/settings.reducer';
+import { loaded, update } from '../store/settings.action';
+import { Setting } from '../../shared/model/setting';
+import { State } from '../../reducers/reducer';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SettingsService {
+
+  private DEFAULT: Setting[] = [{ name: themeActiveKey, value: themeActiveDefault }];
+
+  constructor(
+    private store: Store<State>
+  ) { }
+
+  load(): Observable<Setting[]> {
+    // TODO: this should come from a permanent storage
+    return of(this.DEFAULT).pipe(
+      tap((settings) => this.store.dispatch(loaded({ settings })))
+    );
+  }
+
+  update(setting: Setting): Observable<void> {
+    // TODO: should update permanent storage
+    return from(new Promise<void>(resolve => resolve()));
+  }
+
+  dispatch(setting: Setting): void {
+    this.store.dispatch(update({ setting }));
+  }
+
+  themeActiveSetting(): Observable<string> {
+    return this.store.pipe(select(getThemeActiveSetting));
+  }
+}

--- a/ui/src/app/settings/settings-routing.module.ts
+++ b/ui/src/app/settings/settings-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { SecurityGuard } from '../security/support/security.guard';
+import { SettingsComponent } from './component/settings.component';
+
+const routes: Routes = [
+  {
+    path: 'settings',
+    component: SettingsComponent,
+    canActivate: [SecurityGuard]
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SettingsRoutingModule {
+}

--- a/ui/src/app/settings/settings.module.ts
+++ b/ui/src/app/settings/settings.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { ClarityModule } from '@clr/angular';
+import { SharedModule } from '../shared/shared.module';
+import { SettingsRoutingModule } from './settings-routing.module';
+import { SettingsComponent } from './component/settings.component';
+import * as fromSettings from './store/settings.reducer';
+import { SettingsEffect } from './store/settings.effect';
+
+@NgModule({
+  declarations: [
+    SettingsComponent
+  ],
+  imports: [
+    CommonModule,
+    ClarityModule,
+    SharedModule,
+    SettingsRoutingModule,
+    StoreModule.forFeature(fromSettings.settingsFeatureKey, fromSettings.reducer),
+    EffectsModule.forFeature([
+      SettingsEffect
+    ])
+  ]
+})
+export class SettingsModule {
+}

--- a/ui/src/app/settings/store/settings.action.ts
+++ b/ui/src/app/settings/store/settings.action.ts
@@ -1,0 +1,22 @@
+import { createAction, props } from '@ngrx/store';
+import { Setting } from '../../shared/model/setting';
+
+export const loaded = createAction(
+  '[Settings] loaded',
+  props<{ settings: Setting[] }>()
+);
+
+export const update = createAction(
+  '[Setting] update',
+  props<{ setting: Setting }>()
+);
+
+export const updateError = createAction(
+  '[Setting] update error',
+  props<{ setting: Setting }>()
+);
+
+export const updateOk = createAction(
+  '[Setting] update ok',
+  props<{ setting: Setting }>()
+);

--- a/ui/src/app/settings/store/settings.effect.spec.ts
+++ b/ui/src/app/settings/store/settings.effect.spec.ts
@@ -1,0 +1,74 @@
+import { async, TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { cold } from 'jasmine-marbles';
+import { Router } from '@angular/router';
+import { Action } from '@ngrx/store';
+import { Observable, of } from 'rxjs';
+import * as SettingsActions from './settings.action';
+import { SettingsEffect } from './settings.effect';
+import * as fromSettings from './settings.reducer';
+import { ThemeService } from '../../layout/theme/theme.service';
+import { SettingsService } from '../service/settings.service';
+
+describe('settings/store/settings.effect.ts', () => {
+
+  let effects: SettingsEffect;
+  let actions$: Observable<Action>;
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+  const themeServiceSpy = jasmine.createSpyObj('ThemeService', ['switchTheme']);
+  const settingsServiceSpy = jasmine.createSpyObj('SettingsService', ['update']);
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SettingsEffect,
+        provideMockActions(() => actions$),
+        { provide: Router, useValue: routerSpy },
+        { provide: ThemeService, useValue: themeServiceSpy },
+        { provide: SettingsService, useValue: settingsServiceSpy }
+      ]
+    })
+    .compileComponents();
+    effects = TestBed.inject(SettingsEffect);
+  }));
+
+  it('should update settings', () => {
+    // You can't directly test RxJS code that consumes Promises or uses any of the other schedulers
+    // https://rxjs.dev/guide/testing/marble-testing
+    (settingsServiceSpy.update as jasmine.Spy).and.returnValue(cold('(a|)', {a: (void 0)}));
+    actions$ = of(SettingsActions.update({
+        setting: { name: fromSettings.themeActiveKey, value: 'value1' },
+    }));
+    const expected = cold('(a|)', {
+      a: SettingsActions.updateOk({
+        setting: { name: fromSettings.themeActiveKey, value: 'value1' },
+      })
+    });
+    expect(effects.updateSetting$).toBeObservable(expected);
+    expect (settingsServiceSpy.update).toHaveBeenCalledWith({
+      name: fromSettings.themeActiveKey, value: 'value1'
+    });
+  });
+
+  it('should switch initial theme', () => {
+    actions$ = of(SettingsActions.loaded({
+      settings: [ {name: fromSettings.themeActiveKey, value: 'value1'} ]
+    }));
+    const expected = cold('(a|)', {a: 'value1'});
+    expect(effects.initialSettings$).toBeObservable(expected);
+    expect (themeServiceSpy.switchTheme).toHaveBeenCalledWith('value1');
+  });
+
+  it('should switch theme', () => {
+    actions$ = of(SettingsActions.updateOk({
+      setting: { name: fromSettings.themeActiveKey, value: 'value1' }
+    }));
+    const expected = cold('(a|)', {
+      a: SettingsActions.updateOk({
+        setting: { name: fromSettings.themeActiveKey, value: 'value1' },
+      })
+    });
+    expect(effects.updateTheme$).toBeObservable(expected);
+    expect (themeServiceSpy.switchTheme).toHaveBeenCalledWith('value1');
+  });
+});

--- a/ui/src/app/settings/store/settings.effect.ts
+++ b/ui/src/app/settings/store/settings.effect.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { map, exhaustMap, catchError, tap, take, switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { SettingsService } from '../service/settings.service';
+import * as SettingsActions from './settings.action';
+import { ThemeService } from '../../layout/theme/theme.service';
+import { themeActiveKey } from './settings.reducer';
+
+@Injectable()
+export class SettingsEffect {
+
+  updateSetting$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SettingsActions.update),
+      exhaustMap((setting) => this.settingsService.update(setting.setting)
+        .pipe(
+          map(() => SettingsActions.updateOk({setting: setting.setting})),
+          catchError(() => of(SettingsActions.updateError({setting: setting.setting})))
+        )
+      )
+    ),
+    { dispatch: true }
+  );
+
+  initialSettings$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SettingsActions.loaded),
+      take(1),
+      map(action => action.settings.find(s => s.name === themeActiveKey)?.value),
+      tap(theme => {
+        this.themeService.switchTheme(theme);
+      })
+    ),
+    { dispatch: false }
+  );
+
+  updateTheme$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SettingsActions.updateOk),
+      tap(action => {
+        if (action.setting.name === themeActiveKey) {
+          this.themeService.switchTheme(action.setting.value);
+        }
+      })
+    ),
+    { dispatch: false }
+  );
+
+  constructor(
+    private actions$: Actions,
+    private settingsService: SettingsService,
+    private themeService: ThemeService
+  ) {}
+}

--- a/ui/src/app/settings/store/settings.reducer.spec.ts
+++ b/ui/src/app/settings/store/settings.reducer.spec.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@ngrx/store';
+import * as fromSettings from './settings.reducer';
+import * as SettingsActions from './settings.action';
+
+describe('settings/store/settings.reducer.ts', () => {
+
+  it('should return init state', () => {
+    const newState = fromSettings.reducer(undefined, createAction('noop'));
+    expect(newState).toEqual(fromSettings.initialState);
+  });
+
+  it('should load and update', () => {
+    let expectedState: fromSettings.SettingsState = {
+      settings: [{ name: fromSettings.themeActiveKey, value: 'value1'}]
+    };
+    let newState = fromSettings.reducer(undefined, SettingsActions.loaded({
+      settings: [{ name: fromSettings.themeActiveKey, value: 'value1'}]
+    }));
+    expect(newState).toEqual(expectedState);
+    expectedState = {
+      settings: [{ name: fromSettings.themeActiveKey, value: 'value2'}]
+    };
+    newState = fromSettings.reducer(newState, SettingsActions.update({
+      setting: { name: fromSettings.themeActiveKey, value: 'value2' }
+    }));
+    expect(newState).toEqual(expectedState);
+  });
+});

--- a/ui/src/app/settings/store/settings.reducer.ts
+++ b/ui/src/app/settings/store/settings.reducer.ts
@@ -1,0 +1,67 @@
+import { createReducer, on } from '@ngrx/store';
+import * as SettingsActions from './settings.action';
+import * as fromRoot from '../../reducers/reducer';
+import { Setting } from '../../shared/model/setting';
+
+export const settingsFeatureKey = 'settings';
+export const themeActiveKey = 'theme-active';
+export const themeActiveDefault = 'dark';
+
+export interface SettingsState {
+  settings: Setting[];
+}
+
+export interface State extends fromRoot.State {
+  [settingsFeatureKey]: SettingsState;
+}
+
+export const getSettings = (state: State) => {
+  return state.settings.settings;
+};
+
+export const getThemeActiveSetting = (state: State) => {
+  return state.settings.settings.find(s => s.name === themeActiveKey)?.value;
+};
+
+export const initialState: SettingsState = {
+  settings: [
+    { name: themeActiveKey, value: themeActiveDefault }
+  ]
+};
+
+function mergeSettings(left: Setting[], right: Setting[]): Setting[] {
+  const to = [];
+  const toMap = new Map<string, string>();
+  left.forEach(v => {
+    toMap.set(v.name, v.value);
+  });
+  right.forEach(v => {
+    toMap.set(v.name, v.value);
+  });
+  toMap.forEach((v, k) => {
+    to.push({ name: k, value: v });
+  });
+  return to;
+}
+
+function updateSettings(settings: Setting[], setting: Setting): Setting[] {
+  const to = [];
+  settings.forEach(v => {
+    if (v.name === setting.name) {
+      to.push({ name: v.name, value: setting.value});
+    } else {
+      to.push({ name: v.name, value: v.value});
+    }
+  });
+  return to;
+}
+
+export const reducer = createReducer(
+  initialState,
+  on(SettingsActions.update, (state, setting) => {
+    return { settings: updateSettings(state.settings, setting.setting) };
+  }),
+  on(SettingsActions.loaded, (state, settings) => {
+    return { settings: mergeSettings(state.settings, settings.settings) };
+  })
+);

--- a/ui/src/app/shared/model/setting.ts
+++ b/ui/src/app/shared/model/setting.ts
@@ -1,0 +1,4 @@
+export interface Setting {
+  name: string;
+  value: string;
+}


### PR DESCRIPTION
- Remove theme button in favour of changing it from
  a new settings page.
- Model for setting is a simple key/value pair but via
  an interface if we need some more data in it.
- Add store concept and facilities around it.
- For now this settings store is dummy as it doesn't
  yet integration into any permanent store.
- Change Manage item as settings page took the cog shape.
- Fixes #1477