### PR TITLE
Add migration concept for old ctr app properties

### DIFF
--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.html
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.html
@@ -1,4 +1,24 @@
 <div *ngIf="builder$ | async as builder; else loading">
+
+  <clr-alert *ngIf="task.composed && hasMigrations()" [clrAlertType]="info" [clrAlertClosable]="false">
+    <clr-alert-item>
+      <span class="alert-text">
+        There are properties which can be migrated.
+      </span>
+      <div class="alert-actions">
+        <clr-dropdown>
+          <button class="dropdown-toggle" clrDropdownTrigger>
+            Actions
+            <cds-icon shape="caret" direction="down"></cds-icon>
+          </button>
+          <clr-dropdown-menu clrPosition="bottom-right">
+            <a (click)="migrage()" class="dropdown-item" clrDropdownItem>Migrate</a>
+          </clr-dropdown-menu>
+        </clr-dropdown>
+      </div>
+    </clr-alert-item>
+  </clr-alert>
+
   <form class="form-horizontal" novalidate (ngSubmit)="launchTask()">
     <div>
       <div class="tab-pane">
@@ -244,7 +264,7 @@
 
             <!-- 10 Ctr Properties options -->
             <div class="line-body"
-                 *ngIf="state.ctr && task.composed">
+                 *ngIf="state.ctr && task.composed && builder.ctrProperties.length > 0">
               <div class="form-control form-control-label"
                    *ngIf="!builder.ctrPropertiesState.isLoading && !builder.ctrPropertiesState.isOnError">
                 <strong>{{getCtrProperties(builder.ctrProperties).length}}</strong>

--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.html
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.html
@@ -12,7 +12,7 @@
             <cds-icon shape="caret" direction="down"></cds-icon>
           </button>
           <clr-dropdown-menu clrPosition="bottom-right">
-            <a (click)="migrage()" class="dropdown-item" clrDropdownItem>Migrate</a>
+            <a (click)="migrate()" class="dropdown-item" clrDropdownItem>Migrate</a>
           </clr-dropdown-menu>
         </clr-dropdown>
       </div>

--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.spec.ts
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.spec.ts
@@ -88,4 +88,27 @@ describe('tasks-jobs/tasks/launch/builder/builder.component.ts', () => {
       'app.t1.timestamp.format=yyyy'
     ]));
   });
+
+  it('should have migrations', async () => {
+    component.task = TASK_2;
+    component.properties = [
+      'app.composed-task-runner.composed-task-properties=app.composedtask-t2.app.timestamp.timestamp.format=YYYY',
+      'app.t1.timestamp.format=YYYY'
+    ];
+    fixture.detectChanges();
+    expect(component['calculateMigrations']().migratedMatch.length).toBe(1);
+    expect(component['calculateMigrations']().migratedNomatch.length).toBe(0);
+    expect(component['hasMigrations']()).toBeTruthy();
+  });
+
+  it('should not have migrations', async () => {
+    component.task = TASK_2;
+    component.properties = [
+      'app.t1.timestamp.format=YYYY'
+    ];
+    fixture.detectChanges();
+    expect(component['calculateMigrations']().migratedMatch.length).toBe(0);
+    expect(component['calculateMigrations']().migratedNomatch.length).toBe(0);
+    expect(component['hasMigrations']()).toBeFalsy();
+  });
 });

--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.ts
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.ts
@@ -1035,7 +1035,7 @@ export class BuilderComponent implements OnInit, OnDestroy {
     return this.migrations && this.migrations.migratedMatch && this.migrations.migratedMatch.length > 0;
   }
 
-  migrage() {
+  migrate() {
     if (this.migrations) {
       const ctp = this.refBuilder.ctrProperties.find(prop => prop.id === 'composed-task-properties' && prop.value);
       if (ctp) {

--- a/ui/src/app/tests/data/task.ts
+++ b/ui/src/app/tests/data/task.ts
@@ -270,7 +270,7 @@ export const SIMPLE_TASK_DEFAULT = {
   'description': 'simpledescription',
   'dslText': 'timestamp',
   'lastTaskExecution': null,
- ' name': 'simpletask',
+  'name': 'simpletask',
   'status': 'UNKNOWN'
 };
 
@@ -281,7 +281,7 @@ export const COMPOSED_TASK_DEFAULT = {
   'description': 'composeddescription',
   'dslText': 't1:timestamp && t2:timestamp',
   'lastTaskExecution': null,
- ' name': 'composedtask',
+  'name': 'composedtask',
   'status': 'UNKNOWN'
 };
 

--- a/ui/src/app/tests/service/task-launch.service.mock.ts
+++ b/ui/src/app/tests/service/task-launch.service.mock.ts
@@ -92,6 +92,18 @@ export class TaskLaunchServiceMock {
         sourceType: '',
         isDeprecated: false,
         value: ''
+      },
+      {
+        id: 'composed-task-properties',
+        name: 'composed-task-properties',
+        type: 'java.lang.Integer',
+        description: 'The properties to be used for each of the tasks as well as their deployments.',
+        shortDescription: 'The properties to be used for each of the tasks as well as their deployments.',
+        defaultValue: null,
+        deprecation: null,
+        sourceType: '',
+        isDeprecated: false,
+        value: ''
       }
     ]);
   }


### PR DESCRIPTION
- Add Some UI fu to let user to automatically migrate
  from old ctr app properties(given in 2.7.x line) and
  migrate those to new expected ctr options.
- For this work correctly also #1721 needs to be fixed which
  is a bigger topic and will get done in a separate commit.
- Fixes #1715