### PR TITLE
Solve validation message on invalid task name input

### DIFF
--- a/ui/src/app/tasks-jobs/tasks/create/create.component.html
+++ b/ui/src/app/tasks-jobs/tasks/create/create.component.html
@@ -65,7 +65,7 @@
           <div class="clr-subtext" *ngIf="taskName?.errors && taskName?.errors?.uniqueResource">
             Task name is already taken!
           </div>
-          <div class="clr-subtext" *ngIf="taskName?.errors && taskName?.errors?.pattern">Task task name!</div>
+          <div class="clr-subtext" *ngIf="taskName?.errors && taskName?.errors?.pattern">Invalid task name!</div>
           <div class="clr-subtext" *ngIf="taskName?.errors && taskName?.errors?.maxlength">
             Task name must be less than 256 characters long!
           </div>


### PR DESCRIPTION
Fixed label in 'Create task'.  
It happens when editing task name input with unwanted characters.
Resolves #1805.

Before:

![image](https://user-images.githubusercontent.com/54085737/149803371-09914723-cf06-4d3f-9843-40b8c647dc70.png)


After:

![image](https://user-images.githubusercontent.com/54085737/149804022-d0d57e76-40a9-4d29-8e2e-6d59e636c57b.png)
