### PR TITLE
Delay loading ctr options

### DIFF
--- a/ui/src/app/shared/model/task.model.ts
+++ b/ui/src/app/shared/model/task.model.ts
@@ -98,7 +98,13 @@ export class TaskLaunchConfig {
   }[];
 
   /** Ctr options metadata */
-  ctr: ValuedConfigurationMetadataProperty[];
+  ctr: {
+    options: ValuedConfigurationMetadataProperty[];
+    optionsState: {
+      isLoading: boolean;
+      isOnError: boolean;
+    };
+  };
 
   constructor() {
   }

--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.html
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.html
@@ -244,14 +244,21 @@
 
             <!-- 10 Ctr Properties options -->
             <div class="line-body"
-                 *ngIf="state.ctr && task.composed && builder.ctrProperties.length > 0">
-              <div class="form-control form-control-label">
+                 *ngIf="state.ctr && task.composed">
+              <div class="form-control form-control-label"
+                   *ngIf="!builder.ctrPropertiesState.isLoading && !builder.ctrPropertiesState.isOnError">
                 <strong>{{getCtrProperties(builder.ctrProperties).length}}</strong>
                 <span> /</span> {{builder.ctrProperties.length}} properties
                 <button tabindex="{{401}}" type="button" (click)="openCtrProperties(builder)"
                         class="btn btn-sm btn-secondary">
                   Edit
                 </button>
+              </div>
+              <div *ngIf="builder.ctrPropertiesState.isLoading" class="form-control form-control-label">
+                Loading ...
+              </div>
+              <div *ngIf="builder.ctrPropertiesState.isOnError" class="form-control form-control-label">
+                Error Loading
               </div>
             </div>
 

--- a/ui/src/app/tests/service/task-launch.service.mock.ts
+++ b/ui/src/app/tests/service/task-launch.service.mock.ts
@@ -1,5 +1,7 @@
 import { Observable, of } from 'rxjs';
-import { ValuedConfigurationMetadataPropertyList } from '../../shared/model/detailed-app.model';
+import {
+  ValuedConfigurationMetadataProperty, ValuedConfigurationMetadataPropertyList
+} from '../../shared/model/detailed-app.model';
 import { TaskLaunchConfig } from '../../shared/model/task.model';
 import { TaskLaunchService } from '../../tasks-jobs/tasks/launch/task-launch.service';
 import { ApplicationType } from '../../shared/model/app.model';
@@ -54,7 +56,13 @@ export class TaskLaunchServiceMock {
         }
       }
     ];
-    config.ctr = ValuedConfigurationMetadataPropertyList.parse(CTR_OPTIONS);
+    config.ctr = {
+      options: ValuedConfigurationMetadataPropertyList.parse(CTR_OPTIONS),
+      optionsState: {
+        isLoading: false,
+        isOnError: false
+      }
+    };
     config.deployers = [
       {
         id: 'memory',
@@ -68,6 +76,10 @@ export class TaskLaunchServiceMock {
     ];
 
     return of(config);
+  }
+
+  ctrOptions(): Observable<ValuedConfigurationMetadataProperty[]> {
+    return of([]);
   }
 
   appDetails(type: ApplicationType, name: string, version: string): Observable<Array<any>> {


### PR DESCRIPTION
- As loading ctr options may be a tad slow as it backing
  metadata may come from a jar needed to get downloaded and
  may result error, etc. Delay this operation after
  initial form is built and then update needed form states.
- Also skip load if task is not ctr.
- Fixes #1644

NOTE: for existing functionality to see behaviour, just restart a server and zap ~/.m2/repository/org/springframework/cloud/spring-cloud-dataflow-composed-task-runner.