### PR TITLE
Fix plural of compound nouns

### DIFF
--- a/ui/src/app/layout/nav/nav.component.html
+++ b/ui/src/app/layout/nav/nav.component.html
@@ -33,8 +33,8 @@
     Tasks / Jobs
     <clr-vertical-nav-group-children>
       <a clrVerticalNavLink routerLinkActive="active" routerLink="tasks-jobs/tasks"> Tasks </a>
-      <a clrVerticalNavLink routerLinkActive="active" routerLink="tasks-jobs/task-executions"> Tasks executions </a>
-      <a clrVerticalNavLink routerLinkActive="active" routerLink="tasks-jobs/job-executions"> Jobs executions </a>
+      <a clrVerticalNavLink routerLinkActive="active" routerLink="tasks-jobs/task-executions"> Task executions </a>
+      <a clrVerticalNavLink routerLinkActive="active" routerLink="tasks-jobs/job-executions"> Job executions </a>
       <a
         clrVerticalNavLink
         routerLinkActive="active"


### PR DESCRIPTION
I'm not a native speaker but I think only one `s` is added to form the plural of compound nouns.