### PR TITLE
Dehydrate task launch deployment properties

### DIFF
--- a/ui/src/app/shared/model/task-execution.model.ts
+++ b/ui/src/app/shared/model/task-execution.model.ts
@@ -17,7 +17,7 @@ export class TaskExecution {
   parentExecutionId: number;
   resourceUrl: string;
   appProperties: object;
-  deploymentProperties: object;
+  deploymentProperties: {[key: string]: string};
 
   static parse(input) {
     const execution = new TaskExecution();
@@ -55,13 +55,13 @@ export class TaskExecution {
     return [];
   }
 
-  getDeploymentPropertiesToArray(): Array<any> {
+  getDeploymentPropertiesToArray(): Array<[key: string, value: string]> {
     if (this.deploymentProperties && Object.keys(this.deploymentProperties).length > 0) {
       return Object.keys(this.deploymentProperties).map((key) => {
-        return {
+        return [
           key,
-          value: this.deploymentProperties[key]
-        };
+          this.deploymentProperties[key]
+        ];
       });
     }
     return [];

--- a/ui/src/app/shared/model/task.model.ts
+++ b/ui/src/app/shared/model/task.model.ts
@@ -106,6 +106,8 @@ export class TaskLaunchConfig {
     };
   };
 
+  deploymentProperties: string[];
+
   constructor() {
   }
 }

--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.spec.ts
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.spec.ts
@@ -73,4 +73,19 @@ describe('tasks-jobs/tasks/launch/builder/builder.component.ts', () => {
     fixture.detectChanges();
     expect(component['getArguments']()).toEqual(jasmine.arrayContaining(['app.t1.0=--arg', 'app.t2.0=--arg']));
   });
+
+  it('should parse and dehydrate properties correctly', async () => {
+    component.task = TASK_2;
+    component.properties = [
+      'app.composed-task-runner.split-thread-max-pool-size=10',
+      'deployer.t1.cpu=1',
+      'app.t1.timestamp.format=yyyy'
+    ];
+    fixture.detectChanges();
+    expect(component['getProperties']()).toEqual(jasmine.arrayContaining([
+      'app.composed-task-runner.split-thread-max-pool-size=10',
+      'deployer.t1.cpu=1',
+      'app.t1.timestamp.format=yyyy'
+    ]));
+  });
 });

--- a/ui/src/app/tasks-jobs/tasks/launch/free-text/free-text.component.html
+++ b/ui/src/app/tasks-jobs/tasks/launch/free-text/free-text.component.html
@@ -44,7 +44,7 @@
         </div>
       </ng-template>
     </div>
-    <textarea dataflowAutoResize [dataflowFocus]="true" formControlName="ainput"></textarea>
+    <textarea dataflowAutoResize formControlName="ainput"></textarea>
   </div>
   <div class="bar">
     <div class="btn-group">

--- a/ui/src/app/tests/service/task-launch.service.mock.ts
+++ b/ui/src/app/tests/service/task-launch.service.mock.ts
@@ -74,12 +74,26 @@ export class TaskLaunchServiceMock {
         suffix: 'MB'
       }
     ];
+    config.deploymentProperties = [];
 
     return of(config);
   }
 
   ctrOptions(): Observable<ValuedConfigurationMetadataProperty[]> {
-    return of([]);
+    return of([
+      {
+        id: 'split-thread-max-pool-size',
+        name: 'split-thread-max-pool-size',
+        type: 'java.lang.Integer',
+        description: 'Split\'s maximum pool size. Default is {@code Integer.MAX_VALUE}.',
+        shortDescription: 'Split\'s maximum pool size.',
+        defaultValue: null,
+        deprecation: null,
+        sourceType: '',
+        isDeprecated: false,
+        value: ''
+      }
+    ]);
   }
 
   appDetails(type: ApplicationType, name: string, version: string): Observable<Array<any>> {


### PR DESCRIPTION
- Get deploy props from last execution and re-calculate
  properties so that those will get shows in a form in
  a same way when you'd switch between build/free-text.
- We skip expected sensity values as those are not
  known anymore.
- Fixes #1651