### PR TITLE
Fix URL for en.json to prevent 403

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -103,5 +103,5 @@ export class AppModule {}
 
 // required for AOT compilation
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
-  return new TranslateHttpLoader(http, UrlUtilities.calculateAssetUrl() + '/i18n/');
+  return new TranslateHttpLoader(http, UrlUtilities.calculateAssetUrl() + 'i18n/');
 }


### PR DESCRIPTION
Spring Security Filter resulted in 403 when URL contained //

```
org.springframework.security.web.firewall.RequestRejectedException: The request was rejected because the URL contained a potentially malicious String "//"
at org.springframework.security.web.firewall.StrictHttpFirewall.rejectedBlocklistedUrls(StrictHttpFirewall.java:456)
at org.springframework.security.web.firewall.StrictHttpFirewall.getFirewalledRequest(StrictHttpFirewall.java:429)
at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:196)
```

All other uses of `calculateAssetUrl()` assumed it ends with a `/`