### PR TITLE
[CI] Update jfrog cli to v3 

### DIFF
--- a/.github/workflows/build-snapshot-worker.yml
+++ b/.github/workflows/build-snapshot-worker.yml
@@ -17,9 +17,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - uses: jvalkeal/setup-maven@v1
-      with:
-        maven-version: 3.6.3
     - uses: jfrog/setup-jfrog-cli@v3
       env:
         JF_URL: 'https://repo.spring.io'
@@ -36,7 +33,7 @@ jobs:
     # target deploy repos
     - name: Configure JFrog Cli
       run: |
-        jfrog rt mvnc \
+        jfrog mvnc --use-wrapper \
           --server-id-resolve=${{ vars.JF_SERVER_ID }} \
           --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
@@ -55,7 +52,7 @@ jobs:
     # build and publish to configured target
     - name: Build and Publish
       run: |
-        jfrog rt mvn -U -B clean install
+        jfrog mvn -U -B clean install
         jfrog rt build-publish
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_buildname=spring-cloud-dataflow-ui-main >> $GITHUB_ENV

--- a/.github/workflows/build-snapshot-worker.yml
+++ b/.github/workflows/build-snapshot-worker.yml
@@ -20,11 +20,10 @@ jobs:
     - uses: jvalkeal/setup-maven@v1
       with:
         maven-version: 3.6.3
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # cache maven .m2
     - uses: actions/cache@v2
@@ -38,8 +37,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,14 +19,10 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    # maven version
-    - uses: jvalkeal/setup-maven@v1
-      with:
-        maven-version: 3.6.2
     # build
     - name: Build
       run: |
-        mvn -U -B clean package
+        ./mvnw -U -B clean package
     # clean m2 cache
     - name: Clean cache
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,16 @@ jobs:
       with:
         maven-version: 3.6.2
     # jfrog cli
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     # setup frog cli
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
       with:
         java-version: 1.8
     # maven version
-    - uses: jvalkeal/setup-maven@v1
-      with:
-        maven-version: 3.6.2
     # jfrog cli
     - uses: jfrog/setup-jfrog-cli@v3
       env:
@@ -35,7 +32,7 @@ jobs:
     # setup frog cli
     - name: Configure JFrog Cli
       run: |
-        jfrog rt mvnc \
+        jfrog mvnc --use-wrapper \
           --server-id-resolve=${{ vars.JF_SERVER_ID }} \
           --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
@@ -47,7 +44,7 @@ jobs:
     # build and publish
     - name: Build and Publish
       run: |
-        jfrog rt mvn -U -B clean install
+        jfrog mvn -U -B clean install
         jfrog rt build-publish
     # clean m2 cache
     - name: Clean cache

--- a/.github/workflows/milestone-worker.yml
+++ b/.github/workflows/milestone-worker.yml
@@ -16,9 +16,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - uses: jvalkeal/setup-maven@v1
-      with:
-        maven-version: 3.6.3
     - uses: jfrog/setup-jfrog-cli@v3
       env:
         JF_URL: 'https://repo.spring.io'
@@ -33,7 +30,7 @@ jobs:
     # target deploy repos
     - name: Configure JFrog Cli
       run: |
-        jfrog rt mvnc \
+        jfrog mvnc --use-wrapper \
           --server-id-resolve=${{ vars.JF_SERVER_ID }} \
           --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
@@ -54,7 +51,7 @@ jobs:
     # build and publish to configured target
     - name: Build and Publish
       run: |
-        jfrog rt mvn build-helper:parse-version versions:set \
+        jfrog mvn build-helper:parse-version versions:set \
           -gs .github/settings.xml \
           -Pstagingmilestone \
           -DprocessAllModules=true \
@@ -64,7 +61,7 @@ jobs:
           -B
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_ENV
         jfrog rt build-clean
-        jfrog rt mvn clean install \
+        jfrog mvn clean install \
           -gs .github/settings.xml \
           -P-spring,stagingmilestone \
           -DskipTests -U -B

