### PR TITLE
fix: clean up should be available if streams are disabled

### DIFF
--- a/ui/src/app/manage/tools/tools.component.html
+++ b/ui/src/app/manage/tools/tools.component.html
@@ -1,7 +1,7 @@
 <h1>{{ 'tools.title' | translate }}</h1>
 
 <div class="clr-row">
-  <div class="clr-col-lg-6 clr-col-md-12 clr-col-12" appRole appFeature="streams">
+  <div class="clr-col-lg-12 clr-col-md-12 clr-col-12" appRole appFeature="streams">
     <app-view-card
       [titleModal]="'tools.streams' | translate"
       keyContext="import-export"
@@ -19,7 +19,8 @@
         </div>
       </ng-template>
     </app-view-card>
-
+  </div>
+  <div class="clr-col-lg-12 clr-col-md-12 clr-col-12" appRole appFeature="tasks">
     <app-view-card
       [titleModal]="'tools.cleanUp' | translate"
       keyContext="import-export"
@@ -37,8 +38,7 @@
         </div>
       </ng-template>
     </app-view-card>
-  </div>
-  <div class="clr-col-lg-6 clr-col-md-12 clr-col-12" appRole appFeature="tasks">
+
     <app-view-card [titleModal]="'tools.tasks' | translate" keyContext="import-export" name="import-export" id="tasks">
       <ng-template>
         <div>


### PR DESCRIPTION
Fixes: https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/1942

`CLEAN UP TASK EXECUTIONS` has been moved into the container with `appFeature="tasks"`

Because this looks weird, as on the right side there would be two `app-view-card` and on the left only one I decided to make them all `clr-col-lg-12` to get the max width of the parent container.

<img width="1336" alt="Bildschirmfoto 2023-08-03 um 08 17 43" src="https://github.com/spring-cloud/spring-cloud-dataflow-ui/assets/980773/2d9907f6-0234-4c96-8599-f520ffce74ff">

