### PR TITLE
Fixes for tap links and default app name

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
     "npm-check-updates": "^4.1.0",
     "rxjs": "6.5.4",
     "sockjs-client": "1.4.0",
-    "spring-flo": "https://github.com/spring-projects/spring-flo.git#18459824f4059a0abb33e4b6f42705e711884814",
+    "spring-flo": "https://github.com/spring-projects/spring-flo.git#a2762b49f231ab793ef8d36a6d12c1ad5bca8e10",
     "stompjs": "2.3.3",
     "tippy.js": "5.2.1",
     "tslib": "1.11.1",

--- a/ui/src/app/streams/components/flo/render.service.ts
+++ b/ui/src/app/streams/components/flo/render.service.ts
@@ -229,7 +229,8 @@ export class RenderService implements Flo.Renderer {
       // If reconnecting source anchor to a shape with existing primary link switch the link to tap link
       if (newSource) {
         const outgoingLinks = graph.getConnectedLinks(newSource, { outbound: true });
-        const primaryLink = outgoingLinks.find(ol => ol !== link && !ol.attr('props/isTapLink'));
+        const primaryLink = outgoingLinks.find(ol => ol !== link && !ol.attr('props/isTapLink')
+          && _.isEqual(ol.source(), link.source()));
 
         link.attr('props/isTapLink', primaryLink ? true : false);
         this.refreshVisuals(link, 'props/isTapLink', flo.getPaper());


### PR DESCRIPTION
1. Switch app name to some string click ok
2. Open **Options** again and remove the name typed in step 1. Click Ok
3. The label should not be bold at this moment anymore (default name shouldn't be bold)

Also there is a fix for creating tap links from by dragging from target port to source port