### PR TITLE
feat: Angular OAuth2 login page

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -5,11 +5,22 @@
       {{ 'appRoot.appTitle' | translate }}
       <h5 class="hint">{{ 'appRoot.youHaveToLogin' | translate }}</h5>
     </section>
-    <div style="padding-bottom: 50px">
-      <a href="{{ baseApiUrl }}login" class="btn btn-primary"> Log In </a>
-    </div>
+    <div *ngIf="isOAuth2; then oauth2; else standard"></div>
   </form>
 </div>
+
+<ng-template #standard>
+  <div style="padding-bottom: 50px">
+    <a href="{{ baseApiUrl }}login" class="btn btn-primary"> Log In </a>
+  </div>
+</ng-template>
+<ng-template #oauth2>
+  <div *ngFor="let item of clientRegistrations | async">
+    <div style="padding-bottom: 50px">
+      <a href="{{ baseApiUrl }}oauth2/authorization/{{ item }}" class="btn btn-primary">{{ item }}</a>
+    </div>
+  </div>
+</ng-template>
 
 <ng-template #main>
   <clr-main-container>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -11,6 +11,8 @@ import {UrlUtilities} from './url-utilities.service';
 export class AppComponent {
   shouldProtect = this.securityService.shouldProtect();
   securityEnabled = this.securityService.securityEnabled();
+  isOAuth2 = this.securityService.isOAuth2();
+  clientRegistrations = this.securityService.clientRegistrations();
   baseApiUrl = UrlUtilities.calculateBaseApiUrl();
 
   constructor(

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -83,7 +83,8 @@ import {UrlUtilities} from './url-utilities.service';
                   security.authenticationEnabled,
                   security.authenticated,
                   security.username,
-                  security.roles
+                  security.roles,
+                  security.clientRegistrations
                 );
                 if (security.authenticated || !security.authenticationEnabled) {
                   return aboutService.load().pipe(map(() => security));

--- a/ui/src/app/security/service/security.service.spec.ts
+++ b/ui/src/app/security/service/security.service.spec.ts
@@ -93,7 +93,7 @@ describe('security/service/security.service.ts integration', () => {
   });
 
   it('should have proper state after loaded', () => {
-    service.loaded(false, true, 'fakeuser', ['role1']);
+    service.loaded(false, true, 'fakeuser', ['role1'], []);
 
     let expected = cold('(a|)', {a: false});
     expect(service.securityEnabled().pipe(take(1))).toBeObservable(expected);

--- a/ui/src/app/security/store/security.action.ts
+++ b/ui/src/app/security/store/security.action.ts
@@ -2,7 +2,13 @@ import {createAction, props} from '@ngrx/store';
 
 export const loaded = createAction(
   '[Security] Loaded',
-  props<{enabled: boolean; authenticated: boolean; username: string; roles: string[]}>()
+  props<{enabled: boolean; authenticated: boolean; username: string; roles: string[]; clientRegistrations: string[]}>()
 );
-export const logout = createAction('[Security] Logout');
-export const unauthorised = createAction('[Security] Unauthorised');
+export const logout = createAction(
+  '[Security] Logout',
+  props<{enabled: boolean; authenticated: boolean; username: string; roles: string[]; clientRegistrations: string[]}>()
+);
+export const unauthorised = createAction(
+  '[Security] Unauthorised',
+  props<{enabled: boolean; authenticated: boolean; username: string; roles: string[]; clientRegistrations: string[]}>()
+);

--- a/ui/src/app/security/store/security.effect.spec.ts
+++ b/ui/src/app/security/store/security.effect.spec.ts
@@ -20,8 +20,15 @@ describe('Security Effect', () => {
   }));
 
   it('Unauthorised should logout', () => {
-    actions$ = of(SecurityAction.unauthorised());
-    const expected = cold('(a|)', {a: SecurityAction.logout()});
+    const props = {
+      authenticated: false,
+      enabled: false,
+      username: '',
+      roles: [],
+      clientRegistrations: []
+    };
+    actions$ = of(SecurityAction.unauthorised(props));
+    const expected = cold('(a|)', {a: SecurityAction.logout(props)});
     expect(effects.securityReset$).toBeObservable(expected);
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
   });

--- a/ui/src/app/security/store/security.reducer.spec.ts
+++ b/ui/src/app/security/store/security.reducer.spec.ts
@@ -13,7 +13,8 @@ describe('security/store/security.reducer.ts', () => {
       enabled: false,
       authenticated: true,
       username: 'fakeuser',
-      roles: ['role1', 'role2']
+      roles: ['role1', 'role2'],
+      clientRegistrations: ['test_registration', 'test_registration2']
     };
     let newState = fromSecurity.reducer(
       undefined,
@@ -21,7 +22,8 @@ describe('security/store/security.reducer.ts', () => {
         enabled: false,
         authenticated: true,
         username: 'fakeuser',
-        roles: ['role1', 'role2']
+        roles: ['role1', 'role2'],
+        clientRegistrations: ['test_registration', 'test_registration2']
       })
     );
     expect(newState).toEqual(expectedState);
@@ -29,9 +31,19 @@ describe('security/store/security.reducer.ts', () => {
       enabled: false,
       authenticated: false,
       username: undefined,
-      roles: []
+      roles: [],
+      clientRegistrations: ['test_registration', 'test_registration2']
     };
-    newState = fromSecurity.reducer(newState, SecurityActions.logout());
+    newState = fromSecurity.reducer(
+      newState,
+      SecurityActions.logout({
+        enabled: false,
+        authenticated: false,
+        username: undefined,
+        roles: [],
+        clientRegistrations: ['test_registration', 'test_registration2']
+      })
+    );
     expect(newState).toEqual(expectedState);
   });
 });

--- a/ui/src/app/security/store/security.reducer.ts
+++ b/ui/src/app/security/store/security.reducer.ts
@@ -9,6 +9,7 @@ export interface SecurityState {
   authenticated: boolean;
   username: string;
   roles: string[];
+  clientRegistrations?: string[];
 }
 
 export interface State extends fromRoot.State {
@@ -23,17 +24,22 @@ export const getAuthenticated = (state: State): boolean => state[securityFeature
 
 export const getUsername = (state: State): string => state[securityFeatureKey].username;
 
+export const getClientRegistrations = (state: State): string[] => state[securityFeatureKey].clientRegistrations;
+
 export const getRoles = (state: State): string[] => state[securityFeatureKey].roles;
 
 export const getShouldProtect = createSelector(getEnabled, getAuthenticated, (enabled, authenticated) =>
   !enabled ? false : enabled && !authenticated
 );
 
+export const isOAuth2 = createSelector(getClientRegistrations, clientRegistrations => clientRegistrations.length > 0);
+
 export const initialState: SecurityState = {
   enabled: true,
   authenticated: false,
   username: undefined,
-  roles: []
+  roles: [],
+  clientRegistrations: []
 };
 
 export const reducer = createReducer(
@@ -42,12 +48,14 @@ export const reducer = createReducer(
     enabled: props.enabled,
     authenticated: props.authenticated,
     username: props.username,
-    roles: props.roles
+    roles: props.roles,
+    clientRegistrations: props.clientRegistrations
   })),
-  on(SecurityActions.logout, state => ({
+  on(SecurityActions.logout, (state, props) => ({
     enabled: state.enabled,
     authenticated: false,
     username: undefined,
-    roles: []
+    roles: props.roles,
+    clientRegistrations: props.clientRegistrations
   }))
 );

--- a/ui/src/app/shared/model/security.model.ts
+++ b/ui/src/app/shared/model/security.model.ts
@@ -3,4 +3,5 @@ export interface Security {
   authenticated: boolean;
   username: string;
   roles: string[];
+  clientRegistrations: string[];
 }

--- a/ui/src/app/tests/data/security.ts
+++ b/ui/src/app/tests/data/security.ts
@@ -3,5 +3,6 @@ export const LOAD = {
   authenticated: false,
   username: null,
   roles: [],
+  clientRegistrations: [],
   _links: {self: {href: 'http://localhost:4200/security/info'}}
 };


### PR DESCRIPTION
Address the issue: https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/1887

When OAuth2 is enabled and there are `client-registrations` with `authorization-grand-type` `authorization_code` all those are going to be listed within the Angular-Login, now. Also when you logout and login again you are redirected correctly.

❗There is one thing required to be fixed. Please refer to the backend issue for that. (See: https://github.com/spring-cloud/spring-cloud-dataflow/pull/5350)

See:

![Bildschirmfoto 2023-05-19 um 12 38 34](https://github.com/spring-cloud/spring-cloud-dataflow-ui/assets/980773/cd316b71-f42c-4e33-85dc-6a06ba4ec9bd)

and:

![Bildschirmfoto 2023-05-19 um 12 34 28](https://github.com/spring-cloud/spring-cloud-dataflow-ui/assets/980773/cbdf75da-9465-4e69-b513-bb49f50eee9a)

and:

![Bildschirmfoto 2023-05-19 um 12 30 38](https://github.com/spring-cloud/spring-cloud-dataflow-ui/assets/980773/d75272e7-e35c-4305-994c-255bb4056554)