### PR TITLE
Add messaging when error from thinexecutions endpoint on Job executions screen

### DIFF
--- a/ui/src/app/tasks-jobs/jobs/jobs.component.ts
+++ b/ui/src/app/tasks-jobs/jobs/jobs.component.ts
@@ -38,6 +38,8 @@ export class JobsComponent extends DatagridComponent {
           this.page = page;
           this.updateGroupContext(params);
           this.loading = false;
+        }, error => {
+          this.notificationService.error('An error occurred', error);
         });
     }
   }

--- a/ui/src/app/tasks-jobs/jobs/jobs.component.ts
+++ b/ui/src/app/tasks-jobs/jobs/jobs.component.ts
@@ -39,6 +39,7 @@ export class JobsComponent extends DatagridComponent {
           this.updateGroupContext(params);
           this.loading = false;
         }, error => {
+          this.loading = false;
           this.notificationService.error('An error occurred', error);
         });
     }


### PR DESCRIPTION
Addresses #1620.

Came across this. When a job isn't properly tagged as a Task app, it causes a 404 which causes the job executions screen to spin without any prompts to the user. This can be a bit misleading, so this change adds a notification on the screen when this happens. 

<img width="1464" alt="Screen Shot 2021-01-05 at 11 40 30 AM" src="https://user-images.githubusercontent.com/19558427/103672863-e39fb180-4f4a-11eb-9df0-bce14f10cb4b.png">
