### PR TITLE
Fix duration label key

### DIFF
--- a/ui/src/app/tasks-jobs/jobs/step/step.component.html
+++ b/ui/src/app/tasks-jobs/jobs/step/step.component.html
@@ -423,7 +423,7 @@
                 </div>
               </div>
               <div class="row">
-                <div class="key">{{ 'executions.main.startTime' | translate }}</div>
+                <div class="key">{{ 'executions.main.duration' | translate }}</div>
                 <div class="value">
                   {{ taskExecution.startTime | duration: taskExecution.endTime }}
                 </div>


### PR DESCRIPTION
When we select specific step execution from the job execution screen, on the left where the task execution details are shown, while showing the duration, the label Start Time is used instead of duration.
![image](https://github.com/spring-cloud/spring-cloud-dataflow-ui/assets/85237747/475cf3c9-a25b-4251-a403-ef881bed5c9f)

