### PR TITLE
Redirect to task execution after launch

### DIFF
--- a/ui/src/app/shared/api/task.service.ts
+++ b/ui/src/app/shared/api/task.service.ts
@@ -71,7 +71,7 @@ export class TaskService {
     return forkJoin(tasks.map(task => this.destroyTask(task)));
   }
 
-  launch(taskName: string, args: string, props: string): Observable<any> {
+  launch(taskName: string, args: string, props: string): Observable<number> {
     const headers = HttpUtils.getDefaultHttpHeaders();
     let params = new HttpParams().append('name', taskName);
     if (args) {
@@ -81,8 +81,16 @@ export class TaskService {
       params = params.append('properties', props);
     }
     return this.httpClient
-      .post('/tasks/executions', {}, { headers, params })
+      .post<string>('/tasks/executions', {}, { headers, params })
       .pipe(
+        map(body => {
+          const parsed = parseInt(body, 10);
+          if (isNaN(parsed)) {
+            // sanity check if we get something unexpected
+            throw new Error(`Can't parse ${body} as executionId`);
+          }
+          return parsed;
+        }),
         catchError(ErrorUtils.catchError)
       );
   }

--- a/ui/src/app/tasks-jobs/tasks/launch/launch.component.spec.ts
+++ b/ui/src/app/tasks-jobs/tasks/launch/launch.component.spec.ts
@@ -134,7 +134,7 @@ describe('streams/streams/deploy/deploy.component.ts', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     expect(spy).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledWith(['/tasks-jobs/tasks']);
+    expect(navigate).toHaveBeenCalledWith(['tasks-jobs/task-executions/0']);
     done();
   });
 

--- a/ui/src/app/tasks-jobs/tasks/launch/launch.component.ts
+++ b/ui/src/app/tasks-jobs/tasks/launch/launch.component.ts
@@ -179,9 +179,9 @@ export class LaunchComponent implements OnInit, OnDestroy {
     this.updateArguments(args);
     const prepared = this.prepareParams(this.task.name, this.arguments, this.properties);
     this.taskService.launch(prepared.name, prepared.args, prepared.props)
-      .subscribe(() => {
+      .subscribe((executionId) => {
           this.notificationService.success('Launch success', `Successfully launched task definition "${this.task.name}"`);
-          this.router.navigate(['/tasks-jobs/tasks']);
+          this.router.navigate([`tasks-jobs/task-executions/${executionId}`]);
         },
         error => {
           const err = error.message ? error.message : error.toString();

--- a/ui/src/app/tests/api/task.service.mock.ts
+++ b/ui/src/app/tests/api/task.service.mock.ts
@@ -38,8 +38,8 @@ export class TaskServiceMock {
     return of(tasks);
   }
 
-  launch(taskName: string, args: string, props: string): Observable<any> {
-    return of({});
+  launch(taskName: string, args: string, props: string): Observable<number> {
+    return of(0);
   }
 
   executionStop(taskExecution: TaskExecution): Observable<any> {


### PR DESCRIPTION
- Now simple parse body response from a task launch
  and redirect to returned task execution.
- No special handling of batch
  (aka trying to redirect job execution instead) as batch
  is expected to be a task?
- Fixes #1599