### PR TITLE
Split task arguments only at first equal sign

### DIFF
--- a/ui/src/app/shared/model/task-execution.model.ts
+++ b/ui/src/app/shared/model/task-execution.model.ts
@@ -40,7 +40,13 @@ export class TaskExecution {
   }
 
   getArgumentsToArray(): Array<any> {
-    return (this.arguments || []).map((arg) => arg.split('='));
+    return (this.arguments || []).map((arg) => {
+      const index = arg.indexOf('=');
+      if (index === -1) {
+        return [arg];
+      }
+      return [arg.substring(0, index), arg.substring(index + 1)];
+    });
   }
 
   getAppPropertiesToArray(): Array<any> {


### PR DESCRIPTION
When a user wants the sub tasks of a composed task to be started with the argument `foo=bar`, they can start the composed task with the argument `--composed-task-arguments=foo=bar`. On the page for the execution of the composed task, the `=bar` is currently scrapped as seen here:

![without_bar](https://user-images.githubusercontent.com/25299532/111916166-eace5a00-8a79-11eb-9892-ae4e51cd0986.PNG)

With the proposed change, it looks like this

![with_bar](https://user-images.githubusercontent.com/25299532/111916208-181b0800-8a7a-11eb-8f14-c00af4fc8e0f.PNG)

