### PR TITLE
Fix 5% zoom in create stream page after switching stream list

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
     "luxon": "1.23.0",
     "ngx-toastr": "12.0.1",
     "rxjs": "6.5.4",
-    "spring-flo": "https://github.com/spring-projects/spring-flo#6509f623d1296edef27dea6326f45b2342c31d6f",
+    "spring-flo": "https://github.com/spring-projects/spring-flo#ab8c162113ea37e03f6f1e4221e746e87c185901",
     "tippy.js": "6.2.7",
     "tslib": "^2.0.0",
     "uuid": "8.1.0",


### PR DESCRIPTION
Fix the following:
- create a stream
- show the graph in the list streams
- Go to create stream
- file | log => no graph

(Fixed in Flo - problem is two Flo editors hence lookup for HTML elements by id should be parent scoped)