### PR TITLE
fix: Logos missing in about dialog

### DIFF
--- a/ui/src/app/about/info/info.component.scss
+++ b/ui/src/app/about/info/info.component.scss
@@ -1,0 +1,5 @@
+.modal-about {
+  clr-icon {
+    color: var(--clr-global-font-color);
+  }
+}

--- a/ui/src/app/about/info/info.component.ts
+++ b/ui/src/app/about/info/info.component.ts
@@ -8,7 +8,7 @@ import {JsonPipe} from '@angular/common';
 @Component({
   selector: 'app-about-info',
   templateUrl: './info.component.html',
-  styleUrls: ['./info.component.scss'],
+  styleUrls: ['./info.component.scss']
 })
 export class InfoComponent implements OnInit {
   loading = true;

--- a/ui/src/app/about/info/info.component.ts
+++ b/ui/src/app/about/info/info.component.ts
@@ -7,7 +7,8 @@ import {JsonPipe} from '@angular/common';
 
 @Component({
   selector: 'app-about-info',
-  templateUrl: './info.component.html'
+  templateUrl: './info.component.html',
+  styleUrls: ['./info.component.scss'],
 })
 export class InfoComponent implements OnInit {
   loading = true;


### PR DESCRIPTION
- Solved rendering of icons inside 'About' modal 
