### PR TITLE
Fix line breaks in textarea for Firefox

### DIFF
--- a/ui/src/app/tasks-jobs/tasks/launch/free-text/free-text.component.scss
+++ b/ui/src/app/tasks-jobs/tasks/launch/free-text/free-text.component.scss
@@ -38,9 +38,9 @@
 
   textarea {
     margin: 0;
-    overflow: hidden;
-    overflow-x: scroll;
-    white-space: nowrap;
+    overflow-y: hidden;
+    overflow-x: auto;
+    white-space: pre;
     border: 0 none;
     border-radius: 0;
     height: 20px;


### PR DESCRIPTION
In Firefox, line breaks are not shown in the `textarea` widgets when launching tasks. It currently looks as in the screenshot below. In Chrome, everything looks fine.

The PR changes `white-space` from `nowrap` to `pre`. That way, in both browsers
- line breaks are shown,
- and long lines are not wrapped

I also set `overflow-x` from `scroll` to `auto` to only show the horizontal scroll bar when there is actually something to scroll.

That the arguments are flagged as invalid in the screenshot is a separate issue: https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/1686

![without_fix](https://user-images.githubusercontent.com/25299532/112209544-e04ac680-8c19-11eb-9149-deb186dcdb6c.PNG)