--- a/.github/workflows/milestone-worker.yml
+++ b/.github/workflows/milestone-worker.yml
@@ -19,11 +19,10 @@ jobs:
     - uses: jvalkeal/setup-maven@v1
       with:
         maven-version: 3.6.3
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
@@ -35,8 +34,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-milestone-local \

--- a/.github/workflows/next-dev-version-worker.yml
+++ b/.github/workflows/next-dev-version-worker.yml
@@ -19,11 +19,10 @@ jobs:
     - uses: jvalkeal/setup-maven@v1
       with:
         maven-version: 3.6.3
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # cache maven .m2
     - uses: actions/cache@v2
@@ -37,8 +36,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/next-dev-version-worker.yml
+++ b/.github/workflows/next-dev-version-worker.yml
@@ -16,9 +16,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - uses: jvalkeal/setup-maven@v1
-      with:
-        maven-version: 3.6.3
     - uses: jfrog/setup-jfrog-cli@v3
       env:
         JF_URL: 'https://repo.spring.io'
@@ -35,7 +32,7 @@ jobs:
     # target deploy repos
     - name: Configure JFrog Cli
       run: |
-        jfrog rt mvnc \
+        jfrog mvnc --use-wrapper \
           --server-id-resolve=${{ vars.JF_SERVER_ID }} \
           --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
@@ -54,7 +51,7 @@ jobs:
     # build and publish to configured target
     - name: Build and Publish
       run: |
-        jfrog rt mvn build-helper:parse-version versions:set \
+        jfrog mvn build-helper:parse-version versions:set \
           -DprocessAllModules=true \
           -DgenerateBackupPoms=false \
           -Dartifactory.publish.artifacts=false \
@@ -62,7 +59,7 @@ jobs:
           -B
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_ENV
         jfrog rt build-clean
-        jfrog rt mvn clean install -DskipTests -B
+        jfrog mvn clean install -DskipTests -B
         jfrog rt build-publish
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_buildname=spring-cloud-dataflow-ui-main-ndv >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_buildnumber=$GITHUB_RUN_NUMBER >> $GITHUB_ENV

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -16,9 +16,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - uses: jvalkeal/setup-maven@v1
-      with:
-        maven-version: 3.6.3
     - uses: jfrog/setup-jfrog-cli@v3
       env:
         JF_URL: 'https://repo.spring.io'
@@ -33,7 +30,7 @@ jobs:
     # target deploy repos
     - name: Configure JFrog Cli
       run: |
-        jfrog rt mvnc \
+        jfrog rt mvnc --use-wrapper \
           --server-id-resolve=${{ vars.JF_SERVER_ID }} \
           --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-release-staging \
@@ -52,7 +49,7 @@ jobs:
     # build and publish to configured target
     - name: Build and Publish
       run: |
-        jfrog rt mvn build-helper:parse-version versions:set \
+        jfrog mvn build-helper:parse-version versions:set \
           -gs .github/settings.xml \
           -Pstagingrelease \
           -DprocessAllModules=true \
@@ -62,7 +59,7 @@ jobs:
           -B
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_ENV
         jfrog rt build-clean
-        jfrog rt mvn clean install \
+        jfrog mvn clean install \
           -gs .github/settings.xml \
           -P-spring,stagingrelease \
           -DskipTests -U -B

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -19,11 +19,10 @@ jobs:
     - uses: jvalkeal/setup-maven@v1
       with:
         maven-version: 3.6.3
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
@@ -35,8 +34,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-release-staging \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-staging-local \


### PR DESCRIPTION
Update setup-jfrog-cli to use `JF_ENV_SPRING` instead of `JF_ARTIFACTORY_SPRING` 
Added `JF_URL`
Added reference to `${{ vars.JF_SERVER_ID }}` in place of `repo.spring.io`
Remove maven setup and add --use-wrapper