### PR TITLE
Show horizontal scroll for logs not only at bottom

### DIFF
--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -65,9 +65,11 @@ h1 {
 
 .clr-log {
   padding: 1rem 0;
+  max-height: inherit;
 
   pre {
     overflow: scroll;
+    max-height: inherit;
     background: var(--clr-header-6-bg-color, #00364d);
     padding: 1rem;
     color: var(--clr-header-title-color, #fafafa);

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -68,7 +68,7 @@ h1 {
   max-height: inherit;
 
   pre {
-    overflow: scroll;
+    overflow: auto;
     max-height: inherit;
     background: var(--clr-header-6-bg-color, #00364d);
     padding: 1rem;


### PR DESCRIPTION
The logs available in SCDF can contain quite long lines. Currently, the horizontal scroll bar for that is only visible when one scrolls to the very bottom of the log. This makes it unnecessarily complicated to read the long lines, in my opinion.

Clarity's `modal-body` sets `max-height` to `70vh`. Only if this is inherited for the log, the horizontal scroll bar is always shown.

I observed the problem in both Firefox and Chrome. The PR fixes it for both. The only other use of `clr-log` is for the exit description of steps. With the PR applied, that widget looks same as before in both browsers, respectively.

Below two screenshots from Firefox with the PR applied:

![task_log](https://user-images.githubusercontent.com/25299532/111084328-15686200-8512-11eb-8653-3a9508f0eb78.PNG)
![step_exit_desc](https://user-images.githubusercontent.com/25299532/111084330-1ac5ac80-8512-11eb-9384-64586e071315.PNG)


