### PR TITLE
Translations on tasks table

### DIFF
--- a/ui/src/app/tasks-jobs/tasks/tasks.component.html
+++ b/ui/src/app/tasks-jobs/tasks/tasks.component.html
@@ -87,7 +87,7 @@
     (clrDgColumnResize)="updateContext('sizeDescription', $event)"
     [style.width.px]="context.sizeDescription | datagridcolumn: datagrid:contextName:15 | async"
   >
-    <ng-container> Description </ng-container>
+    <ng-container>{{ 'commons.description' | translate }}</ng-container>
     <clr-dg-filter style="display: none"></clr-dg-filter>
   </clr-dg-column>
   <clr-dg-column
@@ -113,7 +113,7 @@
       </a>
     </clr-dg-cell>
     <clr-dg-cell
-      ><span class="text-truncate">{{ task.description }}</span></clr-dg-cell
+      ><span class="text-truncate">{{ commons.description }}</span></clr-dg-cell
     >
     <clr-dg-cell
       ><span class="dsl-text dsl-truncate">{{ task.dslText }}</span></clr-dg-cell

--- a/ui/src/app/tasks-jobs/tasks/tasks.component.html
+++ b/ui/src/app/tasks-jobs/tasks/tasks.component.html
@@ -113,7 +113,7 @@
       </a>
     </clr-dg-cell>
     <clr-dg-cell
-      ><span class="text-truncate">{{ commons.description }}</span></clr-dg-cell
+      ><span class="text-truncate">{{ task.description }}</span></clr-dg-cell
     >
     <clr-dg-cell
       ><span class="dsl-text dsl-truncate">{{ task.dslText }}</span></clr-dg-cell


### PR DESCRIPTION
Resolves #1848 

Found one missing translation on task page ("Description")

"Definition" and "Status" are already translated into the code. 
When looking on German translations it seemed to me they were wrong but in the end "Definition" and "Status" are valid german words for english "Definition" and "Status".

