### PR TITLE
Handle clearing out ctr options

### DIFF
--- a/ui/src/app/shared/model/detailed-app.model.ts
+++ b/ui/src/app/shared/model/detailed-app.model.ts
@@ -22,7 +22,7 @@ export class ConfigurationMetadataProperty {
   type: string;
   description: string;
   shortDescription: string;
-  defaultValue: string;
+  defaultValue: string | boolean | number;
   deprecation: Deprecation;
   sourceType: string;
   isDeprecated: boolean;
@@ -50,6 +50,7 @@ export class ConfigurationMetadataProperty {
 export class ValuedConfigurationMetadataProperty extends ConfigurationMetadataProperty {
 
   value: string;
+  originalValue?: string;
 
   static parse(input) {
     return ConfigurationMetadataProperty.parse(input) as ValuedConfigurationMetadataProperty;

--- a/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.spec.ts
+++ b/ui/src/app/tasks-jobs/tasks/launch/builder/builder.component.spec.ts
@@ -89,6 +89,21 @@ describe('tasks-jobs/tasks/launch/builder/builder.component.ts', () => {
     ]));
   });
 
+  it('should set property value empty when it is cleared', async () => {
+    component.task = TASK_2;
+    component.properties = [
+      'app.composed-task-runner.split-thread-max-pool-size=',
+      'deployer.t1.cpu=1',
+      'app.t1.timestamp.format=yyyy'
+    ];
+    fixture.detectChanges();
+    expect(component['getProperties']()).toEqual(jasmine.arrayContaining([
+      'app.composed-task-runner.split-thread-max-pool-size=',
+      'deployer.t1.cpu=1',
+      'app.t1.timestamp.format=yyyy'
+    ]));
+  });
+
   it('should have migrations', async () => {
     component.task = TASK_2;
     component.properties = [

--- a/ui/src/app/tests/service/task-launch.service.mock.ts
+++ b/ui/src/app/tests/service/task-launch.service.mock.ts
@@ -74,7 +74,9 @@ export class TaskLaunchServiceMock {
         suffix: 'MB'
       }
     ];
-    config.deploymentProperties = [];
+    config.deploymentProperties = [
+      'app.composed-task-runner.split-thread-max-pool-size=10'
+    ];
 
     return of(config);
   }
@@ -94,12 +96,36 @@ export class TaskLaunchServiceMock {
         value: ''
       },
       {
+        id: 'split-thread-core-pool-size',
+        name: 'split-thread-core-pool-size',
+        type: 'java.lang.Integer',
+        description: 'Split\'s core pool size. Default is 4\;',
+        shortDescription: 'Split\'s core pool size.',
+        defaultValue: 4,
+        deprecation: null,
+        sourceType: '',
+        isDeprecated: false,
+        value: ''
+      },
+      {
         id: 'composed-task-properties',
         name: 'composed-task-properties',
         type: 'java.lang.Integer',
         description: 'The properties to be used for each of the tasks as well as their deployments.',
         shortDescription: 'The properties to be used for each of the tasks as well as their deployments.',
         defaultValue: null,
+        deprecation: null,
+        sourceType: '',
+        isDeprecated: false,
+        value: ''
+      },
+      {
+        id: 'increment-instance-enabled',
+        name: 'increment-instance-enabled',
+        type: 'java.lang.Boolean',
+        description: 'Allows a single ComposedTaskRunner instance to be re-executed without changing the parameters. Default is false which means a ComposedTaskRunner instance can only be executed once with a given set of parameters, if true it can be re-executed.',
+        shortDescription: 'Allows a single ComposedTaskRunner instance to be re-executed without changing the parameters.',
+        defaultValue: true,
         deprecation: null,
         sourceType: '',
         isDeprecated: false,


### PR DESCRIPTION
- Now allows to clear out existing crt option which will
  then get removed from manifest by sending option as
  empty value.
- NOTE: this will only touch crt and we have same issues
  i.e. with app option, which goes to different issue #1730
- Fixes #1721