### PR TITLE
Modal Service with Clarity

### DIFF
--- a/ui/src/app/flo/shared/properties/properties-dialog.component.html
+++ b/ui/src/app/flo/shared/properties/properties-dialog.component.html
@@ -2,7 +2,7 @@
   <div class="modal-title">
     <h3 *ngIf="app" style="margin-top:0.2rem">
       Properties for <strong>{{app.name}}</strong>
-      <span class="{{app.labelTypeClass()}}">{{app.type}}</span>
+      <span class="{{app.labelTypeClass()}}">{{typeString}}</span>
       <span class="label" *ngIf="app.version"><span>{{app.version}}</span></span>
     </h3>
     <label class="modal-search">

--- a/ui/src/app/flo/shared/properties/properties-dialog.component.ts
+++ b/ui/src/app/flo/shared/properties/properties-dialog.component.ts
@@ -1,13 +1,12 @@
-import { Component, ViewEncapsulation, OnInit, Input, AfterViewInit, ViewContainerRef, Inject } from '@angular/core';
+import { Component, ViewEncapsulation, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { PropertiesGroupModel, SearchTextFilter } from '../support/properties-group-model';
 import { debounceTime } from 'rxjs/operators';
 import { App, ApplicationType } from '../../../shared/model/app.model';
-import { GraphNodePropertiesSource } from '../support/graph-node-properties-source';
+import { ModalDialog } from '../../../shared/service/modal.service';
 import { Properties } from 'spring-flo';
 import PropertiesSource = Properties.PropertiesSource;
-import { DOCUMENT } from '@angular/common';
 
 /**
  * Component for displaying application properties and capturing their values.
@@ -21,11 +20,7 @@ import { DOCUMENT } from '@angular/common';
   styleUrls: ['properties-dialog.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class PropertiesDialogComponent implements OnInit {
-
-  @Input() body = false;
-
-  _open = false;
+export class PropertiesDialogComponent extends ModalDialog implements OnInit {
 
   app: App;
 
@@ -41,7 +36,8 @@ export class PropertiesDialogComponent implements OnInit {
 
   propertiesFilter = new SearchTextFilter();
 
-  constructor(@Inject(DOCUMENT) private document: Document, private viewContainerRef: ViewContainerRef) {
+  constructor() {
+    super();
     this.propertiesFormGroup = new FormGroup({});
     this._searchFilterTextSubject = new Subject<string>();
   }
@@ -54,7 +50,6 @@ export class PropertiesDialogComponent implements OnInit {
   }
 
   handleCancel() {
-    // this.bsModalRef.hide();
     this.isOpen = false;
   }
 
@@ -69,15 +64,6 @@ export class PropertiesDialogComponent implements OnInit {
     this._searchFilterTextSubject
       .pipe(debounceTime(500))
       .subscribe(text => this.propertiesFilter.textFilter = text);
-  }
-
-  open(name: string, type: string, version: string, propertiesSource: GraphNodePropertiesSource) {
-    this.app = new App();
-    this.app.name = name;
-    this.app.type = (type as any) as ApplicationType;
-    this.app.version = version;
-    this.setData(propertiesSource);
-    this.isOpen = true;
   }
 
   setData(propertiesSource: PropertiesSource) {
@@ -95,23 +81,17 @@ export class PropertiesDialogComponent implements OnInit {
     this._searchFilterTextSubject.next(text);
   }
 
-  set isOpen(open: boolean) {
-    if (this._open !== open) {
-      this._open = open;
-      if (open) {
-        if (this.body) {
-          this.document.body.appendChild(this.viewContainerRef.element.nativeElement);
-        }
-      } else {
-        if (this.body) {
-          this.document.body.removeChild(this.viewContainerRef.element.nativeElement);
+  get typeString() {
+    if (this.app) {
+      if (this.app.type) {
+        if (typeof this.app.type === 'string') {
+          return <string> this.app.type;
+        } else if (ApplicationType[this.app.type]) {
+          return ApplicationType[this.app.type].toString();
         }
       }
     }
-  }
-
-  get isOpen() {
-    return this._open;
+    return 'UNKNOWN';
   }
 
 }

--- a/ui/src/app/flo/stream/node/stream-node.component.html
+++ b/ui/src/app/flo/stream/node/stream-node.component.html
@@ -88,5 +88,3 @@
 <ul #markerTooltip class="marker-tooltip">
   <li *ngFor="let msg of getErrorMessages()">{{msg}}</li>
 </ul>
-
-<app-stream-properties-dialog-content #options_modal body="true"></app-stream-properties-dialog-content>

--- a/ui/src/app/flo/stream/node/stream-node.component.ts
+++ b/ui/src/app/flo/stream/node/stream-node.component.ts
@@ -2,7 +2,6 @@ import { Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/co
 import { dia } from 'jointjs';
 import { NodeComponent } from '../../shared/support/node-component';
 import { DocService } from '../../shared/service/doc.service';
-import { StreamPropertiesDialogComponent } from '../properties/stream-properties-dialog.component';
 import { PropertiesEditor } from '../properties-editor.service';
 
 /**
@@ -28,14 +27,12 @@ export class StreamNodeComponent extends NodeComponent {
   @ViewChild('paletteNodeTooltip')
   paletteTooltipElement: ElementRef;
 
-  @ViewChild('options_modal', { static: true }) optionsModal: StreamPropertiesDialogComponent;
-
   constructor(docService: DocService, private propertiesEditor: PropertiesEditor) {
     super(docService);
   }
 
   showOptions() {
-    this.propertiesEditor.showForNode(this.optionsModal, <dia.Element> this.view.model, this.paper.model);
+    this.propertiesEditor.showForNode(<dia.Element> this.view.model, this.paper.model);
   }
 
 }

--- a/ui/src/app/flo/stream/properties-editor.service.ts
+++ b/ui/src/app/flo/stream/properties-editor.service.ts
@@ -6,6 +6,9 @@ import {
 } from './properties/stream-properties-source';
 import { Utils } from './support/utils';
 import { PropertiesDialogComponent } from '../shared/properties/properties-dialog.component';
+import { ModalService } from '../../shared/service/modal.service';
+import { StreamPropertiesDialogComponent } from './properties/stream-properties-dialog.component';
+import { App, ApplicationType } from '../../shared/model/app.model';
 
 /**
  * Service for creating properties source for properties dialog component
@@ -15,12 +18,16 @@ import { PropertiesDialogComponent } from '../shared/properties/properties-dialo
 @Injectable()
 export class PropertiesEditor {
 
-  constructor() {}
+  constructor(protected modalService: ModalService) {}
 
-  showForNode(propertiesDialog: PropertiesDialogComponent, element: dia.Element, graph: dia.Graph) {
-    const name = `${element.prop('metadata/name')}`;
-    const version = `${element.prop('metadata/version')}`;
-    const type = `${element.prop('metadata/group').toUpperCase()}`;
+  showForNode(element: dia.Element, graph: dia.Graph) {
+    const app = new App();
+    app.name = `${element.prop('metadata/name')}`;
+    app.type = (`${element.prop('metadata/group').toUpperCase()}` as any) as ApplicationType;
+    app.version = `${element.prop('metadata/version')}`;
+
+    const modal = this.modalService.show(StreamPropertiesDialogComponent);
+    modal.app = app;
 
     const streamHeads: dia.Cell[] = graph.getElements().filter(e => Utils.canBeHeadOfStream(graph, e));
 
@@ -30,7 +37,7 @@ export class PropertiesEditor {
         .map(e => e.attr('stream-name'))
     } : undefined;
 
-    propertiesDialog.open(name, type, version, this.createPropertiesSourceForNode(element, streamHead));
+    modal.setData(this.createPropertiesSourceForNode(element, streamHead));
   }
 
   protected createPropertiesSourceForNode(element: dia.Element, streamHead: StreamHead): StreamGraphPropertiesSource {
@@ -38,10 +45,15 @@ export class PropertiesEditor {
   }
 
   showForLink(propertiesDialog: PropertiesDialogComponent, link: dia.Link) {
-    const name = `${link.prop('metadata/name')}`;
-    const version = `${link.prop('metadata/version')}`;
-    const type = `${link.prop('metadata/group').toUpperCase()}`;
-    propertiesDialog.open(name, type, version, this.createPropertiesSourceForLink(link));
+    const app = new App();
+    app.name = `${link.prop('metadata/name')}`;
+    app.type = (`${link.prop('metadata/group').toUpperCase()}` as any) as ApplicationType;
+    app.version = `${link.prop('metadata/version')}`;
+
+    const modal = this.modalService.show(StreamPropertiesDialogComponent);
+    modal.app = app;
+
+    modal.setData(this.createPropertiesSourceForLink(link));
 
   }
 

--- a/ui/src/app/flo/stream/properties/stream-properties-dialog.component.ts
+++ b/ui/src/app/flo/stream/properties/stream-properties-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ViewContainerRef, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { Properties } from 'spring-flo';
 import { Validators } from '@angular/forms';
 import { StreamAppPropertiesSource } from './stream-properties-source';
@@ -7,7 +7,6 @@ import { StreamService } from '../../../shared/api/stream.service';
 import { Observable } from 'rxjs';
 import { AppUiProperty } from '../../shared/support/app-ui-property';
 import { PropertiesDialogComponent } from '../../shared/properties/properties-dialog.component';
-import { DOCUMENT } from '@angular/common';
 
 // CM extension necessary for snippet support syntax highlighting
 // Lint support
@@ -104,9 +103,8 @@ export class StreamPropertiesDialogComponent extends PropertiesDialogComponent {
 
   public title: string;
 
-  constructor(@Inject(DOCUMENT) document: Document, viewContainerRef: ViewContainerRef, private streamsService: StreamService) {
-    // super(bsModalRef);
-    super(document, viewContainerRef);
+  constructor(private streamsService: StreamService) {
+    super();
   }
 
   setData(propertiesSource: StreamAppPropertiesSource) {

--- a/ui/src/app/flo/task/editor.service.spec.ts
+++ b/ui/src/app/flo/task/editor.service.spec.ts
@@ -63,7 +63,7 @@ describe('Task RenderService', () => {
     fixture = TestBed.createComponent(EditorComponent);
     component = fixture.componentInstance;
     component.metamodel = METAMODEL_SERVICE;
-    component.renderer = new RenderService(METAMODEL_SERVICE, resolver, fixture.debugElement.injector, applicationRef);
+    component.renderer = new RenderService(METAMODEL_SERVICE, null, resolver, fixture.debugElement.injector, applicationRef);
     component.editor = new EditorService();
     const subscription = component.floApi.subscribe((f) => {
       subscription.unsubscribe();

--- a/ui/src/app/flo/task/node/task-node.component.html
+++ b/ui/src/app/flo/task/node/task-node.component.html
@@ -154,5 +154,3 @@
 <ul #markerTooltip class="marker-tooltip">
   <li *ngFor="let msg of getErrorMessages()">{{msg}}</li>
 </ul>
-
-<app-task-properties-dialog-content #options_modal body="true"></app-task-properties-dialog-content>

--- a/ui/src/app/flo/task/node/task-node.component.ts
+++ b/ui/src/app/flo/task/node/task-node.component.ts
@@ -2,7 +2,9 @@ import { Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/co
 import { TaskGraphPropertiesSource } from '../properties/task-properties-source';
 import { NodeComponent } from '../../shared/support/node-component';
 import { DocService } from '../../shared/service/doc.service';
-import { StreamPropertiesDialogComponent } from '../../stream/properties/stream-properties-dialog.component';
+import { ModalService } from '../../../shared/service/modal.service';
+import { App, ApplicationType } from '../../../shared/model/app.model';
+import { TaskPropertiesDialogComponent } from '../properties/task-properties-dialog-component';
 
 /**
  * Component for displaying application properties and capturing their values.
@@ -24,17 +26,20 @@ export class TaskNodeComponent extends NodeComponent {
   @ViewChild('nodeTooltip')
   nodeTooltipElement: ElementRef;
 
-  @ViewChild('options_modal', { static: true })
-  optionsModal: StreamPropertiesDialogComponent;
-
-  constructor(docService: DocService) {
+  constructor(docService: DocService,
+              private modalService?: ModalService) {
     super(docService);
   }
 
   showOptions() {
     const element = this.view.model;
-    this.optionsModal.title = `Properties for ${element.prop('metadata/name').toUpperCase()}`;
-    this.optionsModal.open(element.prop('metadata/name'), 'TASK', null, new TaskGraphPropertiesSource(element));
+    const modal = this.modalService.show(TaskPropertiesDialogComponent);
+    const app = new App();
+    app.name = element.prop('metadata/name');
+    app.type = ApplicationType.task;
+    modal.app = app;
+    modal.title = `Properties for ${element.prop('metadata/name').toUpperCase()}`;
+    modal.setData(new TaskGraphPropertiesSource(element));
   }
 
 }

--- a/ui/src/app/flo/task/properties/task-properties-dialog-component.ts
+++ b/ui/src/app/flo/task/properties/task-properties-dialog-component.ts
@@ -1,13 +1,12 @@
 /* tslint:disable:no-access-missing-member */
 
-import { Component, Inject, ViewContainerRef, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { Properties } from 'spring-flo';
 import { Validators } from '@angular/forms';
 import PropertiesSource = Properties.PropertiesSource;
 import { AppUiProperty } from '../../shared/support/app-ui-property';
 import { PropertiesDialogComponent } from '../../shared/properties/properties-dialog.component';
 import { PropertiesGroupModel } from '../../shared/support/properties-group-model';
-import { DOCUMENT } from '@angular/common';
 
 
 /**
@@ -53,12 +52,10 @@ class TaskPropertiesGroupModel extends PropertiesGroupModel {
 })
 export class TaskPropertiesDialogComponent extends PropertiesDialogComponent {
 
-  isOpen = false;
   public title: string;
 
-  constructor(@Inject(DOCUMENT) document: Document, viewContainerRef: ViewContainerRef) {
-    // super(bsModalRef);
-    super(document, viewContainerRef);
+  constructor() {
+    super();
   }
 
   setData(propertiesSource: PropertiesSource) {

--- a/ui/src/app/flo/task/render.service.spec.ts
+++ b/ui/src/app/flo/task/render.service.spec.ts
@@ -6,7 +6,7 @@
 import { MetamodelService } from './metamodel.service';
 import { RenderService } from './render.service';
 import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
-import { EditorComponent, Flo, FloModule } from 'spring-flo';
+import { EditorComponent, Flo } from 'spring-flo';
 import * as _$ from 'jquery';
 import { CONTROL_GROUP_TYPE, END_NODE_TYPE, START_NODE_TYPE, SYNC_NODE_TYPE, TASK_GROUP_TYPE } from './support/shapes';
 import { ApplicationRef, ComponentFactoryResolver } from '@angular/core';
@@ -63,7 +63,7 @@ describe('Task RenderService', () => {
     fixture = TestBed.createComponent(EditorComponent);
     component = fixture.componentInstance;
     component.metamodel = METAMODEL_SERVICE;
-    component.renderer = new RenderService(METAMODEL_SERVICE, resolver,
+    component.renderer = new RenderService(METAMODEL_SERVICE, null, resolver,
       fixture.debugElement.injector, applicationRef);
     const subscription = component.floApi.subscribe((f) => {
       subscription.unsubscribe();

--- a/ui/src/app/flo/task/render.service.ts
+++ b/ui/src/app/flo/task/render.service.ts
@@ -16,6 +16,8 @@ import { ElementComponent } from '../shared/support/shape-component';
 import { ViewUtils } from '../shared/support/view-utils';
 import { LoggerService } from '../../shared/service/logger.service';
 import { createPaletteGroupHeader } from '../shared/support/shared-shapes';
+import { App, ApplicationType } from '../../shared/model/app.model';
+import { ModalService } from '../../shared/service/modal.service';
 
 const joint: any = _joint;
 
@@ -37,6 +39,7 @@ const SYNC_CANVAS_SIZE = { width: 100, height: 40 };
 export class RenderService implements Flo.Renderer {
 
   constructor(private metamodelService: MetamodelService,
+              private modalService?: ModalService,
               private componentFactoryResolver?: ComponentFactoryResolver,
               private injector?: Injector,
               private applicationRef?: ApplicationRef) {
@@ -145,11 +148,12 @@ export class RenderService implements Flo.Renderer {
    */
   handleLinkEvent(context: Flo.EditorContext, event: string, link: dia.Link): void {
     if (event === 'options') {
-      // TODO
-      // const modalRef = this.bsModalService.show(TaskPropertiesDialogComponent, { class: 'modal-properties' });
-      // modalRef.content.name = `${link.prop('metadata/name')}`;
-      // modalRef.content.type = `TASK`;
-      // modalRef.content.setData(new TaskGraphPropertiesSource(link));
+      const app = new App();
+      app.name = `${link.prop('metadata/name')}`;
+      app.type = ApplicationType.task;
+      const modal = this.modalService.show(TaskPropertiesDialogComponent);
+      modal.app = app;
+      modal.setData(new TaskGraphPropertiesSource(link));
     }
   }
 

--- a/ui/src/app/shared/service/modal.service.ts
+++ b/ui/src/app/shared/service/modal.service.ts
@@ -1,0 +1,78 @@
+import {
+  ApplicationRef,
+  ComponentFactoryResolver,
+  ComponentRef,
+  Inject,
+  EventEmitter,
+  Injectable,
+  Injector,
+  Type
+} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Subject } from 'rxjs';
+
+export class ModalDialog {
+
+  private _open = false;
+
+  private _opened = new EventEmitter<boolean>();
+
+  set isOpen(open: boolean) {
+    if (this._open !== open) {
+      this._open = open;
+      this._opened.emit(open);
+    }
+  }
+
+  get isOpen() {
+    return this._open;
+  }
+
+  get opened(): Subject<boolean> {
+    return this._opened;
+  }
+}
+
+/**
+ * A service for bringing up modal dialogs
+ *
+ * @author Alex Boyko
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ModalService {
+
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private componentFactoryResolver: ComponentFactoryResolver,
+    private injector: Injector,
+    private applicationRef: ApplicationRef
+  ) {}
+
+  public show<T extends ModalDialog>(componentType: Type<T>): T {
+    const nodeComponentFactory = this.componentFactoryResolver.resolveComponentFactory(componentType);
+
+    const componentRef: ComponentRef<T> = nodeComponentFactory.create(this.injector);
+
+    componentRef.changeDetectorRef.markForCheck();
+    componentRef.changeDetectorRef.detectChanges();
+
+    this.applicationRef.attachView(componentRef.hostView);
+    this.document.body.appendChild(componentRef.location.nativeElement);
+
+    const subscription = componentRef.instance.opened.subscribe((open) => {
+      if (!open) {
+        this.document.body.removeChild(componentRef.location.nativeElement);
+        this.applicationRef.detachView(componentRef.hostView);
+        componentRef.destroy();
+        subscription.unsubscribe();
+      }
+    });
+
+    componentRef.instance.isOpen = true;
+
+    return componentRef.instance;
+  }
+
+}


### PR DESCRIPTION
Fixes #1495 

Generally makes Clarity modal dialog easier to use (similarly to **ngx-bootstrap** lib **BsModalService**) across application.