### PR TITLE
Canvas node tooltip width

### DIFF
--- a/ui/src/app/flo/stream/node/stream-node.component.html
+++ b/ui/src/app/flo/stream/node/stream-node.component.html
@@ -18,7 +18,7 @@
   <svg:g class="stream-module">
     <svg:rect class="select-outline"/>
     <svg:g class="shape" tippy [content]="canvasTooltipElement ? canvasTooltipElement.nativeElement : ''"
-           [tippyOptions]="{appendTo: docBody(), placement: 'bottom', delay: 300}"
+           [tippyOptions]="{appendTo: docBody(), placement: 'bottom', delay: 300, maxWidth: 'none'}"
            [attr.disabled]="isDisabled || !canShowCanvasNodeTooltip ? '' : null">
       <svg:rect class="box"/>
 <!--      <svg:image class="type-icon"/>-->

--- a/ui/src/app/flo/task/node/task-node.component.html
+++ b/ui/src/app/flo/task/node/task-node.component.html
@@ -21,7 +21,7 @@
   <svg:g *ngSwitchCase="'END'" class="composed-task">
     <svg:ellipse class="select-outline"/>
     <svg:g class="shape" tippy [content]="nodeTooltipElement ? nodeTooltipElement.nativeElement : ''"
-           [tippyOptions]="{appendTo: docBody(), placement: 'bottom', delay: 300}"
+           [tippyOptions]="{appendTo: docBody(), placement: 'bottom', delay: 300, maxWidth: 'none'}"
            [attr.disabled]="isDisabled ? '' : null">
       <svg:ellipse class="end-outer"/>
       <svg:ellipse class="end-inner"/>


### PR DESCRIPTION
Fixes #1624 

Let width of the tooltip be equal to the table width as table width is well limited already