### PR TITLE
Enable restart button when job status is STOPPED

### DIFF
--- a/ui/src/app/tasks-jobs/jobs/execution/execution.component.html
+++ b/ui/src/app/tasks-jobs/jobs/execution/execution.component.html
@@ -3,7 +3,7 @@
 
   <div class="datagrid-action-bar">
     <button type="button" class="btn btn-sm btn-secondary" (click)="restart()"
-            [disabled]="execution.status !== 'FAILED' && execution.status !== 'ERROR'">
+            [disabled]="execution.status !== 'FAILED' && execution.status !== 'STOPPED' && execution.status !== 'ERROR'">
       Restart the job
     </button>
     <button type="button" class="btn btn-sm btn-secondary" (click)="stop()"

--- a/ui/src/app/tasks-jobs/jobs/jobs.component.html
+++ b/ui/src/app/tasks-jobs/jobs/jobs.component.html
@@ -71,7 +71,7 @@
     <clr-dg-action-overflow>
       <button class="action-item" (click)="details(execution)">Details</button>
       <button class="action-item" (click)="restart(execution)"
-              [disabled]="execution.status !== 'FAILED' && execution.status !== 'ERROR'">
+              [disabled]="execution.status !== 'FAILED' && execution.status !== 'STOPPED' && execution.status !== 'ERROR'">
         Restart
       </button>
       <button class="action-item" (click)="stop(execution)"


### PR DESCRIPTION
Fix the issue #1747 : 
Currently, The "Restart The Job" button is not enabled for the job execution if its status is "Stopped". The restart button is disabled in issue #1407 and the pull request #1408. It is only enabled for the "Failed" job. I think it should be enabled for the "Stopped" job as well.
Please help to review.