### PR TITLE
fix: datagrid highlight color

### DIFF
--- a/ui/src/app/layout/theme/dark-theme.ts
+++ b/ui/src/app/layout/theme/dark-theme.ts
@@ -158,7 +158,7 @@ export const darkTheme: Theme = {
     '--clr-card-box-shadow': '0 0.15rem 0 0 var(--clr-card-border-color)',
     '--clr-card-divider-color': 'var(--clr-card-border-color)',
     '--clr-datagrid-icon-color': 'hsl(203, 16%, 72%)',
-    '--clr-datagrid-row-hover': 'hsl(201, 31%, 23%)',
+    '--clr-datagrid-row-hover': 'rgba(35, 46, 52)',
     '--clr-datagrid-row-selected': 'hsl(0, 0%, 100%)',
     '--clr-datagrid-popover-bg-color': 'hsl(198, 28%, 18%)',
     '--clr-datagrid-action-toggle': 'hsl(203, 16%, 72%)',

--- a/ui/src/app/layout/theme/default-theme.ts
+++ b/ui/src/app/layout/theme/default-theme.ts
@@ -2,6 +2,8 @@ import {Theme} from './types';
 
 export const defaultTheme: Theme = {
   name: 'default',
-  properties: {},
+  properties: {
+    '--clr-datagrid-row-hover': 'rgba(232, 232, 232)'
+  },
   other: ''
 };

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -63,6 +63,10 @@ h1:not([cds-text]) {
   }
 }
 
+.datagrid-row:hover, .datagrid-row:hover .datagrid-row-sticky {
+  background-color: rgb(35, 46, 52);
+}
+
 .clr-log {
   padding: 1rem 0;
   max-height: inherit;

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -63,10 +63,6 @@ h1:not([cds-text]) {
   }
 }
 
-.datagrid-row:hover, .datagrid-row:hover .datagrid-row-sticky {
-  background-color: rgb(35, 46, 52);
-}
-
 .clr-log {
   padding: 1rem 0;
   max-height: inherit;
@@ -99,6 +95,10 @@ h1:not([cds-text]) {
 
 .branding {
   width: 240px;
+}
+
+.datagrid-row:hover, .datagrid-row:hover .datagrid-row-sticky {
+  background: var(--clr-datagrid-row-hover);
 }
 
 .datagrid-row .datagrid-row-sticky {


### PR DESCRIPTION
fixes: https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/1920

The highlight of the datagrid-rows is much less intrusive, now.

![Bildschirmfoto 2023-05-17 um 07 37 38](https://github.com/spring-cloud/spring-cloud-dataflow-ui/assets/980773/dcc6aac0-cd55-40a2-aee3-428f00ee2b92)
